### PR TITLE
:sparkles: Add `cts_t`, `shrink_t` and `expand_t`

### DIFF
--- a/include/stdx/ct_string.hpp
+++ b/include/stdx/ct_string.hpp
@@ -58,6 +58,10 @@ template <std::size_t N> struct ct_string {
     std::array<char, N> value{};
 };
 
+template <stdx::ct_string S> struct cts_t {
+    constexpr static auto value = S;
+};
+
 template <std::size_t N, std::size_t M>
 [[nodiscard]] constexpr auto operator==(ct_string<N> const &lhs,
                                         ct_string<M> const &rhs) -> bool {

--- a/include/stdx/type_traits.hpp
+++ b/include/stdx/type_traits.hpp
@@ -216,5 +216,12 @@ constexpr bool is_structural_v = detail::detect_structural<T>;
 template <typename T, typename = void> constexpr auto is_cx_value_v = false;
 template <typename T>
 constexpr auto is_cx_value_v<T, std::void_t<typename T::cx_value_t>> = true;
+
+#if __cplusplus >= 202002L
+template <typename T>
+using shrink_t = decltype([]() -> T (*)() { return nullptr; });
+
+template <typename T> using expand_t = decltype(T{}()());
+#endif
 } // namespace v1
 } // namespace stdx

--- a/test/ct_string.cpp
+++ b/test/ct_string.cpp
@@ -130,3 +130,9 @@ TEST_CASE("template argument as CX_VALUE", "[ct_string]") {
     constexpr auto s = to_cx_value<"Hello">();
     static_assert(s() == "Hello"_cts);
 }
+
+TEST_CASE("wrap ct_string in type", "[ct_string]") {
+    using namespace stdx::ct_string_literals;
+    using S = stdx::cts_t<"Hello">;
+    static_assert(S::value == "Hello"_cts);
+}

--- a/test/type_traits.cpp
+++ b/test/type_traits.cpp
@@ -1,3 +1,4 @@
+#include <stdx/ct_conversions.hpp>
 #include <stdx/type_traits.hpp>
 
 #include <catch2/catch_test_macros.hpp>
@@ -237,3 +238,19 @@ struct S {
 TEST_CASE("non-structural types", "[type_traits]") {
     static_assert(not stdx::is_structural_v<non_structural::S>);
 }
+
+#if __cplusplus >= 202002L
+namespace {
+template <typename...> struct long_type_name {};
+} // namespace
+
+TEST_CASE("type shrinkage", "[type_traits]") {
+    using A = long_type_name<int, int, int, int, int, int, int, int>;
+    using B = long_type_name<A, A, A, A, A, A, A, A>;
+    using C = long_type_name<B, B, B, B, B, B, B, B>;
+    using X = stdx::shrink_t<C>;
+    static_assert(stdx::type_as_string<X>().size() <
+                  stdx::type_as_string<C>().size());
+    static_assert(std::same_as<stdx::expand_t<X>, C>);
+}
+#endif


### PR DESCRIPTION
- `cts_t` packages a `ct_string` inside a type.
- `shrink_t` and `expand_t` are for relieving some compilation woes in handling long type names.