### PR TITLE
:sparkles: Add `bitset::to<T>` for conversion to unsigned integral

### DIFF
--- a/docs/bitset.adoc
+++ b/docs/bitset.adoc
@@ -14,7 +14,7 @@ platform.
 
 * Stream input and output operators are not implemented.
 * A `std::hash` specialization is not implemented.
-* `to_string`, `to_ulong` and `to_ullong` are not implemented; `to_uint64_t` is available.
+* `to_string`, `to_ulong` and `to_ullong` are not implemented
 
 A bitset has two template parameters: the size of the bitset and the storage
 element type to use. The storage element type must be unsigned.
@@ -56,4 +56,15 @@ using namespace std::string_view_literals;
 auto bs1 = stdx::bitset<8>{"1100"sv};            // bits 2 and 3 set
 auto bs2 = stdx::bitset<8>{"1100"sv, 0, 2};      // bits 0 and 1 set
 auto bs3 = stdx::bitset<8>{"AABB"sv, 0, 2, 'A'}; // bits 0 and 1 set
+----
+
+To convert a bitset back to an integral type, `to<T>` is available where `T` is
+an unsigned integral type large enough to fit all the bits. And `to_natural`
+produces the smallest such unsigned integral type.
+
+[source,cpp]
+----
+auto bs = stdx::bitset<11>{0b101}; // 11 bits, value 5
+auto i = bs.to<std::uint64_t>();   // 5 (a std::uint64_t)
+auto j = bs.to_natural();          // 5 (a std::uint16_t)
 ----

--- a/test/fail/bitset_to_uint64_over_64_bits.cpp
+++ b/test/fail/bitset_to_uint64_over_64_bits.cpp
@@ -1,8 +1,8 @@
 #include <stdx/bitset.hpp>
 
-// EXPECT: Bitset too big for conversion to std::uint64_t
+// EXPECT: Bitset too big for conversion to T
 
 auto main() -> int {
     auto b = stdx::bitset<65, unsigned char>{};
-    auto i = b.to_uint64_t();
+    auto i = b.to<std::uint64_t>();
 }


### PR DESCRIPTION
Remove `to_uint64_t`; it's superseded.