### PR TITLE
:sparkles: Add `template_for_each`

### DIFF
--- a/docs/type_traits.adoc
+++ b/docs/type_traits.adoc
@@ -14,6 +14,8 @@ contains a few things from the standard:
 * https://en.cppreference.com/w/cpp/utility/to_underlying[`to_underlying`] (from C++23)
 * https://en.cppreference.com/w/cpp/types/type_identity[`type_identity`] (from C++20)
 
+=== `always_false_v`
+
 `always_false_v` is a variable template that can be instantiated
 with any number of type arguments and always evaluates to false at compile-time.
 This is useful for writing `static_assert` where it must depend on types (at
@@ -34,6 +36,8 @@ auto f(T) {
 };
 ----
 
+=== `is_function_object_v`
+
 `is_function_object_v` is a variable template that detects whether a type is a
 function object, like a lambda. It is true for generic lambdas, too.
 
@@ -47,6 +51,8 @@ stdx::is_function_object_v<decltype(f)>;         // false
 stdx::is_function_object_v<decltype(lam)>;       // true
 stdx::is_function_object_v<decltype(gen_lam)>;   // true
 ----
+
+=== `is_specialization_of_v`
 
 `is_specialization_of_v` is a variable template that detects whether a type is a
 specialization of a given template.
@@ -62,6 +68,8 @@ stdx::is_specialization_of_v<int, std::optional>; // false
 NOTE: `is_specialization_of` is suitable for templates with type parameters
 only (not template-template parameters or NTTPs).
 
+=== `type_or_t`
+
 `type_or_t` is an alias template that selects a type based on whether or not it
 passes a predicate. If not, a default is returned.
 
@@ -74,3 +82,31 @@ using B = int;
 using X = stdx::type_or_t<std::is_pointer, B>;        // void (implicit default)
 using Y = stdx::type_or_t<std::is_pointer, B, float>; // float (explicit default)
 ----
+
+=== `type_list` and `value_list`
+
+`type_list` is an empty `struct` templated over any number of types.
+`value_list` is an empty `struct` templated over any number of NTTPs.
+
+=== `template_for_each`
+
+A `type_list` or a `value_list` can be iterated with `template_for_each`. A
+function object whose call operator is a unary function template with no runtime
+arguments is passed to each of these functions.
+
+[source,cpp]
+----
+using L1 = stdx::type_list<std::integral_constant<int, 1>,
+                           std::integral_constant<int, 2>>;
+int x{};
+stdx::template_for_each<L1>([&] <typename T> () { x += T::value; });
+// x is now 3
+
+using L2 = stdx::value_list<1, 2>;
+int y{};
+stdx::template_for_each<L2>([&] <auto V> () { y += V; });
+// y is now 3
+----
+
+NOTE: A primary use case of `template_for_each` is to be able to use a list of
+tag types without those types having to be complete.

--- a/include/stdx/type_traits.hpp
+++ b/include/stdx/type_traits.hpp
@@ -87,5 +87,29 @@ template <typename T> struct type_identity {
     using type = T;
 };
 template <typename T> using type_identity_t = typename type_identity<T>::type;
+
+template <typename...> struct type_list;
+template <auto...> struct value_list;
+
+template <typename L> struct for_each_t {
+    static_assert(
+        always_false_v<L>,
+        "template_for_each must be called with a type list (or value list)");
+};
+
+template <template <typename...> typename L, typename... Ts>
+struct for_each_t<L<Ts...>> {
+    template <typename F> constexpr auto operator()(F &&f) const {
+        (f.template operator()<Ts>(), ...);
+    }
+};
+template <template <auto...> typename L, auto... Vs>
+struct for_each_t<L<Vs...>> {
+    template <typename F> constexpr auto operator()(F &&f) const {
+        (f.template operator()<Vs>(), ...);
+    }
+};
+
+template <typename L> constexpr static auto template_for_each = for_each_t<L>{};
 } // namespace v1
 } // namespace stdx

--- a/test/fail/CMakeLists.txt
+++ b/test/fail/CMakeLists.txt
@@ -18,6 +18,7 @@ add_fail_tests(
     subspan_late_end
     subspan_too_big
     subspan_wrapping
+    template_for_each_not_list
     to_address_undefined_on_function)
 
 if(${CMAKE_CXX_STANDARD} GREATER_EQUAL 20)

--- a/test/fail/template_for_each_not_list.cpp
+++ b/test/fail/template_for_each_not_list.cpp
@@ -1,0 +1,7 @@
+#include <stdx/type_traits.hpp>
+
+// EXPECT: must be called with a type list
+
+auto main() -> int {
+    stdx::template_for_each<int>([] {});
+}

--- a/test/type_traits.cpp
+++ b/test/type_traits.cpp
@@ -43,3 +43,42 @@ TEST_CASE("type_or_t", "[type_traits]") {
         std::is_same_v<stdx::type_or_t<std::is_void, int, float>, float>);
     static_assert(std::is_same_v<stdx::type_or_t<std::is_void, int>, void>);
 }
+
+namespace {
+int value{};
+struct add_value {
+    template <typename T> constexpr auto operator()() const -> void {
+        value += T::value;
+    }
+    template <auto T> constexpr auto operator()() const -> void { value += T; }
+};
+} // namespace
+
+TEST_CASE("template_for_each with type list", "[type_traits]") {
+    value = 0;
+    using L = stdx::type_list<std::integral_constant<int, 1>,
+                              std::integral_constant<int, 2>>;
+    stdx::template_for_each<L>(add_value{});
+    CHECK(value == 3);
+}
+
+TEST_CASE("template_for_each with empty type list", "[type_traits]") {
+    value = 42;
+    using L = stdx::type_list<>;
+    stdx::template_for_each<L>(add_value{});
+    CHECK(value == 42);
+}
+
+TEST_CASE("template_for_each with value list", "[type_traits]") {
+    value = 0;
+    using L = stdx::value_list<1, 2>;
+    stdx::template_for_each<L>(add_value{});
+    CHECK(value == 3);
+}
+
+TEST_CASE("template_for_each with empty value list", "[type_traits]") {
+    value = 17;
+    using L = stdx::value_list<>;
+    stdx::template_for_each<L>(add_value{});
+    CHECK(value == 17);
+}


### PR DESCRIPTION
Instantiating a tuple of empty objects just to use `for_each` with the types seems wasteful. `type_list` and `value_list` are useful in general.