### PR TITLE
:bug: Fix `string_view` construction

### DIFF
--- a/include/stdx/ct_string.hpp
+++ b/include/stdx/ct_string.hpp
@@ -52,7 +52,7 @@ template <std::size_t N> struct ct_string {
     constexpr static std::integral_constant<bool, N == 1U> empty{};
 
     constexpr explicit(true) operator std::string_view() const {
-        return std::string_view{value.cbegin(), size()};
+        return std::string_view{value.data(), size()};
     }
 
     std::array<char, N> value{};


### PR DESCRIPTION
Problem:
- `string_view`'s constructor takes a `char const *` and a size, not an iterator and a size. On platforms where an array iterator is not a simple pointer, this fails.

Solution:
- Use `data` instead of `cbegin` to access the string data.