### PR TITLE
:sparkles: Add `bit_mask`

### DIFF
--- a/docs/bit.adoc
+++ b/docs/bit.adoc
@@ -6,26 +6,32 @@ provides an implementation that mirrors
 https://en.cppreference.com/w/cpp/header/bit[`<bit>`], but is
 `constexpr` in C++17. It is mostly based on intrinsics.
 
-=== `to_le` and `to_be`
+=== `bit_mask`
 
-`to_le` and `to_be` are variations on `byteswap` that convert unsigned integral
-types to little- or big-endian respectively. On a little-endian machine, `to_le`
-does nothing, and `to_be` is the equivalent of `byteswap`. On a big endian
-machine it is the other way around.
+`bit_mask` is a function for constructing a bit mask between most-significant
+and least-significant bits.
 
 [source,cpp]
 ----
-constexpr auto x = std::uint32_t{0x12'34'56'78};
-constexpr auto y = stdx::to_be(x); // 0x78'56'34'12 (on a little-endian machine)
+constexpr auto x = stdx::bit_mask<std::uint8_t, 5, 3>();
+static_assert(x == std::uint8_t{0b0011'1000};
+
+// Lsb may be omitted (meaning it's 0)
+constexpr auto y = stdx::bit_mask<std::uint8_t, 5>();
+static_assert(y == std::uint8_t{0b0011'1111};
+
+// omitting both Msb and Lsb means the entire range of the type
+constexpr auto z = stdx::bit_mask<std::uint8_t>();
+static_assert(z == std::uint8_t{0b1111'1111};
 ----
 
-`to_le` and `to_be` are defined for unsigned integral types. Of course for
-`std::uint8_t` they do nothing.
+`Msb` and `Lsb` denote a closed (inclusive) range where `Msb >= Lsb`. The first
+template argument must be an unsigned integral type.
 
 === `bit_pack`
 
-`bit_pack` is a handy function for packing multiple unsigned integral values
-into a larger bit width value.
+`bit_pack` is a function for packing multiple unsigned integral values into a
+larger bit width value.
 
 [source,cpp]
 ----
@@ -47,3 +53,19 @@ static_assert(y == x);
 The arguments are listed in order of significance, i.e. for the binary
 overloads, the first argument is the high bits, and the second argument the low
 bits.
+
+=== `to_le` and `to_be`
+
+`to_le` and `to_be` are variations on `byteswap` that convert unsigned integral
+types to little- or big-endian respectively. On a little-endian machine, `to_le`
+does nothing, and `to_be` is the equivalent of `byteswap`. On a big endian
+machine it is the other way around.
+
+[source,cpp]
+----
+constexpr auto x = std::uint32_t{0x12'34'56'78};
+constexpr auto y = stdx::to_be(x); // 0x78'56'34'12 (on a little-endian machine)
+----
+
+`to_le` and `to_be` are defined for unsigned integral types. Of course for
+`std::uint8_t` they do nothing.

--- a/include/stdx/bit.hpp
+++ b/include/stdx/bit.hpp
@@ -301,5 +301,25 @@ constexpr auto bit_pack<std::uint64_t> =
                               (static_cast<std::uint64_t>(b5) << 16u) |
                               (static_cast<std::uint64_t>(b6) << 8u) | b7;
                    }};
+
+namespace detail {
+template <typename T, std::size_t Bit>
+constexpr auto mask_bits()
+    -> std::enable_if_t<Bit <= std::numeric_limits<T>::digits, T> {
+    if constexpr (Bit == std::numeric_limits<T>::digits) {
+        return std::numeric_limits<T>::max();
+    } else {
+        return (T{1} << Bit) - T{1};
+    }
+}
+} // namespace detail
+
+template <typename T, std::size_t Msb = std::numeric_limits<T>::digits - 1,
+          std::size_t Lsb = 0>
+[[nodiscard]] constexpr auto bit_mask() noexcept
+    -> std::enable_if_t<std::is_unsigned_v<T> and Msb >= Lsb, T> {
+    static_assert(Msb < std::numeric_limits<T>::digits);
+    return detail::mask_bits<T, Msb + 1>() - detail::mask_bits<T, Lsb>();
+}
 } // namespace v1
 } // namespace stdx

--- a/test/bit.cpp
+++ b/test/bit.cpp
@@ -180,3 +180,34 @@ TEST_CASE("bit_pack 8x8 -> 64", "[bit]") {
                                                 0xbc, 0xde,
                                                 0xf0) == 0x1234'5678'9abc'def0);
 }
+
+TEST_CASE("bit_mask (whole range)", "[bit]") {
+    constexpr auto m = stdx::bit_mask<std::uint64_t>();
+    static_assert(m == std::numeric_limits<std::uint64_t>::max());
+    static_assert(m == stdx::bit_mask<std::uint64_t, 63>());
+    static_assert(m == stdx::bit_mask<std::uint64_t, 63, 0>());
+}
+
+TEST_CASE("bit_mask (low bits)", "[bit]") {
+    constexpr auto m = stdx::bit_mask<std::uint8_t, 1, 0>();
+    static_assert(m == 0b0000'0011);
+    static_assert(std::is_same_v<decltype(m), std::uint8_t const>);
+}
+
+TEST_CASE("bit_mask (mid bits)", "[bit]") {
+    constexpr auto m = stdx::bit_mask<std::uint8_t, 4, 3>();
+    static_assert(m == 0b0001'1000);
+    static_assert(std::is_same_v<decltype(m), std::uint8_t const>);
+}
+
+TEST_CASE("bit_mask (high bits)", "[bit]") {
+    constexpr auto m = stdx::bit_mask<std::uint8_t, 7, 6>();
+    static_assert(m == 0b1100'0000);
+    static_assert(std::is_same_v<decltype(m), std::uint8_t const>);
+}
+
+TEST_CASE("bit_mask (single bit)", "[bit]") {
+    constexpr auto m = stdx::bit_mask<std::uint8_t, 5, 5>();
+    static_assert(m == 0b0010'0000);
+    static_assert(std::is_same_v<decltype(m), std::uint8_t const>);
+}


### PR DESCRIPTION
I've written this in various places now. Call-site bit twiddling is tedious, especially dealing with a) integer promotion rules and b) shift-by-the-bit-size-of-the-type is UB.