### PR TITLE
:sparkles: Add panic function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,10 @@ endif()
 add_library(stdx INTERFACE)
 target_include_directories(stdx INTERFACE include)
 target_compile_features(stdx INTERFACE cxx_std_${CMAKE_CXX_STANDARD})
+target_compile_options(
+    stdx
+    INTERFACE
+        $<$<CXX_COMPILER_ID:Clang>:-Wno-gnu-string-literal-operator-template>)
 
 if(PROJECT_IS_TOP_LEVEL)
     add_docs(docs)

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -46,6 +46,7 @@ The following headers are available:
 * https://github.com/intel/cpp-std-extensions/blob/main/include/stdx/function_traits.hpp[`function_traits.hpp`]
 * https://github.com/intel/cpp-std-extensions/blob/main/include/stdx/functional.hpp[`functional.hpp`]
 * https://github.com/intel/cpp-std-extensions/blob/main/include/stdx/intrusive_list.hpp[`instrusive_list.hpp`]
+* https://github.com/intel/cpp-std-extensions/blob/main/include/stdx/panic.hpp[`panic.hpp`]
 * https://github.com/intel/cpp-std-extensions/blob/main/include/stdx/priority.hpp[`priority.hpp`]
 * https://github.com/intel/cpp-std-extensions/blob/main/include/stdx/type_traits.hpp[`type_traits.hpp`]
 * https://github.com/intel/cpp-std-extensions/blob/main/include/stdx/utility.hpp[`utility.hpp`]
@@ -269,6 +270,49 @@ l.remove(&n2); // removal from the middle is constant-time
 l.pop_front();
 l.pop_back();
 ----
+
+== `panic.hpp`
+
+`panic("reason")` is a function that is used in emergencies: something
+fundamental went wrong (e.g. a precondition was violated) and there is no good
+way to recover. It's like `assert` except that the behaviour of `panic` can be
+overridden.
+
+A `panic_handler` is a `struct` that exposes a `static` `panic` method. That
+method may have two overloads: one that takes a `ct_string` template argument
+(as well as more runtime arguments), and another that takes only runtime
+arguments.
+
+The default panic handler does nothing; to override that behaviour, provide a
+custom panic handler and specialize the variable template `stdx::panic_handler`,
+like this for example:
+
+[source,cpp]
+----
+struct custom_panic_handler {
+  static auto panic(auto&&... args) noexcept -> void {
+    // log args and then...
+    std::terminate();
+  }
+
+template <stdx::ct_string S>
+  static auto panic(auto&&... args) noexcept -> void {
+    // log args (including the compile-time string) and then...
+    std::terminate();
+  }
+};
+
+template <> inline auto stdx::panic_handler<> = custom_panic_handler{};
+----
+
+When something inside `stdx` goes wrong, the panic handler's `panic` function
+will be called.
+
+NOTE: `stdx` will always call `panic` with a compile-time string if
+possible (C++20), or with a single `char const *` if not. You are free to use
+`panic` with a logging framework to provide a "fatal" log function; in that case
+any arguments you pass through will be passed to `panic` and presumably handled
+by your choice of logging.
 
 == `priority.hpp`
 

--- a/include/stdx/ct_string.hpp
+++ b/include/stdx/ct_string.hpp
@@ -77,6 +77,12 @@ template <ct_string S, char C> [[nodiscard]] consteval auto split() {
             ct_string<suffix_size>{std::next(it), suffix_size - 1U}};
     }
 }
+
+namespace ct_string_literals {
+template <typename T, T... Cs> CONSTEVAL auto operator""_cts() {
+    return ct_string<sizeof...(Cs) + 1U>{{Cs..., 0}};
+}
+} // namespace ct_string_literals
 } // namespace v1
 } // namespace stdx
 

