### PR TITLE
:sparkles: Allow using `bitset` with enum values

### DIFF
--- a/docs/bitset.adoc
+++ b/docs/bitset.adoc
@@ -15,6 +15,7 @@ platform.
 * Stream input and output operators are not implemented.
 * A `std::hash` specialization is not implemented.
 * `to_string`, `to_ulong` and `to_ullong` are not implemented
+* `operator[]` is read-only: it does not return a proxy reference type
 
 A bitset has two template parameters: the size of the bitset and the storage
 element type to use. The storage element type must be unsigned.
@@ -71,3 +72,17 @@ auto j = bs.to_natural();          // 5 (a std::uint16_t)
 
 Bitsets support all the usual bitwise operators (`and`, `or`, `xor` and `not`)
 and also support `operator-` meaning set difference, or `a & ~b`.
+
+A bitset can also be used with an enumeration that represents bits:
+[source,cpp]
+----
+enum struct Bits { ZERO, ONE, TWO, THREE, MAX };
+auto bs = stdx::bitset<Bits::MAX>{stdx::all_bits}; // 4 bits, value 0b1111
+bs.set(Bits::ZERO);
+bs.reset(Bits::ZERO);
+bs.flip(Bits::ZERO);
+auto bit_zero = bs[Bits::ZERO];
+----
+
+NOTE: The enumeration values are the bit positions, not the bits themselves (the
+enumeration values are not fixed to powers-of-2).

--- a/include/stdx/type_traits.hpp
+++ b/include/stdx/type_traits.hpp
@@ -13,6 +13,8 @@ template <typename E> constexpr auto to_underlying(E e) noexcept {
         return e;
     }
 }
+template <typename E>
+using underlying_type_t = decltype(to_underlying(std::declval<E>()));
 
 template <typename T> struct remove_cvref {
     using type = std::remove_cv_t<std::remove_reference_t<T>>;

--- a/test/bitset.cpp
+++ b/test/bitset.cpp
@@ -422,3 +422,35 @@ TEMPLATE_TEST_CASE("find lowest unset bit (full)", "[bitset]", std::uint8_t,
     constexpr auto bs = stdx::bitset<sz, TestType>{stdx::all_bits};
     static_assert(bs.lowest_unset() == sz);
 }
+
+namespace {
+enum struct Bits : std::uint8_t { ZERO, ONE, TWO, THREE, MAX };
+}
+
+TEST_CASE("use bitset with enum struct (construct)", "[bitset]") {
+    constexpr auto bs = stdx::bitset<Bits::MAX>{};
+    static_assert(bs.size() == stdx::to_underlying(Bits::MAX));
+}
+
+TEST_CASE("use bitset with enum struct (to)", "[bitset]") {
+    constexpr auto bs = stdx::bitset<Bits::MAX>{stdx::all_bits};
+    static_assert(bs.to<Bits>() == static_cast<Bits>(0b1111));
+}
+
+TEST_CASE("use bitset with enum struct (set/flip)", "[bitset]") {
+    auto bs = stdx::bitset<Bits::MAX>{};
+    bs.set(Bits::ZERO);
+    CHECK(bs.to_natural() == 1);
+    bs.reset(Bits::ZERO);
+    CHECK(bs.to_natural() == 0);
+    bs.flip(Bits::ZERO);
+    CHECK(bs.to_natural() == 1);
+}
+
+TEST_CASE("use bitset with enum struct (read index)", "[bitset]") {
+    constexpr auto bs = stdx::bitset<Bits::MAX>{stdx::all_bits};
+    static_assert(bs[Bits::ZERO]);
+    static_assert(bs[Bits::ONE]);
+    static_assert(bs[Bits::TWO]);
+    static_assert(bs[Bits::THREE]);
+}


### PR DESCRIPTION
Problem:
- A `bitset` cannot be specified with enumeration values, nor have bits set/reset using them.

Solution:
- Allow specifying and manipulating a bitset using enumeration values as the bits.