### PR TITLE
:sparkles: Add `same_as_unqualified`

### DIFF
--- a/docs/concepts.adoc
+++ b/docs/concepts.adoc
@@ -58,3 +58,35 @@ auto f(T) -> void {
 
 For the purposes of `has_trait`, a type trait is a class template with one
 parameter that has a `constexpr static bool value` member.
+
+=== `same_as_unqualified`
+
+`same_as_unqualified` is true when two types are the same are removing top-level
+cv-qualifications and references, if any. It's useful for constraining hidden
+friends -- particularly when member functions would need to be replicated with
+different reference qualifiers before C++23.
+
+[source,cpp]
+----
+struct S {
+  // before C++20
+  auto f() & { /* ... */ }
+  auto f() const & { /* ... */ }
+  auto f() && { /* ... */ }
+  auto f() const && { /* ... */ }
+  // (and 4 more for volatile qualifiers!)
+
+  // with C++23's explicit object parameter ("deducing this")
+  template <typename Self>
+  auto f(this Self&& s) {
+    // Self is perfectly-forwarded
+  }
+
+private:
+  // hidden friend alternative
+  template <same_as_unqualified<S> Self>
+  friend auto f(Self&& s) {
+    // Self is perfectly-forwarded
+  }
+};
+----

--- a/docs/type_traits.adoc
+++ b/docs/type_traits.adoc
@@ -138,3 +138,14 @@ stdx::template_for_each<L2>([&] <auto V> () { y += V; });
 
 NOTE: A primary use case of `template_for_each` is to be able to use a list of
 tag types without those types having to be complete.
+
+=== `is_same_unqualified_v`
+
+`is_same_unqualified_v` is a variable template that detects whether a two types
+are the same are removing top-level cv-qualifications and references, if any.
+
+[source,cpp]
+----
+stdx::is_same_unqualified_v<int, int const&>; // true
+stdx::is_same_unqualified_v<int, void>;       // false
+----

--- a/include/stdx/concepts.hpp
+++ b/include/stdx/concepts.hpp
@@ -40,6 +40,10 @@ constexpr auto derived_from =
 template <typename T, typename U>
 constexpr auto same_as = std::is_same_v<T, U> and std::is_same_v<U, T>;
 
+template <typename T, typename U>
+constexpr auto same_as_unqualified =
+    is_same_unqualified_v<T, U> and is_same_unqualified_v<U, T>;
+
 // NOLINTBEGIN(bugprone-macro-parentheses, cppcoreguidelines-macro-usage)
 #define DETECTOR(name, expr)                                                   \
     namespace detail::detect {                                                 \
@@ -123,6 +127,10 @@ concept derived_from =
 template <typename T, typename U>
 concept same_as = std::is_same_v<T, U> and std::is_same_v<U, T>;
 
+template <typename T, typename U>
+concept same_as_unqualified =
+    is_same_unqualified_v<T, U> and is_same_unqualified_v<U, T>;
+
 template <typename T>
 concept equality_comparable = requires(T const &t) {
     { t == t } -> same_as<bool>;
@@ -201,6 +209,10 @@ concept callable = is_callable_v<T>;
 
 template <typename T, template <typename> typename TypeTrait>
 concept has_trait = TypeTrait<T>::value;
+
+template <typename T, typename U>
+concept same_as_unqualified =
+    is_same_unqualified_v<T, U> and is_same_unqualified_v<U, T>;
 
 } // namespace v1
 } // namespace stdx

--- a/include/stdx/type_traits.hpp
+++ b/include/stdx/type_traits.hpp
@@ -133,5 +133,9 @@ struct for_each_t<L<Vs...>> {
 };
 
 template <typename L> constexpr static auto template_for_each = for_each_t<L>{};
+
+template <typename T, typename U>
+constexpr bool is_same_unqualified_v =
+    std::is_same_v<remove_cvref_t<T>, remove_cvref_t<U>>;
 } // namespace v1
 } // namespace stdx

--- a/test/concepts.cpp
+++ b/test/concepts.cpp
@@ -19,7 +19,7 @@ TEST_CASE("signed_integral", "[concepts]") {
     static_assert(not stdx::signed_integral<unsigned int>);
 }
 
-TEST_CASE("unsgined_integral", "[concepts]") {
+TEST_CASE("unsigned_integral", "[concepts]") {
     static_assert(stdx::unsigned_integral<unsigned int>);
     static_assert(not stdx::unsigned_integral<int>);
 }
@@ -27,6 +27,19 @@ TEST_CASE("unsgined_integral", "[concepts]") {
 TEST_CASE("same_as", "[concepts]") {
     static_assert(stdx::same_as<int, int>);
     static_assert(not stdx::same_as<float, int>);
+}
+
+TEST_CASE("same_as_unqualified", "[concepts]") {
+    static_assert(stdx::same_as_unqualified<int, int>);
+    static_assert(not stdx::same_as_unqualified<int, void>);
+    static_assert(stdx::same_as_unqualified<int, int &>);
+    static_assert(stdx::same_as_unqualified<int, int const &>);
+    static_assert(stdx::same_as_unqualified<int, int &&>);
+    static_assert(stdx::same_as_unqualified<int, int const &&>);
+    static_assert(stdx::same_as_unqualified<int &, int>);
+    static_assert(stdx::same_as_unqualified<int const &, int>);
+    static_assert(stdx::same_as_unqualified<int &&, int>);
+    static_assert(stdx::same_as_unqualified<int const &&, int>);
 }
 
 TEST_CASE("convertible_to", "[concepts]") {

--- a/test/type_traits.cpp
+++ b/test/type_traits.cpp
@@ -128,3 +128,16 @@ TEST_CASE("template_for_each with empty value list", "[type_traits]") {
     stdx::template_for_each<L>(add_value{});
     CHECK(value == 17);
 }
+
+TEST_CASE("is_same_unqualified", "[type_traits]") {
+    static_assert(stdx::is_same_unqualified_v<int, int>);
+    static_assert(not stdx::is_same_unqualified_v<int, void>);
+    static_assert(stdx::is_same_unqualified_v<int, int &>);
+    static_assert(stdx::is_same_unqualified_v<int, int const &>);
+    static_assert(stdx::is_same_unqualified_v<int, int &&>);
+    static_assert(stdx::is_same_unqualified_v<int, int const &&>);
+    static_assert(stdx::is_same_unqualified_v<int &, int>);
+    static_assert(stdx::is_same_unqualified_v<int const &, int>);
+    static_assert(stdx::is_same_unqualified_v<int &&, int>);
+    static_assert(stdx::is_same_unqualified_v<int const &&, int>);
+}


### PR DESCRIPTION
A useful concept that matches two types if they are the same after applying `remove_cvref` to both.