### PR TITLE
:sparkles: Add compile-time diagnostic `ct_check`

### DIFF
--- a/docs/ct_conversions.adoc
+++ b/docs/ct_conversions.adoc
@@ -1,4 +1,39 @@
 
+== `ct_check.hpp`
+
+`ct_check` is a construct that can be used to emit user-generated
+compile-time diagnostics. It uses `ct_string`.
+
+For example:
+[source,cpp]
+----
+stdx::ct_check<std::is_integral<float>>.emit<"This is not a very helpful error message">();
+----
+
+The output from this (which varies by compiler) will contain the string given,
+and could be something like:
+[source,bash]
+----
+main.cpp:14:27: error: no matching member function for call to 'emit'
+   14 |     stdx::ct_check<false>.emit<"This is not a very helpful error message">();
+      |     ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+include/stdx/ct_string.hpp:131:27: note: candidate template ignored: constraints not satisfied
+[with S = ct_string<41>{{"This is not a very helpful error m[...]"}}]
+  131 |     constexpr static auto emit()
+      |                           ^
+include/stdx/ct_string.hpp:132:18: note: because
+'diagnostic<ct_string<41>{{"This is not a very helpful error message"}}>' evaluated to false
+  132 |         requires diagnostic<S>
+      |                  ^
+----
+
+Notice that the error message is elided at first, but then given in full. Such
+are the quirks of compilers. If the compile-time condition is true, of course no
+diagnostic will be emitted.
+
+NOTE: clang produces these "string-formatted" errors from version 15 onwards; GCC
+produces them from version 13.2 onwards.
+
 == `ct_conversions.hpp`
 
 https://github.com/intel/cpp-std-extensions/blob/main/include/stdx/ct_conversions.hpp[`ct_conversions.hpp`]

--- a/include/stdx/compiler.hpp
+++ b/include/stdx/compiler.hpp
@@ -43,3 +43,10 @@
 #define LIFETIMEBOUND
 #endif
 #endif
+
+#define STDX_DO_PRAGMA(X) _Pragma(#X)
+#ifdef __clang__
+#define STDX_PRAGMA(X) STDX_DO_PRAGMA(clang X)
+#else
+#define STDX_PRAGMA(X) STDX_DO_PRAGMA(GCC X)
+#endif

--- a/include/stdx/ct_string.hpp
+++ b/include/stdx/ct_string.hpp
@@ -124,6 +124,17 @@ template <ct_string S> CONSTEVAL auto operator""_cts() { return S; }
 } // namespace ct_string_literals
 } // namespace literals
 
+template <bool B> struct ct_check_t {
+    template <ct_string S> constexpr static bool diagnostic = false;
+    template <ct_string S>
+    constexpr static auto emit() -> void
+        requires diagnostic<S>;
+};
+template <> struct ct_check_t<true> {
+    template <ct_string S> constexpr static auto emit() -> void {}
+};
+template <bool B> constexpr auto ct_check = ct_check_t<B>{};
+
 } // namespace v1
 } // namespace stdx
 

--- a/include/stdx/utility.hpp
+++ b/include/stdx/utility.hpp
@@ -186,13 +186,6 @@ constexpr auto is_aligned_with = [](auto v) -> bool {
 #define FWD(x) std::forward<decltype(x)>(x)
 #endif
 
-#define STDX_DO_PRAGMA(X) _Pragma(#X)
-#ifdef __clang__
-#define STDX_PRAGMA(X) STDX_DO_PRAGMA(clang X)
-#else
-#define STDX_PRAGMA(X) STDX_DO_PRAGMA(GCC X)
-#endif
-
 #ifndef CX_VALUE
 #define CX_VALUE(...)                                                          \
     [] {                                                                       \

--- a/test/fail/CMakeLists.txt
+++ b/test/fail/CMakeLists.txt
@@ -25,6 +25,15 @@ add_fail_tests(
     to_address_undefined_on_function)
 
 if(${CMAKE_CXX_STANDARD} GREATER_EQUAL 20)
+    if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang"
+       AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL 15)
+        add_fail_tests(ct_check)
+    endif()
+    if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU" AND ${CMAKE_CXX_COMPILER_VERSION}
+                                                   VERSION_GREATER_EQUAL 13.2)
+        add_fail_tests(ct_check)
+    endif()
+
     add_fail_tests(
         dynamic_span_no_ct_capacity
         dynamic_container_no_ct_capacity

--- a/test/fail/ct_check.cpp
+++ b/test/fail/ct_check.cpp
@@ -1,0 +1,11 @@
+#include <stdx/ct_string.hpp>
+
+// EXPECT: 01234567890123456789012345678901234567890123456789
+
+constexpr auto msg =
+    stdx::ct_string{"01234567890123456789012345678901234567890123456789"};
+
+auto main() -> int {
+    stdx::ct_check<true>.emit<"not emitted">();
+    stdx::ct_check<false>.emit<msg>();
+}


### PR DESCRIPTION
Problem:
- There is no way to produce a user-formatted compile-time diagnostic.

Solution:
- Add `ct_check` to test a condition at compile-time and produce a `ct_string`
  message on failure.

Note:
- A constraint check is the key to prevent the compiler from eliding the string.