### PR TITLE
:bug: Fix tuple equality

### DIFF
--- a/include/stdx/type_traits.hpp
+++ b/include/stdx/type_traits.hpp
@@ -88,8 +88,8 @@ template <typename T> struct type_identity {
 };
 template <typename T> using type_identity_t = typename type_identity<T>::type;
 
-template <typename...> struct type_list;
-template <auto...> struct value_list;
+template <typename...> struct type_list {};
+template <auto...> struct value_list {};
 
 template <typename L> struct for_each_t {
     static_assert(

--- a/test/fail/CMakeLists.txt
+++ b/test/fail/CMakeLists.txt
@@ -22,5 +22,8 @@ add_fail_tests(
     to_address_undefined_on_function)
 
 if(${CMAKE_CXX_STANDARD} GREATER_EQUAL 20)
-    add_fail_tests(tuple_index_out_of_bounds tuple_type_not_found)
+    add_fail_tests(
+        tuple_index_out_of_bounds tuple_equality_mismatch
+        tuple_equality_with_element tuple_spaceship_mismatch
+        tuple_spaceship_with_element tuple_type_not_found)
 endif()

--- a/test/fail/tuple_equality_mismatch.cpp
+++ b/test/fail/tuple_equality_mismatch.cpp
@@ -1,0 +1,9 @@
+#include <stdx/tuple.hpp>
+
+// EXPECT: ambiguous
+
+auto main() -> int {
+    auto t = stdx::tuple{1, 2.0, 3};
+    auto u = stdx::tuple{1, 2.0};
+    auto b = t == u;
+}

--- a/test/fail/tuple_equality_with_element.cpp
+++ b/test/fail/tuple_equality_with_element.cpp
@@ -1,0 +1,12 @@
+#include <stdx/tuple.hpp>
+
+// EXPECT: deleted
+
+struct S {
+    constexpr friend auto operator==(S, S) -> bool = default;
+};
+
+auto main() -> int {
+    auto t = stdx::tuple{S{}};
+    auto b = t == S{};
+}

--- a/test/fail/tuple_spaceship_mismatch.cpp
+++ b/test/fail/tuple_spaceship_mismatch.cpp
@@ -1,0 +1,9 @@
+#include <stdx/tuple.hpp>
+
+// EXPECT: ambiguous
+
+auto main() -> int {
+    auto t = stdx::tuple{1, 2.0, 3};
+    auto u = stdx::tuple{1, 2.0};
+    auto b = t <=> u;
+}

--- a/test/fail/tuple_spaceship_with_element.cpp
+++ b/test/fail/tuple_spaceship_with_element.cpp
@@ -1,0 +1,8 @@
+#include <stdx/tuple.hpp>
+
+// EXPECT: deleted
+
+auto main() -> int {
+    auto t = stdx::tuple{1};
+    auto b = t <=> 1;
+}

--- a/test/indexed_tuple.cpp
+++ b/test/indexed_tuple.cpp
@@ -17,19 +17,24 @@ template <typename Key, typename Value> struct map_entry {
 template <typename T> using key_for = typename T::key_t;
 } // namespace
 
-TEST_CASE("make_indexed_tuple", "[tuple]") {
-    static_assert(stdx::make_indexed_tuple<>() == stdx::tuple{});
-    static_assert(stdx::make_indexed_tuple<>(1, 2, 3) == stdx::tuple{1, 2, 3});
+TEST_CASE("make_indexed_tuple", "[indexed_tuple]") {
+    static_assert(stdx::make_indexed_tuple<>() == stdx::indexed_tuple{});
+    static_assert(stdx::make_indexed_tuple<>(1, 2, 3) ==
+                  stdx::indexed_tuple{1, 2, 3});
 }
 
-TEST_CASE("indexed_tuple destructuring", "[tuple]") {
+TEST_CASE("comparable with regular tuple", "[indexed_tuple]") {
+    static_assert(stdx::indexed_tuple{} == stdx::tuple{});
+}
+
+TEST_CASE("indexed_tuple destructuring", "[indexed_tuple]") {
     auto const t = stdx::make_indexed_tuple<>(1, 3.14f);
     auto const [i, f] = t;
     CHECK(i == 1);
     CHECK(f == 3.14f);
 }
 
-TEST_CASE("tuple with user index", "[tuple]") {
+TEST_CASE("tuple with user index", "[indexed_tuple]") {
     struct X;
     struct Y;
     constexpr auto t = stdx::make_indexed_tuple<key_for>(map_entry<X, int>{42},
@@ -45,7 +50,7 @@ TEST_CASE("tuple with user index", "[tuple]") {
     static_assert(T::size() == 2);
 }
 
-TEST_CASE("indexed_tuple ADL get", "[tuple]") {
+TEST_CASE("indexed_tuple ADL get", "[indexed_tuple]") {
     struct X;
     struct Y;
     constexpr auto t = stdx::make_indexed_tuple<key_for>(map_entry<X, int>{42},
@@ -67,7 +72,7 @@ template <typename T> using key1_for = typename T::key1_t;
 template <typename T> using key2_for = typename T::key2_t;
 } // namespace
 
-TEST_CASE("tuple with multiple user indices", "[tuple]") {
+TEST_CASE("tuple with multiple user indices", "[indexed_tuple]") {
     struct M;
     struct N;
     struct X;
@@ -80,7 +85,7 @@ TEST_CASE("tuple with multiple user indices", "[tuple]") {
     static_assert(stdx::get<Y>(t).value == 17);
 }
 
-TEST_CASE("apply indices", "[tuple]") {
+TEST_CASE("apply indices", "[indexed_tuple]") {
     struct X;
     constexpr auto t = stdx::tuple{map_entry<X, int>{42}};
     constexpr auto u = stdx::apply_indices<key_for>(t);

--- a/test/tuple.cpp
+++ b/test/tuple.cpp
@@ -249,6 +249,11 @@ TEST_CASE("equality comparable (references and non-references)", "[tuple]") {
     CHECK(u == t);
 }
 
+TEST_CASE("equality comparable (conversions)", "[tuple]") {
+    constexpr auto t = stdx::tuple{1};
+    static_assert(t == stdx::tuple{1.0});
+}
+
 namespace {
 struct eq {
     [[nodiscard]] friend constexpr auto operator==(eq lhs, eq rhs) -> bool {
@@ -256,6 +261,8 @@ struct eq {
     }
     int x;
 };
+
+struct eq_derived : eq {};
 } // namespace
 
 TEST_CASE("equality comparable (user-defined)", "[tuple]") {
@@ -263,6 +270,11 @@ TEST_CASE("equality comparable (user-defined)", "[tuple]") {
 
     static_assert(t == stdx::tuple{eq{1}});
     static_assert(t != stdx::tuple{eq{2}});
+}
+
+TEST_CASE("equality comparable (conversions, user-defined)", "[tuple]") {
+    constexpr auto t = stdx::tuple{eq{1}};
+    static_assert(t == stdx::tuple{eq_derived{1}});
 }
 
 TEST_CASE("order comparable", "[tuple]") {

--- a/test/tuple_algorithms.cpp
+++ b/test/tuple_algorithms.cpp
@@ -400,7 +400,7 @@ TEST_CASE("chunk (1-element tuple)", "[tuple_algorithms]") {
     constexpr auto chunked = stdx::chunk(t);
     static_assert(
         std::is_same_v<decltype(chunked), stdx::tuple<stdx::tuple<int>> const>);
-    CHECK(chunked == stdx::tuple{stdx::tuple{1}});
+    CHECK(chunked == stdx::make_tuple(stdx::tuple{1}));
 }
 
 TEST_CASE("count chunks", "[tuple_algorithms]") {


### PR DESCRIPTION
- tuples of references should not compare addresses
- comparing tuples of mismatched sizes (by pack expansion of the shorter pack!) should not compile
- comparing a tuple to one of its elements (by implicit conversion to base!) should not compile