### PR TITLE
:sparkles: Add `for_each` and `for_each_n` to algorithms

### DIFF
--- a/docs/algorithm.adoc
+++ b/docs/algorithm.adoc
@@ -4,6 +4,34 @@
 https://github.com/intel/cpp-std-extensions/blob/main/include/stdx/algorithm.hpp[`algorithm.hpp`]
 provides an implementation of some algorithms.
 
+=== `for_each` and `for_each_n`
+
+`stdx::for_each` is similar to
+https://en.cppreference.com/w/cpp/algorithm/for_each[`std::for_each`], but
+variadic in its inputs.
+
+[source,cpp]
+----
+template <typename InputIt, typename Operation, typename... InputItN>
+constexpr auto for_each(InputIt first, InputIt last,
+                        Operation op, InputItN... first_n) -> Operation;
+----
+
+NOTE: `stdx::for_each` is `constexpr` in C++20 and later, because it uses
+https://en.cppreference.com/w/cpp/utility/functional/invoke[`std::invoke`].
+
+`stdx::for_each_n` is just like `stdx::for_each`, but instead of taking two
+iterators to delimit the input range, it takes an iterator and size.
+
+[source,cpp]
+----
+template <typename InputIt, typename Size, typename Operation,
+          typename... InputItN>
+constexpr auto for_each_n(InputIt first, Size n,
+                          Operation op, InputItN... first_n) -> Operation;
+----
+
+
 === `transform` and `transform_n`
 
 `stdx::transform` is similar to

--- a/docs/tuple_algorithms.adoc
+++ b/docs/tuple_algorithms.adoc
@@ -128,6 +128,13 @@ stdx::enumerate([] <auto Idx> (auto x) { std::cout << Idx << ':' << x << '\n'; }
 ----
 NOTE: Like `for_each`, `enumerate` returns the function object passed to it.
 
+`enumerate` is also available for `std::array`, but to be explicit it is called `unrolled_enumerate`:
+[source,cpp]
+----
+auto a = std::array{1, 2, 3};
+stdx::unrolled_enumerate([] <auto Idx> (auto x) { std::cout << Idx << ':' << x << '\n'; }, a);
+----
+
 === `filter`
 
 `filter` allows compile-time filtering of a tuple based on the types contained.
@@ -161,6 +168,13 @@ NOTE: Like
 https://en.cppreference.com/w/cpp/algorithm/for_each[`std::for_each`],
 `stdx::for_each` returns the function object passed to it. This can be useful
 for stateful function objects.
+
+`for_each` is also available for `std::array`, but to be explicit it is called `unrolled_for_each`:
+[source,cpp]
+----
+auto a = std::array{1, 2, 3};
+stdx::unrolled_for_each([] (auto x) { std::cout << x << '\n'; }, a);
+----
 
 === `sort`
 

--- a/include/stdx/algorithm.hpp
+++ b/include/stdx/algorithm.hpp
@@ -48,6 +48,27 @@ CONSTEXPR_INVOKE auto transform_n(InputIt first, Size n, OutputIt d_first,
     return {d_first, first, first_n...};
 }
 
+template <typename InputIt, typename Operation, typename... InputItN>
+CONSTEXPR_INVOKE auto for_each(InputIt first, InputIt last, Operation op,
+                               InputItN... first_n) -> Operation {
+    while (first != last) {
+        std::invoke(op, *first, *first_n...);
+        static_cast<void>(++first), (static_cast<void>(++first_n), ...);
+    }
+    return op;
+}
+
+template <typename InputIt, typename Size, typename Operation,
+          typename... InputItN>
+CONSTEXPR_INVOKE auto for_each_n(InputIt first, Size n, Operation op,
+                                 InputItN... first_n) -> Operation {
+    while (n-- > 0) {
+        std::invoke(op, *first, *first_n...);
+        static_cast<void>(++first), (static_cast<void>(++first_n), ...);
+    }
+    return op;
+}
+
 #undef CONSTEXPR_INVOKE
 } // namespace v1
 } // namespace stdx

--- a/test/algorithm.cpp
+++ b/test/algorithm.cpp
@@ -1,4 +1,5 @@
 #include <stdx/algorithm.hpp>
+#include <stdx/tuple_algorithms.hpp>
 #include <stdx/tuple_destructure.hpp>
 
 #include <catch2/catch_test_macros.hpp>
@@ -43,4 +44,22 @@ TEST_CASE("n-ary transform_n", "[algorithm]") {
         [](auto... ns) { return (0 + ... + ns); }, std::cbegin(input),
         std::cbegin(input), std::cbegin(input));
     CHECK(output == std::array{4, 8, 12, 16});
+}
+
+TEST_CASE("n-ary for_each", "[algorithm]") {
+    auto const input = std::array{1, 2, 3, 4};
+    auto output = decltype(input){};
+    stdx::for_each(
+        std::cbegin(input), std::cend(input),
+        [it = std::begin(output)](auto n) mutable { *it++ = n + 1; });
+    CHECK(output == std::array{2, 3, 4, 5});
+}
+
+TEST_CASE("n-ary for_each_n", "[algorithm]") {
+    auto const input = std::array{1, 2, 3, 4};
+    auto output = decltype(input){};
+    stdx::for_each_n(
+        std::cbegin(input), std::size(input),
+        [it = std::begin(output)](auto n) mutable { *it++ = n + 1; });
+    CHECK(output == std::array{2, 3, 4, 5});
 }

--- a/test/tuple_algorithms.cpp
+++ b/test/tuple_algorithms.cpp
@@ -130,10 +130,10 @@ TEST_CASE("for_each", "[tuple_algorithms]") {
     }
 }
 
-TEST_CASE("for_each on arrays", "[tuple_algorithms]") {
+TEST_CASE("unrolled_for_each on arrays", "[tuple_algorithms]") {
     auto a = std::array{1, 2, 3};
     auto sum = 0;
-    stdx::for_each(
+    stdx::unrolled_for_each(
         [&](auto &x, auto y) {
             sum += x + y;
             x--;
@@ -627,5 +627,14 @@ TEST_CASE("enumerate", "[tuple_algorithms]") {
     stdx::enumerate(
         [&]<auto Idx>(auto x, auto y) { sum += static_cast<int>(Idx) + x + y; },
         t, t);
+    CHECK(sum == (0 + 1 + 2) + (2 + 4 + 6));
+}
+
+TEST_CASE("unrolled enumerate on arrays", "[tuple_algorithms]") {
+    auto const a = std::array{1, 2, 3};
+    auto sum = 0;
+    stdx::unrolled_enumerate(
+        [&]<auto Idx>(auto x, auto y) { sum += static_cast<int>(Idx) + x + y; },
+        a, a);
     CHECK(sum == (0 + 1 + 2) + (2 + 4 + 6));
 }


### PR DESCRIPTION
- Add variadic `for_each`
- Change tuple `for_each` to be `unrolled_for_each` on arrays
- Add `unrolled_enumerate` for arrays
- Constrain tuple algorithms