### PR TITLE
:sparkles: Add `smallest_uint`

### DIFF
--- a/docs/bit.adoc
+++ b/docs/bit.adoc
@@ -79,6 +79,20 @@ constexpr std::size_t x = stdx::bit_size<std::uint8_t>();
 static_assert(x == 8);
 ----
 
+=== `smallest_uint`
+
+`smallest_uint` is a function template that selects the smallest unsigned
+integral type that will fit a compile-time value.
+
+[source,cpp]
+----
+constexpr auto x = stdx::smallest_uint<42>();   // std::uint8_t{}
+constexpr auto y = stdx::smallest_uint<1337>(); // std::uint16_t{}
+
+// smallest_uint_t is the type of a call to smallest_uint
+using T = stdx::smallest_uint_t<1337>; // std::uint16_t
+----
+
 === `to_le` and `to_be`
 
 `to_le` and `to_be` are variations on `byteswap` that convert unsigned integral

--- a/include/stdx/bit.hpp
+++ b/include/stdx/bit.hpp
@@ -340,5 +340,24 @@ template <typename T>
 template <typename T> constexpr auto bit_size() -> std::size_t {
     return sizeof(T) * CHAR_BIT;
 }
+
+template <std::size_t N, typename S = void> CONSTEVAL auto smallest_uint() {
+    if constexpr (not std::is_same_v<S, void>) {
+        static_assert(std::is_unsigned_v<S>,
+                      "smallest_uint override must be an unsigned type");
+        return S{};
+    } else if constexpr (N <= std::numeric_limits<std::uint8_t>::digits) {
+        return std::uint8_t{};
+    } else if constexpr (N <= std::numeric_limits<std::uint16_t>::digits) {
+        return std::uint16_t{};
+    } else if constexpr (N <= std::numeric_limits<std::uint32_t>::digits) {
+        return std::uint32_t{};
+    } else {
+        return std::uint64_t{};
+    }
+}
+
+template <std::size_t N, typename S = void>
+using smallest_uint_t = decltype(smallest_uint<N, S>());
 } // namespace v1
 } // namespace stdx

--- a/include/stdx/bitset.hpp
+++ b/include/stdx/bitset.hpp
@@ -23,22 +23,6 @@ struct all_bits_t {};
 constexpr inline auto all_bits = all_bits_t{};
 
 namespace detail {
-template <std::size_t N, typename S> CONSTEVAL auto select_storage() {
-    if constexpr (not std::is_same_v<S, void>) {
-        static_assert(std::is_unsigned_v<S>,
-                      "Underlying storage of bitset must be an unsigned type");
-        return S{};
-    } else if constexpr (N <= std::numeric_limits<std::uint8_t>::digits) {
-        return std::uint8_t{};
-    } else if constexpr (N <= std::numeric_limits<std::uint16_t>::digits) {
-        return std::uint16_t{};
-    } else if constexpr (N <= std::numeric_limits<std::uint32_t>::digits) {
-        return std::uint32_t{};
-    } else {
-        return std::uint64_t{};
-    }
-}
-
 template <std::size_t N, typename StorageElem> class bitset {
     constexpr static auto storage_elem_size =
         std::numeric_limits<StorageElem>::digits;
@@ -185,7 +169,7 @@ template <std::size_t N, typename StorageElem> class bitset {
     }
 
     [[nodiscard]] constexpr auto to_natural() const {
-        using T = decltype(select_storage<N, void>());
+        using T = smallest_uint_t<N>;
         static_assert(N <= std::numeric_limits<T>::digits,
                       "Bitset too big for conversion to T");
         return to<T>();
@@ -415,8 +399,7 @@ constexpr auto for_each(F &&f, bitset<M, S> const &...bs) -> F {
 } // namespace detail
 
 template <std::size_t N, typename StorageElem = void>
-using bitset =
-    detail::bitset<N, decltype(detail::select_storage<N, StorageElem>())>;
+using bitset = detail::bitset<N, decltype(smallest_uint<N, StorageElem>())>;
 
 } // namespace v1
 } // namespace stdx

--- a/test/fail/bitset_signed_storage.cpp
+++ b/test/fail/bitset_signed_storage.cpp
@@ -1,5 +1,5 @@
 #include <stdx/bitset.hpp>
 
-// EXPECT: Underlying storage of bitset must be an unsigned type
+// EXPECT: smallest_uint override must be an unsigned type
 
 auto main() -> int { auto b = stdx::bitset<32, int>{}; }


### PR DESCRIPTION
What used to be `detail::select_storage`