### PR TITLE
:sparkles: Add `byterator`

### DIFF
--- a/include/stdx/bit.hpp
+++ b/include/stdx/bit.hpp
@@ -32,7 +32,7 @@ using endian = std::endian;
 
 #if __cpp_lib_bit_cast < 201806L
 template <typename To, typename From>
-[[nodiscard]] constexpr auto bit_cast(From &from) noexcept -> To {
+[[nodiscard]] constexpr auto bit_cast(From &&from) noexcept -> To {
     return __builtin_bit_cast(To, from);
 }
 #else

--- a/include/stdx/byterator.hpp
+++ b/include/stdx/byterator.hpp
@@ -1,0 +1,212 @@
+#pragma once
+
+#include <stdx/bit.hpp>
+#include <stdx/memory.hpp>
+#include <stdx/utility.hpp>
+
+#include <cstddef>
+#include <cstring>
+#include <functional>
+#include <iterator>
+#include <type_traits>
+
+namespace stdx {
+inline namespace v1 {
+
+namespace detail {
+template <typename It>
+constexpr auto is_byteratorish_v =
+    std::is_base_of_v<std::random_access_iterator_tag,
+                      typename std::iterator_traits<It>::iterator_category> and
+    std::is_trivially_copyable_v<typename std::iterator_traits<It>::value_type>;
+
+template <typename It>
+constexpr auto iterator_value_type()
+    -> decltype(*std::declval<typename std::iterator_traits<It>::pointer>());
+
+template <typename It>
+using iterator_value_t = decltype(iterator_value_type<It>());
+} // namespace detail
+
+template <typename T> class byterator {
+    using byte_t = std::remove_reference_t<forward_like_t<T, std::byte>>;
+    byte_t *ptr;
+
+    [[nodiscard]] constexpr friend auto operator==(byterator const &x,
+                                                   byterator const &y) -> bool {
+        return x.ptr == y.ptr;
+    }
+
+    template <typename It,
+              std::enable_if_t<std::is_same_v<detail::iterator_value_t<It>, T>,
+                               int> = 0>
+    [[nodiscard]] constexpr friend auto operator==(byterator const &x,
+                                                   It y) -> bool {
+        return static_cast<void const *>(x.ptr) ==
+               static_cast<void const *>(stdx::to_address(y));
+    }
+
+#if __cpp_impl_three_way_comparison >= 201907L
+    [[nodiscard]] constexpr friend auto operator<=>(byterator const &x,
+                                                    byterator const &y) {
+        return x.ptr <=> y.ptr;
+    }
+#else
+    [[nodiscard]] constexpr friend auto operator!=(byterator const &x,
+                                                   byterator const &y) -> bool {
+        return not(x == y);
+    }
+
+    template <typename It>
+    [[nodiscard]] constexpr friend auto operator==(It y,
+                                                   byterator const &x) -> bool {
+        return x == y;
+    }
+    template <typename It>
+    [[nodiscard]] constexpr friend auto operator!=(byterator const &x,
+                                                   It y) -> bool {
+        return not(x == y);
+    }
+    template <typename It>
+    [[nodiscard]] constexpr friend auto operator!=(It y,
+                                                   byterator const &x) -> bool {
+        return not(x == y);
+    }
+
+    [[nodiscard]] constexpr friend auto operator<(byterator const &x,
+                                                  byterator const &y) -> bool {
+        return std::less{}(x.ptr, y.ptr);
+    }
+    [[nodiscard]] constexpr friend auto operator<=(byterator const &x,
+                                                   byterator const &y) -> bool {
+        return std::less_equal{}(x.ptr, y.ptr);
+    }
+    [[nodiscard]] constexpr friend auto operator>(byterator const &x,
+                                                  byterator const &y) -> bool {
+        return std::greater{}(x.ptr, y.ptr);
+    }
+    [[nodiscard]] constexpr friend auto operator>=(byterator const &x,
+                                                   byterator const &y) -> bool {
+        return std::greater_equal{}(x.ptr, y.ptr);
+    }
+#endif
+
+  public:
+    using difference_type = std::ptrdiff_t;
+    using value_type = std::byte;
+    using pointer = value_type *;
+    using reference = value_type &;
+    using iterator_category = std::random_access_iterator_tag;
+
+    template <typename It,
+              std::enable_if_t<detail::is_byteratorish_v<It>, int> = 0>
+    explicit byterator(It it) : ptr(bit_cast<byte_t *>(stdx::to_address(it))) {}
+
+    [[nodiscard]] constexpr auto operator->() const -> byte_t * { return ptr; }
+    [[nodiscard]] constexpr auto operator*() const -> byte_t & { return *ptr; }
+
+    constexpr auto operator++() -> byterator & {
+        ++ptr;
+        return *this;
+    }
+    [[nodiscard]] constexpr auto operator++(int) -> byterator {
+        auto tmp = *this;
+        ++(*this);
+        return tmp;
+    }
+    constexpr auto operator--() -> byterator & {
+        --ptr;
+        return *this;
+    }
+    [[nodiscard]] constexpr auto operator--(int) -> byterator {
+        auto tmp = *this;
+        --(*this);
+        return tmp;
+    }
+
+    constexpr auto operator+=(difference_type d) -> byterator & {
+        ptr += d;
+        return *this;
+    }
+    constexpr auto operator-=(difference_type d) -> byterator & {
+        ptr -= d;
+        return *this;
+    }
+
+    [[nodiscard]] friend constexpr auto
+    operator+(byterator i, difference_type d) -> byterator {
+        i += d;
+        return i;
+    }
+    [[nodiscard]] friend constexpr auto operator+(difference_type d,
+                                                  byterator i) -> byterator {
+        i += d;
+        return i;
+    }
+    [[nodiscard]] friend constexpr auto
+    operator-(byterator i, difference_type d) -> byterator {
+        i -= d;
+        return i;
+    }
+    [[nodiscard]] friend constexpr auto
+    operator-(byterator x, byterator y) -> difference_type {
+        return x.ptr - y.ptr;
+    }
+
+    [[nodiscard]] constexpr auto operator[](difference_type n) -> byte_t & {
+        return ptr[n];
+    }
+    [[nodiscard]] constexpr auto
+    operator[](difference_type n) const -> byte_t const & {
+        return ptr[n];
+    }
+
+    template <typename V = std::uint8_t, typename R = V,
+              std::enable_if_t<std::is_trivially_copyable_v<V>, int> = 0>
+    [[nodiscard]] auto peek() -> R {
+        V v;
+        std::memcpy(std::addressof(v), ptr, sizeof(V));
+        return static_cast<R>(v);
+    }
+
+    template <typename V = std::uint8_t, typename R = V,
+              std::enable_if_t<std::is_trivially_copyable_v<V>, int> = 0>
+    [[nodiscard]] auto read() -> R {
+        R ret = peek<V, R>();
+        ptr += sizeof(V);
+        return ret;
+    }
+
+    template <typename V,
+              std::enable_if_t<std::is_trivially_copyable_v<remove_cvref_t<V>>,
+                               int> = 0>
+    auto write(V &&v) -> void {
+        using R = remove_cvref_t<V>;
+        std::memcpy(ptr, std::addressof(v), sizeof(R));
+        ptr += sizeof(R);
+    }
+
+    [[nodiscard]] auto peeku8() { return peek<std::uint8_t>(); }
+    [[nodiscard]] auto readu8() { return read<std::uint8_t>(); }
+    template <typename V> [[nodiscard]] auto writeu8(V &&v) {
+        return write(static_cast<std::uint8_t>(std::forward<V>(v)));
+    }
+
+    [[nodiscard]] auto peeku16() { return peek<std::uint16_t>(); }
+    [[nodiscard]] auto readu16() { return read<std::uint16_t>(); }
+    template <typename V> [[nodiscard]] auto writeu16(V &&v) {
+        return write(static_cast<std::uint16_t>(std::forward<V>(v)));
+    }
+
+    [[nodiscard]] auto peeku32() { return peek<std::uint32_t>(); }
+    [[nodiscard]] auto readu32() { return read<std::uint32_t>(); }
+    template <typename V> [[nodiscard]] auto writeu32(V &&v) {
+        return write(static_cast<std::uint32_t>(std::forward<V>(v)));
+    }
+};
+
+template <typename It, std::enable_if_t<detail::is_byteratorish_v<It>, int> = 0>
+byterator(It) -> byterator<detail::iterator_value_t<It>>;
+
+} // namespace v1
+} // namespace stdx

--- a/include/stdx/memory.hpp
+++ b/include/stdx/memory.hpp
@@ -26,7 +26,7 @@ template <typename T> constexpr auto to_address(T const &t) {
     if constexpr (detail::detect::pointer_traits_to_address<T>) {
         return std::pointer_traits<T>::to_address(t);
     } else {
-        return to_address(t.operator->());
+        return stdx::to_address(t.operator->());
     }
 }
 } // namespace v1

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,6 +17,7 @@ add_tests(
     bind
     bit
     bitset
+    byterator
     cached
     callable
     concepts

--- a/test/byterator.cpp
+++ b/test/byterator.cpp
@@ -1,0 +1,260 @@
+#include <stdx/byterator.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <array>
+#include <iterator>
+
+TEST_CASE("constructible from an iterator", "[byterator]") {
+    auto const a = std::array{1, 2, 3, 4};
+    auto const b = stdx::byterator{std::begin(a)};
+    CHECK(static_cast<void const *>(stdx::to_address(std::begin(a))) ==
+          static_cast<void const *>(stdx::to_address(b)));
+}
+
+TEST_CASE("equality comparable to iterator", "[byterator]") {
+    auto const a = std::array{1, 2, 3, 4};
+    auto const b = stdx::byterator{std::begin(a)};
+    CHECK((b == std::begin(a)));
+    CHECK((std::begin(a) == b));
+    CHECK((b != std::end(a)));
+    CHECK((std::end(a) != b));
+}
+
+TEST_CASE("copy constructible", "[byterator]") {
+    auto const a = std::array{stdx::to_be<std::uint16_t>(0x0102),
+                              stdx::to_be<std::uint16_t>(0x0304)};
+    auto const b = stdx::byterator{std::begin(a)};
+    auto i = b;
+    CHECK((i == b));
+}
+
+TEST_CASE("increment and decrement", "[byterator]") {
+    auto const a = std::array{stdx::to_be<std::uint16_t>(0x0102),
+                              stdx::to_be<std::uint16_t>(0x0304)};
+    auto const b = stdx::byterator{std::begin(a)};
+    auto i = b;
+    CHECK((++i != b));
+    CHECK((--i == b));
+    auto j = i++;
+    CHECK((j == b));
+    auto k = i--;
+    CHECK((i == j));
+    CHECK((k != j));
+}
+
+TEST_CASE("random access arithmetic", "[byterator]") {
+    auto const a = std::array{stdx::to_be<std::uint16_t>(0x0102),
+                              stdx::to_be<std::uint16_t>(0x0304)};
+    auto const b = stdx::byterator{std::begin(a)};
+    auto i = b;
+    CHECK((i + 1 != b));
+    i += 1;
+    CHECK((i == b + 1));
+    CHECK(i - b == 1);
+    CHECK((i - 1 == b));
+    i -= 1;
+    CHECK((i == b));
+}
+
+TEST_CASE("equality comparable", "[byterator]") {
+    auto const a = std::array{1, 2, 3, 4};
+    auto x = stdx::byterator{std::begin(a)};
+    static_assert(stdx::equality_comparable<decltype(x)>);
+    auto y = x;
+    CHECK(x == y);
+    ++y;
+    CHECK(x != y);
+}
+
+TEST_CASE("totally ordered", "[byterator]") {
+    auto const a = std::array{1, 2, 3, 4};
+    auto x = stdx::byterator{std::begin(a)};
+    static_assert(stdx::totally_ordered<decltype(x)>);
+    auto y = std::next(x);
+    CHECK(x < y);
+    CHECK(x <= y);
+    CHECK(y > x);
+    CHECK(y >= x);
+}
+
+TEST_CASE("dereference to byte const& (read)", "[byterator]") {
+    auto const a = std::array{stdx::to_be<std::uint16_t>(0x0102),
+                              stdx::to_be<std::uint16_t>(0x0304)};
+    auto i = stdx::byterator{std::begin(a)};
+    CHECK(*i++ == std::byte{1});
+    CHECK(*i++ == std::byte{2});
+    CHECK(*i++ == std::byte{3});
+    CHECK(*i++ == std::byte{4});
+    CHECK((i == std::end(a)));
+}
+
+TEST_CASE("dereference to byte & (write)", "[byterator]") {
+    auto a = std::array{stdx::to_be<std::uint16_t>(0x0102),
+                        stdx::to_be<std::uint16_t>(0x0304)};
+    auto i = stdx::byterator{std::begin(a)};
+    *i = std::byte{3};
+    CHECK(a[0] == stdx::to_be<std::uint16_t>(0x0302));
+}
+
+TEST_CASE("random access indexing (read)", "[byterator]") {
+    auto const a = std::array{stdx::to_be<std::uint16_t>(0x0102),
+                              stdx::to_be<std::uint16_t>(0x0304)};
+    auto const b = stdx::byterator{std::begin(a)};
+    auto i = b;
+    CHECK(i[2] == std::byte{3});
+}
+
+TEST_CASE("random access indexing (write)", "[byterator]") {
+    auto a = std::array{stdx::to_be<std::uint16_t>(0x0102),
+                        stdx::to_be<std::uint16_t>(0x0304)};
+    auto b = stdx::byterator{std::begin(a)};
+    b[2] = std::byte{5};
+    CHECK(a[1] == stdx::to_be<std::uint16_t>(0x0504));
+}
+
+TEST_CASE("peek uint8_t", "[byterator]") {
+    auto const a = std::array{stdx::to_be<std::uint16_t>(0x0102),
+                              stdx::to_be<std::uint16_t>(0x0304)};
+    auto i = stdx::byterator{std::begin(a)};
+    static_assert(std::is_same_v<decltype(i.readu8()), std::uint8_t>);
+    CHECK(i.peeku8() == 1);
+    CHECK((i == std::begin(a)));
+}
+
+TEST_CASE("read uint8_t", "[byterator]") {
+    auto const a = std::array{stdx::to_be<std::uint16_t>(0x0102),
+                              stdx::to_be<std::uint16_t>(0x0304)};
+    auto i = stdx::byterator{std::begin(a)};
+    auto j = std::next(i);
+    static_assert(std::is_same_v<decltype(i.readu8()), std::uint8_t>);
+    CHECK(i.readu8() == 1);
+    CHECK((i == j));
+}
+
+TEST_CASE("write uint8_t", "[byterator]") {
+    auto a = std::array{stdx::to_be<std::uint16_t>(0x0102),
+                        stdx::to_be<std::uint16_t>(0x0304)};
+    auto i = stdx::byterator{std::begin(a)};
+    auto j = std::next(i);
+    i.writeu8(3);
+    CHECK(a[0] == stdx::to_be<std::uint16_t>(0x0302));
+    CHECK((i == j));
+}
+
+TEST_CASE("peek uint16_t", "[byterator]") {
+    auto const a = std::array{stdx::to_be<std::uint16_t>(0x0102),
+                              stdx::to_be<std::uint16_t>(0x0304)};
+    auto i = stdx::byterator{std::begin(a)};
+    static_assert(std::is_same_v<decltype(i.readu16()), std::uint16_t>);
+    CHECK(i.peeku16() == stdx::to_be<std::uint16_t>(0x0102));
+    CHECK((i == std::begin(a)));
+}
+
+TEST_CASE("read uint16_t", "[byterator]") {
+    auto const a = std::array{stdx::to_be<std::uint16_t>(0x0102),
+                              stdx::to_be<std::uint16_t>(0x0304)};
+    auto i = stdx::byterator{std::begin(a)};
+    auto j = i + 2;
+    static_assert(std::is_same_v<decltype(i.readu16()), std::uint16_t>);
+    CHECK(i.readu16() == stdx::to_be<std::uint16_t>(0x0102));
+    CHECK((i == j));
+}
+
+TEST_CASE("write uint16_t", "[byterator]") {
+    auto a = std::array{stdx::to_be<std::uint16_t>(0x0102),
+                        stdx::to_be<std::uint16_t>(0x0304)};
+    auto i = stdx::byterator{std::begin(a)};
+    auto j = i + 2;
+    i.writeu16(3);
+    CHECK(a[0] == 3);
+    CHECK((i == j));
+}
+
+TEST_CASE("peek uint32_t", "[byterator]") {
+    auto const a = std::array{stdx::to_be<std::uint16_t>(0x0102),
+                              stdx::to_be<std::uint16_t>(0x0304)};
+    auto i = stdx::byterator{std::begin(a)};
+    static_assert(std::is_same_v<decltype(i.readu32()), std::uint32_t>);
+    CHECK(i.peeku32() == stdx::to_be<std::uint32_t>(0x01020304));
+    CHECK((i == std::begin(a)));
+}
+
+TEST_CASE("read uint32_t", "[byterator]") {
+    auto const a = std::array{stdx::to_be<std::uint16_t>(0x0102),
+                              stdx::to_be<std::uint16_t>(0x0304)};
+    auto i = stdx::byterator{std::begin(a)};
+    static_assert(std::is_same_v<decltype(i.readu32()), std::uint32_t>);
+    CHECK(i.readu32() == stdx::to_be<std::uint32_t>(0x01020304));
+    CHECK((i == std::end(a)));
+}
+
+TEST_CASE("write uint32_t", "[byterator]") {
+    auto a = std::array{stdx::to_be<std::uint16_t>(0x0102),
+                        stdx::to_be<std::uint16_t>(0x0304)};
+    auto i = stdx::byterator{std::begin(a)};
+    i.writeu32(stdx::to_be<std::uint32_t>(0x05060708));
+    CHECK(a[0] == stdx::to_be<std::uint16_t>(0x0506));
+    CHECK(a[1] == stdx::to_be<std::uint16_t>(0x0708));
+    CHECK((i == std::end(a)));
+}
+
+namespace {
+enum struct E : std::uint8_t { A = 1, B = 2, C = 3 };
+}
+
+TEST_CASE("peek enum", "[byterator]") {
+    auto const a = std::array{stdx::to_be<std::uint16_t>(0x0102),
+                              stdx::to_be<std::uint16_t>(0x0304)};
+    auto i = stdx::byterator{std::begin(a)};
+    static_assert(std::is_same_v<decltype(i.readu32()), std::uint32_t>);
+    CHECK(i.peek<E>() == E::A);
+}
+
+TEST_CASE("read enum", "[byterator]") {
+    auto const a = std::array{stdx::to_be<std::uint16_t>(0x0102),
+                              stdx::to_be<std::uint16_t>(0x0304)};
+    auto i = stdx::byterator{std::begin(a)};
+    static_assert(std::is_same_v<decltype(i.readu32()), std::uint32_t>);
+    CHECK(i.read<E>() == E::A);
+}
+
+TEST_CASE("write enum", "[byterator]") {
+    auto a = std::array{stdx::to_be<std::uint16_t>(0x0102),
+                        stdx::to_be<std::uint16_t>(0x0304)};
+    auto i = stdx::byterator{std::begin(a)};
+    i.write(E::C);
+    CHECK(a[0] == stdx::to_be<std::uint16_t>(0x0302));
+}
+
+namespace {
+enum struct E2 : std::uint32_t { A = 1, B = 2, C = 3 };
+}
+
+TEST_CASE("peek enum (constrained size)", "[byterator]") {
+    auto const a = std::array{stdx::to_be<std::uint16_t>(0x0102),
+                              stdx::to_be<std::uint16_t>(0x0304)};
+    auto i = stdx::byterator{std::begin(a)};
+    static_assert(std::is_same_v<decltype(i.readu32()), std::uint32_t>);
+    CHECK(i.peek<std::uint8_t, E2>() == E2::A);
+}
+
+TEST_CASE("read enum (constrained size)", "[byterator]") {
+    auto const a = std::array{stdx::to_be<std::uint16_t>(0x0102),
+                              stdx::to_be<std::uint16_t>(0x0304)};
+    auto i = stdx::byterator{std::begin(a)};
+    auto j = std::next(i);
+    static_assert(std::is_same_v<decltype(i.readu32()), std::uint32_t>);
+    CHECK(i.read<std::uint8_t, E2>() == E2::A);
+    CHECK((i == j));
+}
+
+TEST_CASE("write enum (constrained size)", "[byterator]") {
+    auto a = std::array{stdx::to_be<std::uint16_t>(0x0102),
+                        stdx::to_be<std::uint16_t>(0x0304)};
+    auto i = stdx::byterator{std::begin(a)};
+    auto j = std::next(i);
+    i.writeu8(E::C);
+    CHECK(a[0] == stdx::to_be<std::uint16_t>(0x0302));
+    CHECK((i == j));
+}


### PR DESCRIPTION
Problem:
- It is a common case to have a table of &lt;unsigned words&gt; from which we want to read &lt;arbitrary-size unsigned quantity&gt; as we interpret the table. For example, an array of std::uint32_t where we read some things as 16-bit, some things as 8-bit, etc.

Solution:
- Add `byterator` - an iterator-like type that allows extra read/write operations. It behaves like a random access iterator (to `std::byte`) but also has operations to peek, read and write arbitrary trivially-copyable types.