--- a/include/stdx/panic.hpp
+++ b/include/stdx/panic.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <stdx/ct_string.hpp>
+
+#include <utility>
+
+namespace stdx {
+inline namespace v1 {
+struct default_panic_handler {
+    template <typename... Args>
+    static auto panic(Args &&...) noexcept -> void {}
+
+#if __cplusplus >= 202002L
+    template <ct_string, typename... Args>
+    static auto panic(Args &&...) noexcept -> void {}
+#endif
+};
+
+template <typename...> inline auto panic_handler = default_panic_handler{};
+
+template <typename... Ts, typename... Args> auto panic(Args &&...args) -> void {
+    panic_handler<Ts...>.panic(std::forward<Args>(args)...);
+}
+
+#if __cplusplus >= 202002L
+template <ct_string S, typename... Ts, typename... Args>
+auto panic(Args &&...args) -> void {
+    panic_handler<Ts...>.template panic<S>(std::forward<Args>(args)...);
+}
+#endif
+} // namespace v1
+} // namespace stdx
+
+#if __cplusplus >= 202002L
+#define STDX_PANIC(MSG, ...)                                                   \
+    [] {                                                                       \
+        using stdx::ct_string_literals::operator""_cts;                        \
+        stdx::panic<MSG##_cts>(__VA_ARGS__);                                   \
+    }()
+#else
+#define STDX_PANIC(...) stdx::panic(__VA_ARGS__)
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,3 +20,21 @@ add_unit_test(
     LIBRARIES
     warnings
     stdx)
+
+add_unit_test(
+    default_panic_test
+    CATCH2
+    FILES
+    default_panic.cpp
+    LIBRARIES
+    warnings
+    stdx)
+
+add_unit_test(
+    panic_test
+    CATCH2
+    FILES
+    panic.cpp
+    LIBRARIES
+    warnings
+    stdx)

--- a/test/ct_string.cpp
+++ b/test/ct_string.cpp
@@ -12,6 +12,11 @@ TEST_CASE("construction", "[ct_string]") {
     [[maybe_unused]] constexpr auto s = stdx::ct_string{"ABC"};
 }
 
+TEST_CASE("UDL", "[ct_string]") {
+    using namespace stdx::ct_string_literals;
+    [[maybe_unused]] constexpr auto s = "ABC"_cts;
+}
+
 TEST_CASE("empty", "[ct_string]") {
     constexpr auto s1 = stdx::ct_string{""};
     static_assert(s1.empty());

--- a/test/default_panic.cpp
+++ b/test/default_panic.cpp
@@ -1,0 +1,19 @@
+#include <stdx/ct_string.hpp>
+#include <stdx/panic.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("default panic called with runtime arguments", "[default panic]") {
+    stdx::panic("uh-oh");
+}
+
+#if __cplusplus >= 202002L
+TEST_CASE("default panic called with compile-time strings", "[default panic]") {
+    using namespace stdx::ct_string_literals;
+    stdx::panic<"uh-oh"_cts>();
+}
+#endif
+
+TEST_CASE("default panic called through macro", "[default panic]") {
+    STDX_PANIC("uh-oh");
+}

--- a/test/panic.cpp
+++ b/test/panic.cpp
@@ -1,0 +1,59 @@
+#include <stdx/ct_string.hpp>
+#include <stdx/panic.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <string_view>
+
+namespace {
+bool runtime_call{};
+#if __cplusplus >= 202002L
+bool compile_time_call{};
+#endif
+
+struct injected_handler {
+    template <typename Why, typename... Ts>
+    static auto panic(Why why, Ts &&...) noexcept -> void {
+        CHECK(std::string_view{why} == "uh-oh");
+        runtime_call = true;
+    }
+
+#if __cplusplus >= 202002L
+    template <stdx::ct_string Why, typename... Ts>
+    static auto panic(Ts &&...) noexcept -> void {
+        static_assert(std::string_view{Why} == "uh-oh");
+        compile_time_call = true;
+    }
+#endif
+};
+} // namespace
+
+template <> inline auto stdx::panic_handler<> = injected_handler{};
+
+TEST_CASE("panic called with runtime arguments", "[panic]") {
+    runtime_call = false;
+    stdx::panic("uh-oh");
+    CHECK(runtime_call);
+}
+
+#if __cplusplus >= 202002L
+TEST_CASE("panic called with compile-time strings", "[panic]") {
+    compile_time_call = false;
+    using namespace stdx::ct_string_literals;
+    stdx::panic<"uh-oh"_cts>();
+    CHECK(compile_time_call);
+}
+
+TEST_CASE("compile-time panic called through macro", "[panic]") {
+    compile_time_call = false;
+    STDX_PANIC("uh-oh");
+    CHECK(compile_time_call);
+}
+#else
+TEST_CASE("runtime panic called through macro", "[panic]") {
+    runtime_call = false;
+    STDX_PANIC("uh-oh");
+    CHECK(runtime_call);
+}
+#endif


### PR DESCRIPTION
`panic` is used for various unrecoverable cases - usually precondition violations - inside `stdx` instead of calling `assert` or throwing exceptions.