### PR TITLE
:art: Return a value from `ct_check::emit`

### DIFF
--- a/include/stdx/ct_string.hpp
+++ b/include/stdx/ct_string.hpp
@@ -124,14 +124,18 @@ template <ct_string S> CONSTEVAL auto operator""_cts() { return S; }
 } // namespace ct_string_literals
 } // namespace literals
 
+struct ct_check_value {};
+
 template <bool B> struct ct_check_t {
     template <ct_string S> constexpr static bool diagnostic = false;
     template <ct_string S>
-    constexpr static auto emit() -> void
+    constexpr static auto emit() -> ct_check_value
         requires diagnostic<S>;
 };
 template <> struct ct_check_t<true> {
-    template <ct_string S> constexpr static auto emit() -> void {}
+    template <ct_string S> constexpr static auto emit() -> ct_check_value {
+        return {};
+    }
 };
 template <bool B> constexpr auto ct_check = ct_check_t<B>{};
 

--- a/test/fail/ct_check.cpp
+++ b/test/fail/ct_check.cpp
@@ -6,6 +6,6 @@ constexpr auto msg =
     stdx::ct_string{"01234567890123456789012345678901234567890123456789"};
 
 auto main() -> int {
-    stdx::ct_check<true>.emit<"not emitted">();
+    [[maybe_unused]] auto x = stdx::ct_check<true>.emit<"not emitted">();
     stdx::ct_check<false>.emit<msg>();
 }


### PR DESCRIPTION
Problem:
- It's useful to assign the result of `ct_check::emit` to a declared variable in cases where we aren't inside a function. For example, a fallback instantiation of a class template that wants to emit an error can declare a member variable.

Solution:
- Return a value from `ct_check::emit`.