### PR TITLE
:sparkles: Add `to_be` and `to_le`

### DIFF
--- a/docs/bit.adoc
+++ b/docs/bit.adoc
@@ -5,3 +5,17 @@ https://github.com/intel/cpp-std-extensions/blob/main/include/stdx/bit.hpp[`bit.
 provides an implementation that mirrors
 https://en.cppreference.com/w/cpp/header/bit[`<bit>`], but is
 `constexpr` in C++17. It is mostly based on intrinsics.
+
+`to_le` and `to_be` are variations on `byteswap` that convert unsigned integral
+types to little- or big-endian respectively. On a little-endian machine, `to_le`
+does nothing, and `to_be` is the equivalent of `byteswap`. On a big endian
+machine it is the other way around.
+
+[source,cpp]
+----
+constexpr auto x = std::uint32_t{0x12'34'56'78};
+constexpr auto y = stdx::to_be(x); // 0x78'56'34'12 (on a little-endian machine)
+----
+
+`to_le` and `to_be` are defined for unsigned integral types. Of course for
+`std::uint8_t` they do nothing.

--- a/include/stdx/bit.hpp
+++ b/include/stdx/bit.hpp
@@ -228,5 +228,24 @@ using std::bit_width;
 using std::has_single_bit;
 #endif
 
+template <typename T>
+[[nodiscard]] constexpr auto to_le(T x) noexcept
+    -> std::enable_if_t<std::is_unsigned_v<T>, T> {
+    if constexpr (stdx::endian::native == stdx::endian::big) {
+        return byteswap(x);
+    } else {
+        return x;
+    }
+}
+
+template <typename T>
+[[nodiscard]] constexpr auto to_be(T x) noexcept
+    -> std::enable_if_t<std::is_unsigned_v<T>, T> {
+    if constexpr (stdx::endian::native == stdx::endian::little) {
+        return byteswap(x);
+    } else {
+        return x;
+    }
+}
 } // namespace v1
 } // namespace stdx

--- a/test/bit.cpp
+++ b/test/bit.cpp
@@ -14,6 +14,42 @@ TEST_CASE("byteswap", "[bit]") {
                   0x08070605'04030201ull);
 }
 
+TEST_CASE("to little endian", "[bit]") {
+    static_assert(stdx::to_le(std::uint8_t{1u}) == 1u);
+
+    [[maybe_unused]] constexpr std::uint16_t u16{0x1234};
+    [[maybe_unused]] constexpr std::uint32_t u32{0x1234'5678};
+    [[maybe_unused]] constexpr std::uint64_t u64{0x1234'5678'9abc'def0};
+
+    if constexpr (stdx::endian::native == stdx::endian::little) {
+        CHECK(stdx::to_le(u16) == u16);
+        CHECK(stdx::to_le(u32) == u32);
+        CHECK(stdx::to_le(u64) == u64);
+    } else if constexpr (stdx::endian::native == stdx::endian::big) {
+        CHECK(stdx::to_le(u16) == stdx::byteswap(u16));
+        CHECK(stdx::to_le(u32) == stdx::byteswap(u32));
+        CHECK(stdx::to_le(u64) == stdx::byteswap(u64));
+    }
+}
+
+TEST_CASE("to big endian", "[bit]") {
+    static_assert(stdx::to_be(std::uint8_t{1u}) == 1u);
+
+    [[maybe_unused]] constexpr std::uint16_t u16{0x1234};
+    [[maybe_unused]] constexpr std::uint32_t u32{0x1234'5678};
+    [[maybe_unused]] constexpr std::uint64_t u64{0x1234'5678'9abc'def0};
+
+    if constexpr (stdx::endian::native == stdx::endian::big) {
+        CHECK(stdx::to_be(u16) == u16);
+        CHECK(stdx::to_be(u32) == u32);
+        CHECK(stdx::to_be(u64) == u64);
+    } else if constexpr (stdx::endian::native == stdx::endian::little) {
+        CHECK(stdx::to_be(u16) == stdx::byteswap(u16));
+        CHECK(stdx::to_be(u32) == stdx::byteswap(u32));
+        CHECK(stdx::to_be(u64) == stdx::byteswap(u64));
+    }
+}
+
 TEMPLATE_TEST_CASE("popcount", "[bit]", std::uint8_t, std::uint16_t,
                    std::uint32_t, std::uint64_t) {
     static_assert(stdx::popcount(TestType{}) == 0);


### PR DESCRIPTION
Folks implementing cryptography might use `byteswap`. For the rest of us, writing e.g. network protocol handlers, `to_le` and `to_be` are much more useful. They should really be in the standard.