### PR TITLE
:sparkles: Add `has_trait` concept

### DIFF
--- a/docs/concepts.adoc
+++ b/docs/concepts.adoc
@@ -21,9 +21,13 @@ NOTE: For compatibility with the standard and with
 https://en.cppreference.com/w/cpp/types/is_base_of[`std::is_base_of`], a class
 is considered to be `derived_from` itself.
 
-Also one non-standard but useful concept: `callable`. `callable` is modelled by
-functions by and objects with `operator()`. In particular it is true for generic
-lambda expressions, where `operator()` is a function template.
+`concepts.hpp` also has a couple of non-standard but useful concepts.
+
+=== `callable`
+
+`callable` is modelled by functions by and objects with `operator()`. In
+particular it is true for generic lambda expressions, where `operator()` is a
+function template.
 
 [source,cpp]
 ----
@@ -36,3 +40,21 @@ static_assert(stdx::callable<decltype(lambda)>);
 auto generic_lambda = [] (auto i) { return i + 1; };
 static_assert(stdx::callable<decltype(generic_lambda)>);
 ----
+
+=== `has_trait`
+
+`has_trait` is used to turn a type trait (standard or otherwise) into a concept.
+There are many type traits and comparatively few standard concepts; this concept
+helps bridge the gap more easily and concisely than writing out boilerplate
+concepts for type traits.
+
+[source,cpp]
+----
+template <stdx::has_trait<std::is_class> T>
+auto f(T) -> void {
+  // can only be called with class types
+}
+----
+
+For the purposes of `has_trait`, a type trait is a class template with one
+parameter that has a `constexpr static bool value` member.

--- a/include/stdx/concepts.hpp
+++ b/include/stdx/concepts.hpp
@@ -92,6 +92,9 @@ constexpr auto predicate =
 
 template <typename T> constexpr auto callable = is_callable_v<T>;
 
+template <typename T, template <typename> typename TypeTrait>
+constexpr auto has_trait = TypeTrait<T>::value;
+
 #else
 
 // After C++20, we can define concepts that are lacking in the library
@@ -163,6 +166,9 @@ concept predicate = invocable<F, Args> and
 template <typename T>
 concept callable = is_callable_v<T>;
 
+template <typename T, template <typename> typename TypeTrait>
+concept has_trait = TypeTrait<T>::value;
+
 #endif
 
 } // namespace v1
@@ -192,6 +198,9 @@ using std::predicate;
 
 template <typename T>
 concept callable = is_callable_v<T>;
+
+template <typename T, template <typename> typename TypeTrait>
+concept has_trait = TypeTrait<T>::value;
 
 } // namespace v1
 } // namespace stdx

--- a/test/concepts.cpp
+++ b/test/concepts.cpp
@@ -136,3 +136,8 @@ TEST_CASE("callable", "[concepts]") {
     static_assert(stdx::callable<decltype(l_callable_int)>);
     static_assert(stdx::callable<decltype(l_callable_generic)>);
 }
+
+TEST_CASE("models_trait", "[concepts]") {
+    static_assert(stdx::has_trait<int *, std::is_pointer>);
+    static_assert(not stdx::has_trait<int, std::is_pointer>);
+}


### PR DESCRIPTION
It's annoying to write boilerplate concepts to constrain by type traits. `has_trait` fixes that.