### PR TITLE
:art: Don't use nonstandard UDL extension

### DIFF
--- a/include/stdx/ct_string.hpp
+++ b/include/stdx/ct_string.hpp
@@ -116,9 +116,7 @@ operator+(ct_string<N> const &lhs,
 
 inline namespace literals {
 inline namespace ct_string_literals {
-template <typename T, T... Cs> CONSTEVAL auto operator""_cts() {
-    return ct_string<sizeof...(Cs) + 1U>{{Cs..., 0}};
-}
+template <ct_string S> CONSTEVAL auto operator""_cts() { return S; }
 } // namespace ct_string_literals
 } // namespace literals
 


### PR DESCRIPTION
GCC and clang allow a user-defined literal operator template with the signature:
```cpp
template <typename T, T...> auto operator""_udl();
```

This is a non-standard extension and for our purposes at least it is replaced in C++20 by using an operator template with a structural NTTP:
```cpp
template <ct_string S> auto operator""_udl();
```