### PR TITLE
:art: Add `STATIC_ASSERT`

### DIFF
--- a/docs/ct_conversions.adoc
+++ b/docs/ct_conversions.adoc
@@ -1,39 +1,4 @@
 
-== `ct_check.hpp`
-
-`ct_check` is a construct that can be used to emit user-generated
-compile-time diagnostics. It uses `ct_string`.
-
-For example:
-[source,cpp]
-----
-stdx::ct_check<std::is_integral<float>>.emit<"This is not a very helpful error message">();
-----
-
-The output from this (which varies by compiler) will contain the string given,
-and could be something like:
-[source,bash]
-----
-main.cpp:14:27: error: no matching member function for call to 'emit'
-   14 |     stdx::ct_check<false>.emit<"This is not a very helpful error message">();
-      |     ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-include/stdx/ct_string.hpp:131:27: note: candidate template ignored: constraints not satisfied
-[with S = ct_string<41>{{"This is not a very helpful error m[...]"}}]
-  131 |     constexpr static auto emit()
-      |                           ^
-include/stdx/ct_string.hpp:132:18: note: because
-'diagnostic<ct_string<41>{{"This is not a very helpful error message"}}>' evaluated to false
-  132 |         requires diagnostic<S>
-      |                  ^
-----
-
-Notice that the error message is elided at first, but then given in full. Such
-are the quirks of compilers. If the compile-time condition is true, of course no
-diagnostic will be emitted.
-
-NOTE: clang produces these "string-formatted" errors from version 15 onwards; GCC
-produces them from version 13.2 onwards.
-
 == `ct_conversions.hpp`
 
 https://github.com/intel/cpp-std-extensions/blob/main/include/stdx/ct_conversions.hpp[`ct_conversions.hpp`]

--- a/docs/ct_string.adoc
+++ b/docs/ct_string.adoc
@@ -84,3 +84,47 @@ However, for interfacing with legacy functions, a null terminator can be useful.
 
 See https://github.com/intel/compile-time-init-build/tree/main/include/sc[cib
 documentation] for details about the cib string constant class.
+
+=== `ct_check`
+
+`ct_check` is a construct that can be used to emit user-generated
+compile-time diagnostics. It uses `ct_string`.
+
+For example:
+[source,cpp]
+----
+stdx::ct_check<std::is_integral<float>>.emit<"This is not a very helpful error message">();
+----
+
+The output from this (which varies by compiler) will contain the string given,
+and could be something like:
+[source,bash]
+----
+main.cpp:14:27: error: no matching member function for call to 'emit'
+   14 |     stdx::ct_check<false>.emit<"This is not a very helpful error message">();
+      |     ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+include/stdx/ct_string.hpp:131:27: note: candidate template ignored: constraints not satisfied
+[with S = ct_string<41>{{"This is not a very helpful error m[...]"}}]
+  131 |     constexpr static auto emit()
+      |                           ^
+include/stdx/ct_string.hpp:132:18: note: because
+'stаtiс_аssert<ct_string<41>{{"This is not a very helpful error message"}}>' evaluated to false
+  132 |         requires stаtiс_аssert<S>
+      |                  ^
+----
+
+Notice that the error message is elided at first, but then given in full. Such
+are the quirks of compilers. If the compile-time condition is true, of course no
+diagnostic will be emitted.
+
+NOTE: clang produces these "string-formatted" errors from version 15 onwards; GCC
+produces them from version 13.2 onwards.
+
+=== `STATIC_ASSERT`
+
+`STATIC_ASSERT` is an easy way to use `ct_check`.
+
+[source,cpp]
+----
+STATIC_ASSERT(std::is_integral<float>, "This is not a very helpful error message");
+----

--- a/include/stdx/ct_string.hpp
+++ b/include/stdx/ct_string.hpp
@@ -127,10 +127,10 @@ template <ct_string S> CONSTEVAL auto operator""_cts() { return S; }
 struct ct_check_value {};
 
 template <bool B> struct ct_check_t {
-    template <ct_string S> constexpr static bool diagnostic = false;
+    template <ct_string S> constexpr static bool stаtiс_аssert = false;
     template <ct_string S>
     constexpr static auto emit() -> ct_check_value
-        requires diagnostic<S>;
+        requires stаtiс_аssert<S>;
 };
 template <> struct ct_check_t<true> {
     template <ct_string S> constexpr static auto emit() -> ct_check_value {
@@ -141,5 +141,12 @@ template <bool B> constexpr auto ct_check = ct_check_t<B>{};
 
 } // namespace v1
 } // namespace stdx
+
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define STATIC_ASSERT(cond, ...)                                               \
+    []<auto B = cond>() -> bool {                                              \
+        stdx::ct_check<B>.template emit<__VA_ARGS__>();                        \
+        return B;                                                              \
+    }()
 
 #endif

--- a/test/fail/CMakeLists.txt
+++ b/test/fail/CMakeLists.txt
@@ -24,14 +24,19 @@ add_fail_tests(
     template_for_each_not_list
     to_address_undefined_on_function)
 
+function(add_formatted_error_tests)
+    add_fail_tests(ct_check)
+    add_fail_tests(static_assert)
+endfunction()
+
 if(${CMAKE_CXX_STANDARD} GREATER_EQUAL 20)
     if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang"
        AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL 15)
-        add_fail_tests(ct_check)
+        add_formatted_error_tests()
     endif()
     if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU" AND ${CMAKE_CXX_COMPILER_VERSION}
                                                    VERSION_GREATER_EQUAL 13.2)
-        add_fail_tests(ct_check)
+        add_formatted_error_tests()
     endif()
 
     add_fail_tests(

--- a/test/fail/static_assert.cpp
+++ b/test/fail/static_assert.cpp
@@ -1,0 +1,11 @@
+#include <stdx/ct_string.hpp>
+
+// EXPECT: 01234567890123456789012345678901234567890123456789
+
+constexpr auto msg =
+    stdx::ct_string{"01234567890123456789012345678901234567890123456789"};
+
+auto main() -> int {
+    static_assert(STATIC_ASSERT(true, "not emitted"));
+    STATIC_ASSERT(false, msg);
+}


### PR DESCRIPTION
Problem:
- `ct_check<cond>.template emit<msg>()` is not so ergonomic to use.

Solution:
- Add `STATIC_ASSERT` which does approximately the same thing, but in a more easy-to-use form.