### PR TITLE
:zap: :boom: Remove some expensive includes

### DIFF
--- a/include/stdx/concepts.hpp
+++ b/include/stdx/concepts.hpp
@@ -5,7 +5,6 @@
 #if __has_include(<concepts>)
 #include <concepts>
 #endif
-#include <iterator>
 
 #if __cpp_lib_concepts < 202002L
 
@@ -98,13 +97,6 @@ template <typename T> constexpr auto callable = is_callable_v<T>;
 template <typename T, template <typename> typename TypeTrait>
 constexpr auto has_trait = TypeTrait<T>::value;
 
-DETECTOR(range_begin, (std::begin(std::declval<T &>())))
-DETECTOR(range_end, (std::end(std::declval<T &>())))
-
-template <typename T>
-constexpr auto range =
-    detail::detect::range_begin<T> and detail::detect::range_end<T>;
-
 #undef DETECTOR
 
 template <typename T> constexpr auto structural = is_structural_v<T>;
@@ -188,12 +180,6 @@ template <typename T, template <typename> typename TypeTrait>
 concept has_trait = TypeTrait<T>::value;
 
 template <typename T>
-concept range = requires(T &t) {
-    std::begin(t);
-    std::end(t);
-};
-
-template <typename T>
 concept structural = is_structural_v<T>;
 
 #endif
@@ -232,12 +218,6 @@ concept has_trait = TypeTrait<T>::value;
 template <typename T, typename U>
 concept same_as_unqualified =
     is_same_unqualified_v<T, U> and is_same_unqualified_v<U, T>;
-
-template <typename T>
-concept range = requires(T &t) {
-    std::begin(t);
-    std::end(t);
-};
 
 template <typename T>
 concept structural = is_structural_v<T>;

--- a/include/stdx/detail/list_common.hpp
+++ b/include/stdx/detail/list_common.hpp
@@ -3,8 +3,6 @@
 #include <stdx/concepts.hpp>
 #include <stdx/panic.hpp>
 
-#include <cstddef>
-#include <iterator>
 #include <type_traits>
 #include <utility>
 

--- a/include/stdx/intrusive_forward_list.hpp
+++ b/include/stdx/intrusive_forward_list.hpp
@@ -3,8 +3,9 @@
 #include <stdx/detail/list_common.hpp>
 
 #include <cstddef>
+#if __cplusplus < 202002L
 #include <iterator>
