### PR TITLE
:sparkles: Add `bit_size`

### DIFF
--- a/docs/bit.adoc
+++ b/docs/bit.adoc
@@ -14,15 +14,15 @@ and least-significant bits.
 [source,cpp]
 ----
 constexpr auto x = stdx::bit_mask<std::uint8_t, 5, 3>();
-static_assert(x == std::uint8_t{0b0011'1000};
+static_assert(x == std::uint8_t{0b0011'1000});
 
 // Lsb may be omitted (meaning it's 0)
 constexpr auto y = stdx::bit_mask<std::uint8_t, 5>();
-static_assert(y == std::uint8_t{0b0011'1111};
+static_assert(y == std::uint8_t{0b0011'1111});
 
 // omitting both Msb and Lsb means the entire range of the type
 constexpr auto z = stdx::bit_mask<std::uint8_t>();
-static_assert(z == std::uint8_t{0b1111'1111};
+static_assert(z == std::uint8_t{0b1111'1111});
 ----
 
 `Msb` and `Lsb` denote a closed (inclusive) range where `Msb >= Lsb`. The first
@@ -53,6 +53,18 @@ static_assert(y == x);
 The arguments are listed in order of significance, i.e. for the binary
 overloads, the first argument is the high bits, and the second argument the low
 bits.
+
+=== `bit_size`
+
+`bit_size` returns a `std::size_t`: the size of its type argument in bits. For
+unsigned integral types, this is equivalent to
+https://en.cppreference.com/w/cpp/types/numeric_limits/digits[`std::numeric_limits<T>::digits`].
+
+[source,cpp]
+----
+constexpr std::size_t x = stdx::bit_size<std::uint8_t>();
+static_assert(x == 8);
+----
 
 === `to_le` and `to_be`
 

--- a/include/stdx/bit.hpp
+++ b/include/stdx/bit.hpp
@@ -4,6 +4,7 @@
 #include <stdx/type_traits.hpp>
 #include <stdx/utility.hpp>
 
+#include <climits>
 #include <cstdint>
 #include <limits>
 #include <type_traits>
@@ -320,6 +321,10 @@ template <typename T, std::size_t Msb = std::numeric_limits<T>::digits - 1,
     -> std::enable_if_t<std::is_unsigned_v<T> and Msb >= Lsb, T> {
     static_assert(Msb < std::numeric_limits<T>::digits);
     return detail::mask_bits<T, Msb + 1>() - detail::mask_bits<T, Lsb>();
+}
+
+template <typename T> constexpr auto bit_size() -> std::size_t {
+    return sizeof(T) * CHAR_BIT;
 }
 } // namespace v1
 } // namespace stdx

--- a/test/bit.cpp
+++ b/test/bit.cpp
@@ -5,6 +5,7 @@
 
 #include <cstdint>
 #include <limits>
+#include <type_traits>
 
 TEST_CASE("byteswap", "[bit]") {
     static_assert(stdx::byteswap(std::uint8_t{1u}) == 1u);
@@ -210,4 +211,11 @@ TEST_CASE("bit_mask (single bit)", "[bit]") {
     constexpr auto m = stdx::bit_mask<std::uint8_t, 5, 5>();
     static_assert(m == 0b0010'0000);
     static_assert(std::is_same_v<decltype(m), std::uint8_t const>);
+}
+
+TEMPLATE_TEST_CASE("bit_size", "[bit]", std::uint8_t, std::uint16_t,
+                   std::uint32_t, std::uint64_t, std::int8_t, std::int16_t,
+                   std::int32_t, std::int64_t) {
+    static_assert(stdx::bit_size<TestType>() ==
+                  std::numeric_limits<std::make_unsigned_t<TestType>>::digits);
 }


### PR DESCRIPTION
Much more readable and discoverable than something like `std::numeric_limits<T>::digits + std::numeric_limits<T>::is_signed`.