### PR TITLE
Fix optional transform, add nullptr as sentinel for optional pointers

### DIFF
--- a/include/stdx/optional.hpp
+++ b/include/stdx/optional.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <stdx/functional.hpp>
 #include <stdx/type_traits.hpp>
+#include <stdx/utility.hpp>
 
 #include <limits>
 #include <memory>
@@ -32,7 +34,7 @@ template <typename T, typename TS = tombstone_traits<T>> class optional {
                       not stdx::is_specialization_of_v<TS, tombstone_traits>,
                   "Don't define tombstone traits for plain integral types");
     constexpr static inline auto traits = TS{};
-    [[no_unique_address]] T val{traits()};
+    T val{traits()};
 
   public:
     using value_type = T;
@@ -129,23 +131,29 @@ template <typename T, typename TS = tombstone_traits<T>> class optional {
     template <typename F> constexpr auto transform(F &&f) & {
         using func_t = stdx::remove_cvref_t<F>;
         using U = std::invoke_result_t<func_t, value_type &>;
-        return *this ? optional<U>{std::forward<F>(f)(val)} : optional<U>{};
+        return *this ? optional<U>{with_result_of{
+                           [&] { return std::forward<F>(f)(val); }}}
+                     : optional<U>{};
     }
     template <typename F> constexpr auto transform(F &&f) const & {
         using func_t = stdx::remove_cvref_t<F>;
         using U = std::invoke_result_t<func_t, value_type const &>;
-        return *this ? optional<U>{std::forward<F>(f)(val)} : optional<U>{};
+        return *this ? optional<U>{with_result_of{
+                           [&] { return std::forward<F>(f)(val); }}}
+                     : optional<U>{};
     }
     template <typename F> constexpr auto transform(F &&f) && {
         using func_t = stdx::remove_cvref_t<F>;
         using U = std::invoke_result_t<func_t, value_type &&>;
-        return *this ? optional<U>{std::forward<F>(f)(std::move(val))}
+        return *this ? optional<U>{with_result_of{
+                           [&] { return std::forward<F>(f)(std::move(val)); }}}
                      : optional<U>{};
     }
     template <typename F> constexpr auto transform(F &&f) const && {
         using func_t = stdx::remove_cvref_t<F>;
-        using U = std::invoke_result_t<func_t, value_type &&>;
-        return *this ? optional<U>{std::forward<F>(f)(std::move(val))}
+        using U = std::invoke_result_t<func_t, value_type const &&>;
+        return *this ? optional<U>{with_result_of{
+                           [&] { return std::forward<F>(f)(std::move(val)); }}}
                      : optional<U>{};
     }
 
@@ -222,12 +230,15 @@ template <typename F, typename... Ts,
                                                     optional>)>>
 constexpr auto transform(F &&f, Ts &&...ts) {
     using func_t = stdx::remove_cvref_t<F>;
-    using U =
-        std::invoke_result_t<func_t, decltype(std::forward<Ts>(ts).value())...>;
+    using R = std::invoke_result_t<
+        func_t,
+        forward_like_t<Ts, typename stdx::remove_cvref_t<Ts>::value_type>...>;
     if ((... and ts.has_value())) {
-        return std::forward<F>(f)(std::forward<Ts>(ts).value()...);
+        return optional<R>{with_result_of{[&] {
+            return std::forward<F>(f)(std::forward<Ts>(ts).value()...);
+        }}};
     }
-    return U{};
+    return optional<R>{};
 }
 } // namespace v1
 } // namespace stdx

--- a/include/stdx/optional.hpp
+++ b/include/stdx/optional.hpp
@@ -25,6 +25,11 @@ struct tombstone_traits<T, std::enable_if_t<std::is_floating_point_v<T>>> {
     }
 };
 
+template <typename T>
+struct tombstone_traits<T, std::enable_if_t<std::is_pointer_v<T>>> {
+    constexpr auto operator()() const { return nullptr; }
+};
+
 template <auto V> struct tombstone_value {
     constexpr auto operator()() const { return V; }
 };

--- a/test/optional.cpp
+++ b/test/optional.cpp
@@ -319,9 +319,8 @@ TEST_CASE("and_then (const rvalue ref)", "[optional]") {
 TEST_CASE("transform (multi-arg)", "[optional]") {
     auto o1 = stdx::optional<S>{17};
     auto o2 = stdx::optional<S>{42};
-    auto o3 = transform(
-        [](S &x, S &y) { return stdx::optional<S>{x.value + y.value}; }, o1,
-        o2);
+    auto o3 =
+        transform([](S &x, S &y) { return S{x.value + y.value}; }, o1, o2);
     CHECK(o3->value == 59);
 }
 
@@ -389,4 +388,19 @@ TEST_CASE("optional floating-point value has default sentinel", "[optional]") {
     CHECK(std::isinf(*o1));
     auto const o2 = stdx::optional{1.0f};
     CHECK(o1 < o2);
+}
+
+TEST_CASE("transform (non-movable)", "[optional]") {
+    auto o1 = stdx::optional<non_movable>{17};
+    auto o2 = o1.transform([](auto &x) { return non_movable{x.value + 42}; });
+    CHECK(o2->value == 59);
+}
+
+TEST_CASE("transform (multi-arg nonmovable)", "[optional]") {
+    auto o1 = stdx::optional<non_movable>{17};
+    auto o2 = stdx::optional<non_movable>{42};
+    auto o3 = transform(
+        [](auto &x, auto &y) { return non_movable{x.value + y.value}; }, o1,
+        o2);
+    CHECK(o3->value == 59);
 }

--- a/test/optional.cpp
+++ b/test/optional.cpp
@@ -390,6 +390,15 @@ TEST_CASE("optional floating-point value has default sentinel", "[optional]") {
     CHECK(o1 < o2);
 }
 
+TEST_CASE("optional pointer value has default sentinel", "[optional]") {
+    auto const o1 = stdx::optional<float *>{};
+    CHECK(not o1);
+    CHECK(*o1 == nullptr);
+    float f{1.0f};
+    auto const o2 = stdx::optional<float *>{&f};
+    CHECK(o1 < o2);
+}
+
 TEST_CASE("transform (non-movable)", "[optional]") {
     auto o1 = stdx::optional<non_movable>{17};
     auto o2 = o1.transform([](auto &x) { return non_movable{x.value + 42}; });


### PR DESCRIPTION
- variadic transform was just wrong
- neither member-function nor variadic transform dealt with nonmovable types
- optional pointers have a default sentinel of nullptr