-#include <type_traits>
+#endif
 
 namespace stdx {
 inline namespace v1 {
@@ -18,7 +19,9 @@ class intrusive_forward_list {
         using value_type = N;
         using pointer = value_type *;
         using reference = value_type &;
+#if __cplusplus < 202002L
         using iterator_category = std::forward_iterator_tag;
+#endif
 
         constexpr iterator_t() = default;
         constexpr explicit iterator_t(pointer n) : node{n} {}

--- a/include/stdx/intrusive_list.hpp
+++ b/include/stdx/intrusive_list.hpp
@@ -3,9 +3,10 @@
 #include <stdx/detail/list_common.hpp>
 
 #include <cstddef>
+#if __cplusplus < 202002L
 #include <iterator>
+#endif
 #include <type_traits>
-#include <utility>
 
 namespace stdx {
 inline namespace v1 {
@@ -19,7 +20,9 @@ class intrusive_list {
         using value_type = N;
         using pointer = value_type *;
         using reference = value_type &;
+#if __cplusplus < 202002L
         using iterator_category = std::forward_iterator_tag;
+#endif
 
         constexpr iterator_t() = default;
         constexpr explicit iterator_t(pointer n) : node{n} {}
@@ -98,7 +101,7 @@ class intrusive_list {
 
     constexpr auto unchecked_insert(iterator it, pointer n) -> void {
         if (it != end()) {
-            auto p = std::addressof(*it);
+            auto p = it.operator->();
             n->next = p;
             n->prev = p->prev;
             p->prev = n;

--- a/include/stdx/ranges.hpp
+++ b/include/stdx/ranges.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <iterator>
+
+namespace stdx {
+inline namespace v1 {
+
+#if __cplusplus < 202002L
+
+// NOLINTBEGIN(bugprone-macro-parentheses, cppcoreguidelines-macro-usage)
+#define DETECTOR(name, expr)                                                   \
+    namespace detail::detect {                                                 \
+    template <typename T, typename = void> constexpr auto name = false;        \
+    template <typename T>                                                      \
+    constexpr auto name<T, std::void_t<decltype(expr)>> = true;                \
+    }
+// NOLINTEND(bugprone-macro-parentheses, cppcoreguidelines-macro-usage)
+
+DETECTOR(range_begin, (std::begin(std::declval<T &>())))
+DETECTOR(range_end, (std::end(std::declval<T &>())))
+
+template <typename T>
+constexpr auto range =
+    detail::detect::range_begin<T> and detail::detect::range_end<T>;
+
+#undef DETECTOR
+
+#else
+
+template <typename T>
+concept range = requires(T &t) {
+    std::begin(t);
+    std::end(t);
+};
+
+#endif
+
+} // namespace v1
+} // namespace stdx

--- a/include/stdx/tuple.hpp
+++ b/include/stdx/tuple.hpp
@@ -7,8 +7,6 @@
 #include <array>
 #include <concepts>
 #include <cstddef>
-#include <iterator>
-#include <memory>
 #include <type_traits>
 #include <utility>
 

--- a/include/stdx/tuple_algorithms.hpp
+++ b/include/stdx/tuple_algorithms.hpp
@@ -11,7 +11,6 @@
 #include <algorithm>
 #include <array>
 #include <cstddef>
-#include <iterator>
 #include <type_traits>
 #include <utility>
 
@@ -28,9 +27,9 @@ template <tuplelike... Ts> [[nodiscard]] constexpr auto tuple_cat(Ts &&...ts) {
 
         [[maybe_unused]] constexpr auto element_indices = [&] {
             std::array<detail::index_pair, total_num_elements> indices{};
-            auto p = std::data(indices);
+            auto p = indices.data();
             ((p = std::remove_cvref_t<Ts>::fill_inner_indices(p)), ...);
-            auto q = std::data(indices);
+            auto q = indices.data();
             std::size_t n{};
             ((q = std::remove_cvref_t<Ts>::fill_outer_indices(q, n++)), ...);
             return indices;
@@ -62,7 +61,7 @@ template <template <typename T> typename Pred, tuplelike T>
                                                               : std::size_t{}));
         constexpr auto indices = [] {
             auto a = std::array<std::size_t, num_matches>{};
-            [[maybe_unused]] auto it = std::begin(a);
+            [[maybe_unused]] auto it = a.begin();
             [[maybe_unused]] auto copy_index =
                 [&]<std::size_t I, typename Elem> {
                     if constexpr (Pred<Elem>::value) {
@@ -190,9 +189,9 @@ template <template <typename> typename Proj = std::type_identity_t,
     constexpr auto indices = []<std::size_t... Is>(std::index_sequence<Is...>) {
         auto a = std::array<P, sizeof...(Is)>{
             P{stdx::type_as_string<Proj<tuple_element_t<Is, T>>>(), Is}...};
-        std::sort(
-            std::begin(a), std::end(a),
-            [](auto const &p1, auto const &p2) { return p1.first < p2.first; });
+        std::sort(a.begin(), a.end(), [](auto const &p1, auto const &p2) {
+            return p1.first < p2.first;
+        });
         return a;
     }(std::make_index_sequence<T::size()>{});
 
@@ -267,7 +266,7 @@ template <template <typename> typename Proj = std::type_identity_t,
                         offset + Js, stdx::remove_cvref_t<Tuple>>...>{
                         std::forward<Tuple>(t)[index<offset + Js>]...};
                 }(std::make_index_sequence<chunks[Is].size>{})...);
-        }(std::make_index_sequence<std::size(chunks)>{});
+        }(std::make_index_sequence<chunks.size()>{});
     }
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,6 +41,7 @@ add_tests(
     overload
     panic
     priority
+    ranges
     remove_cvref
     span
     to_underlying

--- a/test/concepts.cpp
+++ b/test/concepts.cpp
@@ -156,11 +156,6 @@ TEST_CASE("models_trait", "[concepts]") {
     static_assert(not stdx::has_trait<int, std::is_pointer>);
 }
 
-TEST_CASE("range", "[concepts]") {
-    static_assert(not stdx::range<int>);
-    static_assert(stdx::range<std::array<int, 4>>);
-}
-
 namespace {
 struct non_structural {
     ~non_structural() {} // nontrivial destructor

--- a/test/intrusive_list_properties.cpp
+++ b/test/intrusive_list_properties.cpp
@@ -153,8 +153,7 @@ template <typename ListSut> struct IntrusiveListCommands {
         void apply(ListModel &m) const override {
             auto wrapped_index = index % static_cast<int>(m.size());
 
-            auto iter = m.begin();
-            std::advance(iter, wrapped_index);
+            auto iter = std::next(m.begin(), wrapped_index);
             m.erase(iter);
         }
 
@@ -163,8 +162,7 @@ template <typename ListSut> struct IntrusiveListCommands {
 
             auto wrapped_index = index % static_cast<int>(m.size());
 
-            auto iter = sut.list.begin();
-            std::advance(iter, wrapped_index);
+            auto iter = std::next(sut.list.begin(), wrapped_index);
             auto p = &(*iter);
 
             sut.list.remove(p);

--- a/test/ranges.cpp
+++ b/test/ranges.cpp
@@ -1,0 +1,10 @@
+#include <stdx/ranges.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <array>
+
+TEST_CASE("range concept", "[ranges]") {
+    static_assert(not stdx::range<int>);
+    static_assert(stdx::range<std::array<int, 4>>);
+}


### PR DESCRIPTION
Problem:
- Profiling shows the following includes to be particularly expensive:
  - `<iterator>`
  - `<memory>`

Solution:
- Remove uses of `std::begin()`, `std::end()` etc in favour of the member functions where possible.
- Remove uses of `std::addressof()` where possible.
- Move the `range` concept from `concepts.hpp` to `ranges.hpp`. Using `std::begin` and `std::end` here is preferable so that C-style arrays model `range`. But it need not be included by default in `concepts.hpp`: this also matches the standard better.

Note:
- This is a breaking change since the `range` concept moved.