### PR TITLE
:art: Enable `for_each` on `std::array`

### DIFF
--- a/include/stdx/tuple.hpp
+++ b/include/stdx/tuple.hpp
@@ -385,6 +385,8 @@ tuple_impl(Ts...)
 } // namespace detail
 
 template <typename T> constexpr auto tuple_size_v = T::size();
+template <typename T, std::size_t N>
+constexpr auto tuple_size_v<std::array<T, N>> = N;
 
 template <std::size_t I, typename T>
 using tuple_element_t = decltype(T::ugly_Value(index<I>));

--- a/test/tuple_algorithms.cpp
+++ b/test/tuple_algorithms.cpp
@@ -130,6 +130,19 @@ TEST_CASE("for_each", "[tuple_algorithms]") {
     }
 }
 
+TEST_CASE("for_each on arrays", "[tuple_algorithms]") {
+    auto a = std::array{1, 2, 3};
+    auto sum = 0;
+    stdx::for_each(
+        [&](auto &x, auto y) {
+            sum += x + y;
+            x--;
+        },
+        a, a);
+    CHECK(sum == 12);
+    CHECK(a == std::array{0, 1, 2});
+}
+
 TEST_CASE("tuple_cat", "[tuple_algorithms]") {
     static_assert(stdx::tuple_cat() == stdx::tuple{});
     static_assert(stdx::tuple_cat(stdx::tuple{}, stdx::tuple{}) ==


### PR DESCRIPTION
We often write plain indexed for loops in order to work on two arrays... here's a better way.