### PR TITLE
:construction_worker: Add mutation tests

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -15,6 +15,7 @@ env:
   DEFAULT_CXX_STANDARD: 20
   DEFAULT_LLVM_VERSION: 18
   DEFAULT_GCC_VERSION: 13
+  MULL_LLVM_VERSION: 15
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -347,6 +348,52 @@ jobs:
 
           echo "</details>" >> $GITHUB_STEP_SUMMARY
           test $FAILSIZE = "0"
+
+  mutate:
+    runs-on: ${{ github.repository_owner == 'intel' && 'intel-' || '' }}ubuntu-22.04
+    steps:
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+
+      - name: Install build tools
+        run: |
+          wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh ${{env.MULL_LLVM_VERSION}}
+          sudo apt install -y ninja-build
+
+      - name: Install mull
+        env:
+          MULL_VERSION: 0.23.0
+        run: |
+          wget https://github.com/mull-project/mull/releases/download/${{env.MULL_VERSION}}/Mull-${{env.MULL_LLVM_VERSION}}-${{env.MULL_VERSION}}-LLVM-${{env.MULL_LLVM_VERSION}}.0-ubuntu-22.04.deb
+          sudo dpkg -i Mull-${{env.MULL_LLVM_VERSION}}-${{env.MULL_VERSION}}-LLVM-${{env.MULL_LLVM_VERSION}}.0-ubuntu-22.04.deb
+
+      - name: Restore CPM cache
+        env:
+          cache-name: cpm-cache-0
+        id: cpm-cache-restore
+        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        with:
+          path: ~/cpm-cache
+          key: ${{runner.os}}-${{env.cache-name}}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+          restore-keys: |
+            ${{runner.os}}-${{env.cache-name}}-
+
+      - name: Configure CMake
+        env:
+          CC: "/usr/lib/llvm-${{env.MULL_LLVM_VERSION}}/bin/clang"
+          CXX: "/usr/lib/llvm-${{env.MULL_LLVM_VERSION}}/bin/clang++"
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_CXX_STANDARD=${{env.DEFAULT_CXX_STANDARD}} -DCPM_SOURCE_CACHE=~/cpm-cache
+
+      - name: Save CPM cache
+        env:
+          cache-name: cpm-cache-0
+        if: steps.cpm-cache-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        with:
+          path: ~/cpm-cache
+          key: ${{runner.os}}-${{env.cache-name}}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+
+      - name: Build and run mull tests
+        run: cmake --build build -t mull_tests
 
   merge_ok:
     runs-on: ${{ github.repository_owner == 'intel' && 'intel-' || '' }}ubuntu-22.04

--- a/mull.yml
+++ b/mull.yml
@@ -1,0 +1,7 @@
+mutators:
+  - cxx_all
+ignoreMutators:
+  - cxx_remove_void_call
+excludePaths:
+  - .*/include/stdx/.*
+timeout: 10000

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,8 @@
 function(add_tests)
-    foreach(name ${ARGN})
+    set(multiValueArgs FILES MULL_EXCLUSIONS)
+    cmake_parse_arguments(TEST "" "" "${multiValueArgs}" ${ARGN})
+
+    foreach(name ${TEST_FILES})
         add_unit_test(
             "${name}_test"
             CATCH2
@@ -8,10 +11,14 @@ function(add_tests)
             LIBRARIES
             warnings
             stdx)
