### PR TITLE
:bug: Remove incorrect `LIFETIMEBOUND` annotation

### DIFF
--- a/include/stdx/span.hpp
+++ b/include/stdx/span.hpp
@@ -120,12 +120,12 @@ class span : public detail::span_base<T, Extent> {
 
     template <typename R,
               std::enable_if_t<dependent_extent<R> != dynamic_extent, int> = 0>
-    explicit constexpr span(R &&r LIFETIMEBOUND)
+    explicit constexpr span(R &&r)
         : ptr{stdx::to_address(std::begin(std::forward<R>(r)))} {}
 
     template <typename R,
               std::enable_if_t<dependent_extent<R> == dynamic_extent, int> = 0>
-    explicit constexpr span(R &&r LIFETIMEBOUND)
+    explicit constexpr span(R &&r)
         : base_t{std::begin(std::forward<R>(r)), std::end(std::forward<R>(r))},
           ptr{stdx::to_address(std::begin(std::forward<R>(r)))} {}
 


### PR DESCRIPTION
When a span is constructed from a range, it's not necessarily lifetimebound to that range. That range might be another view type, in which case it's OK for the span to outlive it - as long as the span doesn't outlive the underlying data.