### PR TITLE
:sparkles: Add support for non-structural types as NTTPs

### DIFF
--- a/docs/type_traits.adoc
+++ b/docs/type_traits.adoc
@@ -96,6 +96,22 @@ to write this function where the template takes a mixture of type, value, and
 template parameters. So this is useful for templates whose parameters are all
 types or all values.
 
+=== `is_structural_v`
+
+`is_structural_v<T>` is `true` when `T` is a
+https://en.cppreference.com/w/cpp/language/template_parameters#Non-type_template_parameter[structural
+type] suitable for use as a non-type template parameter.
+
+[source,cpp]
+----
+static_assert(stdx::is_structural_v<int>);
+static_assert(not stdx::is_structural_v<std::string>);
+----
+
+NOTE: Detecting structurality of a type is not yet possible in the general case,
+so there are certain structural types for which this trait will be `false`. In
+practice those types should be rare, and there should be no false positives.
+
 === `type_or_t`
 
 `type_or_t` is an alias template that selects a type based on whether or not it

--- a/docs/utility.adoc
+++ b/docs/utility.adoc
@@ -15,6 +15,29 @@ auto x = 1729;                 // int
 auto y = stdx::as_unsigned(x); // unsigned int
 ----
 
+=== `CX_VALUE`
+
+`CX_VALUE` is a macro that wraps its argument in a constexpr callable, which can
+be used as a
+https://en.cppreference.com/w/cpp/language/template_parameters#Non-type_template_parameter[non-type
+template argument]. The compile-time value can be retrieved by calling the
+callable. This is useful for passing non-structural types as template arguments.
+
+[source,cpp]
+----
+// A std::string_view value cannot be a template argument,
+// so wrap it in CX_VALUE
+constexpr auto ts_value = CX_VALUE(std::string_view{});
+auto o = stdx::optional<std:string_view,
+                        stdx::tombstone_value<ts_value>>;
+----
+
+NOTE: This is supported for C++20 and later: it still requires the ability to
+pass lambda expressions as non-type template arguments. The type must still be a
+https://en.cppreference.com/w/cpp/named_req/LiteralType[literal type] to be used
+at compile time, but need not necessarily be a structural type. (The usual
+difference is that structural types cannot have private members.)
+
 === `forward_like`
 
 `forward_like` is an implementation of
@@ -24,6 +47,24 @@ https://en.cppreference.com/w/cpp/utility/forward_like[`std::forward_like`].
 [source,cpp]
 ----
 static_assert(stdx::same_as<stdx::forward_like_t<int &, float>, float &>);
+----
+
+=== `FWD`
+
+`FWD` is a macro that perfectly forwards its argument. It's useful for C++17
+lambdas which can't have a template head to name their types.
+
+[source,cpp]
+----
+// C++20 and later possibility
+auto l = [] <typename Arg> (auto&& arg) {
+  return f(std::forward<Arg>(arg));
+};
+
+// equivalent
+auto l = [] (auto&& arg) {
+  return f(FWD(arg));
+};
 ----
 
 === `overload`

--- a/include/stdx/concepts.hpp
+++ b/include/stdx/concepts.hpp
@@ -107,6 +107,8 @@ constexpr auto range =
 
 #undef DETECTOR
 
+template <typename T> constexpr auto structural = is_structural_v<T>;
+
 #else
 
 // After C++20, we can define concepts that are lacking in the library
@@ -191,6 +193,9 @@ concept range = requires(T &t) {
     std::end(t);
 };
 
+template <typename T>
+concept structural = is_structural_v<T>;
+
 #endif
 
 } // namespace v1
@@ -233,6 +238,9 @@ concept range = requires(T &t) {
     std::begin(t);
     std::end(t);
 };
+
+template <typename T>
+concept structural = is_structural_v<T>;
 
 } // namespace v1
 } // namespace stdx

--- a/include/stdx/optional.hpp
+++ b/include/stdx/optional.hpp
@@ -31,7 +31,13 @@ struct tombstone_traits<T, std::enable_if_t<std::is_pointer_v<T>>> {
 };
 
 template <auto V> struct tombstone_value {
-    constexpr auto operator()() const { return V; }
+    constexpr auto operator()() const {
+        if constexpr (stdx::is_cx_value_v<decltype(V)>) {
+            return V();
+        } else {
+            return V;
+        }
+    }
 };
 
 template <typename T, typename TS = tombstone_traits<T>> class optional {

--- a/include/stdx/utility.hpp
+++ b/include/stdx/utility.hpp
@@ -148,3 +148,14 @@ auto as_signed(T t) {
 #ifndef FWD
 #define FWD(x) std::forward<decltype(x)>(x)
 #endif
+
+#ifndef CX_VALUE
+#define CX_VALUE(...)                                                          \
+    [] {                                                                       \
+        struct {                                                               \
+            constexpr auto operator()() const noexcept { return __VA_ARGS__; } \
+            using cx_value_t [[maybe_unused]] = void;                          \
+        } val;                                                                 \
+        return val;                                                            \
+    }()
+#endif

--- a/test/concepts.cpp
+++ b/test/concepts.cpp
@@ -160,3 +160,14 @@ TEST_CASE("range", "[concepts]") {
     static_assert(not stdx::range<int>);
     static_assert(stdx::range<std::array<int, 4>>);
 }
+
+namespace {
+struct non_structural {
+    ~non_structural() {} // nontrivial destructor
+};
+} // namespace
+
+TEST_CASE("structural", "[type_traits]") {
+    static_assert(stdx::structural<int>);
+    static_assert(not stdx::structural<non_structural>);
+}

--- a/test/optional.cpp
+++ b/test/optional.cpp
@@ -5,6 +5,7 @@
 #include <cmath>
 #include <cstdint>
 #include <optional>
+#include <string_view>
 #include <type_traits>
 #include <utility>
 
@@ -413,3 +414,13 @@ TEST_CASE("transform (multi-arg nonmovable)", "[optional]") {
         o2);
     CHECK(o3->value == 59);
 }
+
+#if __cpp_nontype_template_args >= 201911L
+TEST_CASE("tombstone with non-structural value", "[optional]") {
+    constexpr auto ts_value = CX_VALUE(std::string_view{});
+    auto const o =
+        stdx::optional<std::string_view, stdx::tombstone_value<ts_value>>{};
+    CHECK(not o);
+    CHECK(*o == std::string_view{});
+}
+#endif


### PR DESCRIPTION
It's useful to be able to construct a `stdx::optional<std::string_view>`.