### PR TITLE
:children_crossing: Make ct_string interface safer with begin/end

### DIFF
--- a/docs/ct_string.adoc
+++ b/docs/ct_string.adoc
@@ -56,11 +56,27 @@ struct named_thing {
     // if the character doesn't exist, p.first is equal to S and p.second is empty
     // otherwise p.first is everything up to (but not including) the character,
     // and p.second is everything after (also not including)
+
+    // we can also iterate over a ct_string
+    for (auto c : S) { ... }
+
+    // a ct_string can also explicitly convert to a std::string_view
+    constexpr auto sv = static_cast<std::string_view>(S);
+
+    // when required, we can access the underlying array of chars,
+    // which includes the null terminator
+    const auto& char_array = S.value;
   }
 };
 ----
 
 NOTE: `size` and `empty` are always available as `constexpr`.
+
+CAUTION: `ct_string` stores an internal array (`value`) which includes the null
+terminator for the string. The `size` reported by the `ct_string` is one less
+than the size of the internal array. Thus the `begin`, `end` and `size` of a
+`ct_string` all represent the string of characters without the null terminator.
+However, for interfacing with legacy functions, a null terminator can be useful.
 
 See https://github.com/intel/compile-time-init-build/tree/main/include/sc[cib
 documentation] for details about the cib string constant class.

--- a/include/stdx/ct_string.hpp
+++ b/include/stdx/ct_string.hpp
@@ -30,6 +30,15 @@ template <std::size_t N> struct ct_string {
         }
     }
 
+    [[nodiscard]] constexpr auto begin() const { return std::begin(value); }
+    [[nodiscard]] constexpr auto end() const {
+        return std::prev(std::end(value));
+    }
+    [[nodiscard]] constexpr auto rbegin() const {
+        return std::next(std::rbegin(value));
+    }
+    [[nodiscard]] constexpr auto rend() const { return std::rend(value); }
+
     constexpr static std::integral_constant<std::size_t, N - 1U> size{};
     constexpr static std::integral_constant<bool, N == 1U> empty{};
 

--- a/test/ct_string.cpp
+++ b/test/ct_string.cpp
@@ -2,6 +2,10 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <iterator>
+#include <string_view>
+#include <type_traits>
+
 namespace {
 template <typename T, T...> struct string_constant {};
 } // namespace
@@ -90,4 +94,26 @@ TEST_CASE("string concat", "[ct_string]") {
     constexpr auto s1 = stdx::ct_string{"abc"};
     constexpr auto s2 = stdx::ct_string{"def"};
     static_assert(s1 + s2 == stdx::ct_string{"abcdef"});
+}
+
+TEST_CASE("ct_string as iterable", "[ct_string]") {
+    constexpr auto s = stdx::ct_string{"abc"};
+    static_assert(std::next(std::begin(s), std::size(s)) == std::end(s));
+
+    auto it = std::cbegin(s);
+    CHECK(*it++ == 'a');
+    CHECK(*it++ == 'b');
+    CHECK(*it++ == 'c');
+    CHECK(it == std::cend(s));
+}
+
+TEST_CASE("ct_string as reverse iterable", "[ct_string]") {
+    constexpr auto s = stdx::ct_string{"abc"};
+    static_assert(std::next(std::rbegin(s), std::size(s)) == std::rend(s));
+
+    auto it = std::crbegin(s);
+    CHECK(*it++ == 'c');
+    CHECK(*it++ == 'b');
+    CHECK(*it++ == 'a');
+    CHECK(it == std::crend(s));
 }


### PR DESCRIPTION
Problem:
- `ct_string` stores an internal array including a null terminator, but `size` reports the string length without the null terminator. This on its own is OK, but...
- iterating a `ct_string` required using begin and end on the underlying `value` (the array including the null terminator). Therefore `size` was at odds with the number of items iterated.

Solution:
- Add `begin` and `end` for ct_string that allow direct iteration and agree with `size`. Similarly, `rbegin` and `rend` to allow reverse iteration excluding the null terminator.