+        if(NOT name IN_LIST TEST_MULL_EXCLUSIONS)
+            add_mull_test("${name}_test" EXCLUDE_CTEST)
+        endif()
     endforeach()
 endfunction()
 
 add_tests(
+    FILES
     algorithm
     always_false
     bind
@@ -53,7 +60,7 @@ add_tests(
     udls)
 
 if(${CMAKE_CXX_STANDARD} GREATER_EQUAL 20)
-    add_tests(ct_format ct_string indexed_tuple tuple tuple_algorithms)
+    add_tests(FILES ct_format ct_string indexed_tuple tuple tuple_algorithms)
 endif()
 
 add_subdirectory(fail)

--- a/test/ct_format.cpp
+++ b/test/ct_format.cpp
@@ -67,20 +67,20 @@ TEST_CASE("format a compile-time enum argument", "[ct_format]") {
 }
 
 TEST_CASE("format a runtime argument", "[ct_format]") {
-    auto x = 42;
+    auto x = 17;
     CHECK(stdx::ct_format<"Hello {}">(x) ==
-          stdx::format_result{"Hello {}"_cts, stdx::make_tuple(42)});
-    static_assert(stdx::ct_format<"Hello {}">(42) ==
-                  stdx::format_result{"Hello {}"_cts, stdx::make_tuple(42)});
+          stdx::format_result{"Hello {}"_cts, stdx::make_tuple(17)});
+    static_assert(stdx::ct_format<"Hello {}">(17) ==
+                  stdx::format_result{"Hello {}"_cts, stdx::make_tuple(17)});
 }
 
 TEST_CASE("format a compile-time and a runtime argument (1)", "[ct_format]") {
-    auto x = 42;
+    auto x = 17;
     CHECK(stdx::ct_format<"Hello {} {}">(CX_VALUE(int), x) ==
-          stdx::format_result{"Hello int {}"_cts, stdx::make_tuple(42)});
+          stdx::format_result{"Hello int {}"_cts, stdx::make_tuple(17)});
     static_assert(
-        stdx::ct_format<"Hello {} {}">(CX_VALUE(int), 42) ==
-        stdx::format_result{"Hello int {}"_cts, stdx::make_tuple(42)});
+        stdx::ct_format<"Hello {} {}">(CX_VALUE(int), 17) ==
+        stdx::format_result{"Hello int {}"_cts, stdx::make_tuple(17)});
 }
 
 TEST_CASE("format a compile-time and a runtime argument (2)", "[ct_format]") {
@@ -141,13 +141,13 @@ TEST_CASE("format_to a different type", "[ct_format]") {
     static_assert(stdx::ct_format<"{}", string_constant>(CX_VALUE("A"sv)) ==
                   string_constant<char, 'A'>{});
 
-    auto x = 42;
+    auto x = 17;
     CHECK(stdx::ct_format<"{}", string_constant>(x) ==
           stdx::format_result{string_constant<char, '{', '}'>{},
-                              stdx::make_tuple(42)});
-    static_assert(stdx::ct_format<"{}", string_constant>(42) ==
+                              stdx::make_tuple(17)});
+    static_assert(stdx::ct_format<"{}", string_constant>(17) ==
                   stdx::format_result{string_constant<char, '{', '}'>{},
-                                      stdx::make_tuple(42)});
+                                      stdx::make_tuple(17)});
 }
 
 TEST_CASE("format a string-type argument", "[ct_format]") {

--- a/test/cx_map.cpp
+++ b/test/cx_map.cpp
@@ -44,8 +44,10 @@ TEST_CASE("const get", "[cx_map]") {
 TEST_CASE("update existing key", "[cx_map]") {
     auto t = stdx::cx_map<int, int, 64>{};
     t.put(13, 500);
-    t.put(13, 700);
+    REQUIRE(t.contains(13));
+    CHECK(t.get(13) == 500);
 
+    t.put(13, 700);
     REQUIRE(t.contains(13));
     CHECK(t.get(13) == 700);
 }

--- a/test/cx_multimap.cpp
+++ b/test/cx_multimap.cpp
@@ -50,13 +50,25 @@ TEST_CASE("erase values", "[cx_multimap]") {
 
     t.put(60, 1);
     t.put(60, 2);
-    t.put(60, 3);
+    t.put(61, 3);
+    t.put(62, 4);
+    CHECK(t.size() == 3);
 
-    t.erase(60, 2);
-    CHECK(t.size() == 1);
+    CHECK(t.erase(60, 1));
+    CHECK(t.size() == 3);
+    CHECK(not t.contains(60, 1));
+    CHECK(t.contains(60, 2));
+
+    CHECK(t.erase(60, 2));
+    CHECK(t.size() == 2);
     CHECK(not t.contains(60, 2));
+    CHECK(t.contains(61, 3));
+    CHECK(t.contains(62, 4));
 
-    t.erase(60);
+    t.erase(61);
+    CHECK(t.size() == 1);
+    CHECK(t.contains(62, 4));
+    t.erase(62);
     CHECK(t.empty());
 }
 

--- a/test/cx_set.cpp
+++ b/test/cx_set.cpp
@@ -45,8 +45,8 @@ TEST_CASE("insert multiple", "[cx_set]") {
     stdx::cx_set<int, 64> t;
 
     t.insert(10);
-    t.insert(10);
-
+    CHECK(t.size() == 1);
+    CHECK(not t.insert(10));
     CHECK(t.size() == 1);
     CHECK(not t.empty());
     CHECK(t.contains(10));
@@ -56,7 +56,7 @@ TEST_CASE("erase all", "[cx_set]") {
     stdx::cx_set<int, 64> t;
 
     t.insert(10);
-    t.erase(10);
+    CHECK(t.erase(10) == 1);
 
     CHECK(t.size() == 0);
     CHECK(t.empty());
@@ -67,6 +67,7 @@ TEST_CASE("erase some", "[cx_set]") {
     stdx::cx_set<int, 64> t;
 
     t.insert(10);
+    CHECK(t.contains(10));
     t.insert(11);
     t.erase(10);
 

--- a/test/cx_vector.cpp
+++ b/test/cx_vector.cpp
@@ -172,9 +172,9 @@ TEST_CASE("resize_and_overwrite", "[cx_vector]") {
     stdx::cx_vector<int, 5> v{1, 2, 3, 4, 5};
     resize_and_overwrite(v, [](int *dest, std::size_t max_size) {
         CHECK(max_size == 5);
-        *dest = 42;
+        *dest = 17;
         return 1u;
     });
     REQUIRE(v.size() == 1u);
-    CHECK(v[0] == 42);
+    CHECK(v[0] == 17);
 }

--- a/test/function_traits.cpp
+++ b/test/function_traits.cpp
@@ -170,28 +170,29 @@ TEST_CASE("generic lambda arity", "[function_traits]") {
 }
 
 namespace {
-bool called_1{};
-bool called_2{};
+int called_1{};
+int called_2{};
 
 template <typename F>
 constexpr auto call_f(F f, stdx::priority_t<1>) -> stdx::return_t<F> {
-    called_1 = true;
+    ++called_1;
     return f();
 }
 
 template <typename F> constexpr auto call_f(F f, stdx::priority_t<0>) -> void {
-    called_2 = true;
+    ++called_2;
     f(0);
 }
 } // namespace
 
 TEST_CASE("SFINAE friendly", "[function_traits]") {
-    called_1 = false;
-    called_2 = false;
+    called_1 = 0;
+    called_2 = 0;
     auto f1 = []() -> int { return 1; };
     auto f2 = [](auto) -> void {};
     call_f(f1, stdx::priority<1>);
-    CHECK(called_1);
+    CHECK(called_1 == 1);
+    CHECK(called_2 == 0);
     call_f(f2, stdx::priority<1>);
-    CHECK(called_2);
+    CHECK(called_2 == 1);
 }

--- a/test/intrusive_forward_list.cpp
+++ b/test/intrusive_forward_list.cpp
@@ -240,9 +240,9 @@ TEST_CASE("checked operation clears pointers on clear", "[intrusive_list]") {
 
 namespace {
 #if __cplusplus >= 202002L
-bool compile_time_call{};
+int compile_time_calls{};
 #else
-bool runtime_call{};
+int runtime_calls{};
 #endif
 
 struct injected_handler {
@@ -250,13 +250,13 @@ struct injected_handler {
     template <stdx::ct_string Why, typename... Ts>
     static auto panic(Ts &&...) noexcept -> void {
         static_assert(std::string_view{Why} == "bad list node!");
-        compile_time_call = true;
+        ++compile_time_calls;
     }
 #else
     template <typename Why, typename... Ts>
     static auto panic(Why why, Ts &&...) noexcept -> void {
         CHECK(std::string_view{why} == "bad list node!");
-        runtime_call = true;
+        ++runtime_calls;
     }
 #endif
 };
@@ -270,15 +270,15 @@ TEST_CASE("checked panic when pushing populated node", "[intrusive_list]") {
     int_node n{5};
 
     n.next = &n;
-    compile_time_call = false;
+    compile_time_calls = 0;
     list.push_back(&n);
-    CHECK(compile_time_call);
+    CHECK(compile_time_calls == 1);
     list.pop_front();
 
     n.next = &n;
-    compile_time_call = false;
+    compile_time_calls = 0;
     list.push_front(&n);
-    CHECK(compile_time_call);
+    CHECK(compile_time_calls == 1);
 }
 #else
 TEST_CASE("checked panic when pushing populated node", "[intrusive_list]") {
@@ -286,15 +286,15 @@ TEST_CASE("checked panic when pushing populated node", "[intrusive_list]") {
     int_node n{5};
 
     n.next = &n;
-    runtime_call = false;
+    runtime_calls = 0;
     list.push_back(&n);
-    CHECK(runtime_call);
+    CHECK(runtime_calls == 1);
     list.pop_front();
 
     n.next = &n;
-    runtime_call = false;
+    runtime_calls = 0;
     list.push_front(&n);
-    CHECK(runtime_call);
+    CHECK(runtime_calls == 1);
 }
 #endif
 

--- a/test/intrusive_list_properties.cpp
+++ b/test/intrusive_list_properties.cpp
@@ -42,7 +42,7 @@ template <typename ListSut> struct IntrusiveListCommands {
     static void rc_assert_equal(ListModel const &m, ListSut const &sut) {
         RC_ASSERT(m.empty() == sut.list.empty());
 
-        if (!m.empty() && !sut.list.empty()) {
+        if (!m.empty()) {
             RC_ASSERT(m.front() == sut.list.front().value);
             RC_ASSERT(m.back() == sut.list.back().value);
         }

--- a/test/numeric.cpp
+++ b/test/numeric.cpp
@@ -40,13 +40,14 @@ TEST_CASE("n-ary transform_reduce_n", "[numeric]") {
     CHECK(v == 40);
 }
 
-TEST_CASE("transform_reduce with output fixed by template arumgent",
+TEST_CASE("transform_reduce with output fixed by template argument",
           "[numeric]") {
     auto const input = std::array{1.5, 2.5, 3.5, 4.5};
-    auto const v = stdx::transform_reduce<double>(
-        std::cbegin(input), std::cend(input), 0, std::plus{},
-        [](auto n) { return n * 2; });
-    CHECK(v == 24);
+    auto v =
+        stdx::transform_reduce<double>(std::cbegin(input), std::cend(input), 0,
+                                       std::plus{}, [](auto n) { return n; });
+    static_assert(std::is_same_v<decltype(v), double>);
+    CHECK(v == 12);
 }
 
 TEST_CASE("saturate_cast cppreference example", "[numeric]") {

--- a/test/optional.cpp
+++ b/test/optional.cpp
@@ -95,6 +95,16 @@ TEST_CASE("in-place construction (no args)", "[optional]") {
     static_assert(o);
 }
 
+TEST_CASE("retrieve value", "[optional]") {
+    auto o = stdx::optional<E>{E::VALUE};
+    CHECK(o.value() == E::VALUE);
+}
+
+TEST_CASE("operator*", "[optional]") {
+    auto o = stdx::optional<E>{E::VALUE};
+    CHECK(*o == E::VALUE);
+}
+
 TEST_CASE("assignment from nullopt", "[optional]") {
     auto o = stdx::optional<E>{E::VALUE};
     o = std::nullopt;
@@ -104,7 +114,8 @@ TEST_CASE("assignment from nullopt", "[optional]") {
 TEST_CASE("assignment from value", "[optional]") {
     auto o = stdx::optional<E>{};
     o = E::VALUE;
-    CHECK(o);
+    REQUIRE(o);
+    CHECK(*o == E::VALUE);
 }
 
 TEST_CASE("trivially copy assignable", "[optional]") {
@@ -121,16 +132,6 @@ TEST_CASE("has_value and boolean conversion", "[optional]") {
     constexpr auto o = stdx::optional<E>{E::VALUE};
     static_assert(o.has_value());
     static_assert(o);
-}
-
-TEST_CASE("retrieve value", "[optional]") {
-    auto o = stdx::optional<E>{E::VALUE};
-    CHECK(o.value() == E::VALUE);
-}
-
-TEST_CASE("operator*", "[optional]") {
-    auto o = stdx::optional<E>{E::VALUE};
-    CHECK(*o == E::VALUE);
 }
 
 TEST_CASE("operator->", "[optional]") {
@@ -181,6 +182,7 @@ TEST_CASE("less than - both engaged", "[optional]") {
     auto o1 = stdx::optional<S>{17};
     auto o2 = stdx::optional<S>{42};
     CHECK(o1 < o2);
+    CHECK(not(o1 < o1));
 }
 
 TEST_CASE("less than - neither engaged", "[optional]") {
@@ -397,6 +399,7 @@ TEST_CASE("optional pointer value has default sentinel", "[optional]") {
     CHECK(*o1 == nullptr);
     float f{1.0f};
     auto const o2 = stdx::optional<float *>{&f};
+    CHECK(**o2 == 1.0f);
     CHECK(o1 < o2);
 }
 

--- a/test/panic.cpp
+++ b/test/panic.cpp
@@ -7,23 +7,23 @@
 #include <string_view>
 
 namespace {
-bool runtime_call{};
+int runtime_calls{};
 #if __cplusplus >= 202002L
-bool compile_time_call{};
+int compile_time_calls{};
 #endif
 
 struct injected_handler {
     template <typename Why, typename... Ts>
     static auto panic(Why why, Ts &&...) noexcept -> void {
         CHECK(std::string_view{why} == "uh-oh");
-        runtime_call = true;
+        ++runtime_calls;
     }
 
 #if __cplusplus >= 202002L
     template <stdx::ct_string Why, typename... Ts>
     static auto panic(Ts &&...) noexcept -> void {
         static_assert(std::string_view{Why} == "uh-oh");
-        compile_time_call = true;
+        ++compile_time_calls;
     }
 #endif
 };
@@ -32,28 +32,28 @@ struct injected_handler {
 template <> inline auto stdx::panic_handler<> = injected_handler{};
 
 TEST_CASE("panic called with runtime arguments", "[panic]") {
-    runtime_call = false;
+    runtime_calls = 0;
     stdx::panic("uh-oh");
-    CHECK(runtime_call);
+    CHECK(runtime_calls == 1);
 }
 
 #if __cplusplus >= 202002L
 TEST_CASE("panic called with compile-time strings", "[panic]") {
-    compile_time_call = false;
+    compile_time_calls = 0;
     using namespace stdx::ct_string_literals;
     stdx::panic<"uh-oh"_cts>();
-    CHECK(compile_time_call);
+    CHECK(compile_time_calls == 1);
 }
 
 TEST_CASE("compile-time panic called through macro", "[panic]") {
-    compile_time_call = false;
+    compile_time_calls = 0;
     STDX_PANIC("uh-oh");
-    CHECK(compile_time_call);
+    CHECK(compile_time_calls == 1);
 }
 #else
 TEST_CASE("runtime panic called through macro", "[panic]") {
-    runtime_call = false;
+    runtime_calls = 0;
     STDX_PANIC("uh-oh");
-    CHECK(runtime_call);
+    CHECK(runtime_calls == 1);
 }
 #endif

--- a/test/tuple_algorithms.cpp
+++ b/test/tuple_algorithms.cpp
@@ -51,6 +51,8 @@ TEST_CASE("transform preserves references", "[tuple_algorithms]") {
         },
         stdx::tuple{1});
     CHECK(std::addressof(value) == std::addressof(u[stdx::index<0>]));
+    CHECK(u == stdx::tuple{2});
+    CHECK(value == 2);
 }
 
 namespace {
@@ -187,6 +189,9 @@ TEST_CASE("tuple_cat (references)", "[tuple_algorithms]") {
     auto x = 1;
     auto t = stdx::tuple_cat(stdx::tuple<int &>{x}, stdx::tuple<int &>{x});
     static_assert(std::is_same_v<decltype(t), stdx::tuple<int &, int &>>);
+    CHECK(std::addressof(x) == std::addressof(t[stdx::index<0>]));
+    CHECK(std::addressof(x) == std::addressof(t[stdx::index<1>]));
+    CHECK(x == 1);
     stdx::get<0>(t) = 2;
     CHECK(x == 2);
     stdx::get<1>(t) = 1;
@@ -199,6 +204,9 @@ TEST_CASE("tuple_cat (const references)", "[tuple_algorithms]") {
                              stdx::tuple<int const &>{x});
     static_assert(
         std::is_same_v<decltype(t), stdx::tuple<int const &, int const &>>);
+    CHECK(std::addressof(x) == std::addressof(t[stdx::index<0>]));
+    CHECK(std::addressof(x) == std::addressof(t[stdx::index<1>]));
+    CHECK(x == 1);
     x = 2;
     CHECK(stdx::get<0>(t) == 2);
     CHECK(stdx::get<1>(t) == 2);
@@ -206,10 +214,15 @@ TEST_CASE("tuple_cat (const references)", "[tuple_algorithms]") {
 
 TEST_CASE("tuple_cat (rvalue references)", "[tuple_algorithms]") {
     auto x = 1;
-    auto y = 2;
+    auto y = 1;
     auto t = stdx::tuple_cat(stdx::tuple<int &&>{std::move(x)},
                              stdx::tuple<int &&>{std::move(y)});
     static_assert(std::is_same_v<decltype(t), stdx::tuple<int &&, int &&>>);
+    CHECK(std::addressof(x) == std::addressof(t[stdx::index<0>]));
+    CHECK(std::addressof(y) == std::addressof(t[stdx::index<1>]));
+    CHECK(x == 1);
+    CHECK(y == 1);
+
     x = 2;
     CHECK(stdx::get<0>(t) == 2);
     y = 2;
@@ -558,9 +571,11 @@ TEST_CASE("unique preserves references", "[tuple_algorithms]") {
     int y{2};
     auto t = stdx::forward_as_tuple(x, y);
     static_assert(std::is_same_v<decltype(t), stdx::tuple<int &, int &>>);
+    CHECK(t == stdx::tuple{1, 2});
     auto u = stdx::unique(t);
     static_assert(std::is_same_v<decltype(u), stdx::tuple<int &>>);
     CHECK(u == stdx::tuple{1});
+    CHECK(std::addressof(x) == std::addressof(u[stdx::index<0>]));
 }
 
 TEST_CASE("unique with move only types", "[tuple_algorithms]") {
@@ -597,9 +612,12 @@ TEST_CASE("to_sorted_set preserves references", "[tuple_algorithms]") {
     static_assert(
         std::is_same_v<decltype(t),
                        stdx::tuple<int &, int &, double &, double &>>);
+    CHECK(t == stdx::tuple{1, 2, 3.0, 4.0});
     auto u = stdx::to_sorted_set(t);
     static_assert(std::is_same_v<decltype(u), stdx::tuple<double &, int &>>);
     CHECK(u == stdx::tuple{3.0, 1});
+    CHECK(std::addressof(a) == std::addressof(u[stdx::index<0>]));
+    CHECK(std::addressof(x) == std::addressof(u[stdx::index<1>]));
 }
 
 TEST_CASE("to_unsorted_set", "[tuple_algorithms]") {
@@ -619,9 +637,12 @@ TEST_CASE("to_unsorted_set preserves references", "[tuple_algorithms]") {
     static_assert(
         std::is_same_v<decltype(t),
                        stdx::tuple<int &, int &, double &, double &>>);
+    CHECK(t == stdx::tuple{1, 2, 3.0, 4.0});
     auto u = stdx::to_unsorted_set(t);
     static_assert(std::is_same_v<decltype(u), stdx::tuple<int &, double &>>);
     CHECK(u == stdx::tuple{1, 3.0});
+    CHECK(std::addressof(x) == std::addressof(u[stdx::index<0>]));
+    CHECK(std::addressof(a) == std::addressof(u[stdx::index<1>]));
 }
 
 TEST_CASE("to_unsorted_set with move only types", "[tuple_algorithms]") {
@@ -740,6 +761,8 @@ TEST_CASE("tuple_cons (references)", "[tuple_algorithms]") {
     auto x = 1;
     auto t = stdx::tuple_cons(1, stdx::tuple<int &>{x});
     static_assert(std::is_same_v<decltype(t), stdx::tuple<int, int &>>);
+    CHECK(t == stdx::tuple{1, 1});
+    CHECK(std::addressof(x) == std::addressof(t[stdx::index<1>]));
 }
 
 TEST_CASE("tuple_snoc", "[tuple_algorithms]") {
@@ -759,6 +782,8 @@ TEST_CASE("tuple_snoc (references)", "[tuple_algorithms]") {
     auto x = 1;
     auto t = stdx::tuple_snoc(stdx::tuple<int &>{x}, 1);
     static_assert(std::is_same_v<decltype(t), stdx::tuple<int &, int>>);
+    CHECK(t == stdx::tuple{1, 1});
+    CHECK(std::addressof(x) == std::addressof(t[stdx::index<0>]));
 }
 
 TEST_CASE("tuple_push_front", "[tuple_algorithms]") {

--- a/test/type_traits.cpp
+++ b/test/type_traits.cpp
@@ -96,6 +96,9 @@ TEST_CASE("type_or_t", "[type_traits]") {
 namespace {
 int value{};
 struct add_value {
+    add_value() = default;
+    add_value(int init) { value = init; }
+
     template <typename T> constexpr auto operator()() const -> void {
         value += T::value;
     }
@@ -121,30 +124,26 @@ TEST_CASE("template_for_each with type list", "[type_traits]") {
 }
 
 TEST_CASE("template_for_each with empty type list", "[type_traits]") {
-    value = 42;
     using L = stdx::type_list<>;
-    stdx::template_for_each<L>(add_value{});
-    CHECK(value == 42);
+    stdx::template_for_each<L>(add_value{17});
+    CHECK(value == 17);
 }
 
 TEST_CASE("template_for_each with value list", "[type_traits]") {
-    value = 0;
     using L = stdx::value_list<1, 2>;
-    stdx::template_for_each<L>(add_value{});
+    stdx::template_for_each<L>(add_value{0});
     CHECK(value == 3);
 }
 
 TEST_CASE("template_for_each with empty value list", "[type_traits]") {
-    value = 17;
     using L = stdx::value_list<>;
-    stdx::template_for_each<L>(add_value{});
+    stdx::template_for_each<L>(add_value{17});
     CHECK(value == 17);
 }
 
 TEST_CASE("template_for_each with index sequence", "[type_traits]") {
-    value = 0;
     using L = std::make_index_sequence<3>;
-    stdx::template_for_each<L>(add_value{});
+    stdx::template_for_each<L>(add_value{0});
     CHECK(value == 3);
 }
 

--- a/test/with_result_of.cpp
+++ b/test/with_result_of.cpp
@@ -26,9 +26,9 @@ TEST_CASE("implicit conversion (rvalue)", "[with_result_of]") {
 }
 
 TEST_CASE("capturing lambda", "[with_result_of]") {
-    auto value = 42;
+    auto value = 17;
     auto const result = [](int n) {
-        return n;
+        return n + 42;
     }(stdx::with_result_of{[&]() { return value; }});
-    CHECK(result == value);
+    CHECK(result == 59);
 }


### PR DESCRIPTION
Problem:
- Quis custodiet ipsos custodies? (Who tests the tests?)

Solution:
- Mutation testing tests the tests.

Note:
- To run mutation tests, build the `mull_tests` target.
- Mull tests are run as a CI job but this doesn't gate `merge_ok`.
- The CI job runs mutations tests on ubuntu-22.04, LLVM 15, mull v0.23.0. This is the current "latest version" taking into consideration the constraints. When we run on ubuntu-24.04, we can use LLVM 17 for mull. And later versions as they are supported.