### PR TITLE
:art: Allow bare template arguments in `STATIC_ASSERT`

### DIFF
--- a/docs/static_assert.adoc
+++ b/docs/static_assert.adoc
@@ -14,7 +14,9 @@ constexpr auto f() {
 f<float>(); // produces compile-time error
 ----
 
-The arguments to be formatted (if any) must be wrapped in xref:utility.adoc#_cx_value[`CX_VALUE`].
+The arguments to be formatted (if any) must be wrapped in
+xref:utility.adoc#_cx_value[`CX_VALUE`] if they are not admissible as template
+arguments.
 
 The output from this (which varies by compiler) will contain the formatted
 string, and could be something like:

--- a/include/stdx/static_assert.hpp
+++ b/include/stdx/static_assert.hpp
@@ -23,11 +23,15 @@ template <> struct ct_check_t<true> {
 template <bool B> constexpr auto ct_check = ct_check_t<B>{};
 
 namespace detail {
-template <ct_string Fmt, auto... Args>
-constexpr auto static_format()
-    requires(... and cx_value<decltype(Args)>)
-{
-    return ct_format<Fmt>(Args...);
+template <ct_string Fmt, auto... Args> constexpr auto static_format() {
+    constexpr auto make_ct = []<auto V>() {
+        if constexpr (cx_value<decltype(V)>) {
+            return V;
+        } else {
+            return CX_VALUE(V);
+        }
+    };
+    return ct_format<Fmt>(make_ct.template operator()<Args>()...);
 }
 } // namespace detail
 

--- a/test/fail/static_assert_format.cpp
+++ b/test/fail/static_assert_format.cpp
@@ -1,14 +1,10 @@
 #include <stdx/static_assert.hpp>
 #include <stdx/utility.hpp>
 
-#include <string_view>
-
 // EXPECT: hello world int 123
 
 template <typename T> constexpr auto f() {
-    using namespace std::string_view_literals;
-    STATIC_ASSERT(false, "hello {} {} {}", CX_VALUE("world"sv), CX_VALUE(T),
-                  CX_VALUE(123));
+    STATIC_ASSERT(false, "hello {} {} {}", CX_VALUE("world"), CX_VALUE(T), 123);
 }
 
 auto main() -> int { f<int>(); }


### PR DESCRIPTION
Problem:
- `STATIC_ASSERT("{}", 42)` should be allowed, because `42` can be a template argument.

Solution:
- Allow it.