### PR TITLE
:zap: Improve compile time for a common transform use case

### DIFF
--- a/include/stdx/tuple.hpp
+++ b/include/stdx/tuple.hpp
@@ -504,11 +504,18 @@ constexpr auto apply(Op &&op, T &&t) -> decltype(auto) {
     return std::forward<T>(t).apply(std::forward<Op>(op));
 }
 
-template <typename Op, tuplelike T> constexpr auto transform(Op &&op, T &&t) {
-    return std::forward<T>(t).apply([&]<typename... Ts>(Ts &&...ts) {
-        return stdx::tuple<decltype(op(std::forward<Ts>(ts)))...>{
-            op(std::forward<Ts>(ts))...};
-    });
+template <template <typename> typename... Fs, typename Op, tuplelike T>
+constexpr auto transform(Op &&op, T &&t) {
+    if constexpr (sizeof...(Fs) == 0) {
+        return std::forward<T>(t).apply([&]<typename... Ts>(Ts &&...ts) {
+            return stdx::tuple<decltype(op(std::forward<Ts>(ts)))...>{
+                op(std::forward<Ts>(ts))...};
+        });
+    } else {
+        return std::forward<T>(t).apply([&]<typename... Ts>(Ts &&...ts) {
+            return stdx::make_indexed_tuple<Fs...>(op(std::forward<Ts>(ts))...);
+        });
+    }
 }
 
 template <typename Op, tuplelike T>


### PR DESCRIPTION
`cib` uses transform on a single tuple adding an index. The single-arg transform overload did not allow indexing, so this was using the slower-to-compile more general form of transform.

This change saves ~30% of the transform time for the cib benchmark.