### PR TITLE
:bug: Don't assume `std::array<>::iterator` is a pointer

### DIFF
--- a/include/stdx/cx_map.hpp
+++ b/include/stdx/cx_map.hpp
@@ -45,24 +45,24 @@ template <typename Key, typename Value, std::size_t N> class cx_map {
         : storage{vs...}, current_size{sizeof...(Vs)} {}
 
     [[nodiscard]] constexpr auto begin() LIFETIMEBOUND -> iterator {
-        return std::begin(storage);
+        return std::data(storage);
     }
     [[nodiscard]] constexpr auto begin() const LIFETIMEBOUND -> const_iterator {
-        return std::begin(storage);
+        return std::data(storage);
     }
     [[nodiscard]] constexpr auto
     cbegin() const LIFETIMEBOUND -> const_iterator {
-        return std::cbegin(storage);
+        return std::data(storage);
     }
 
     [[nodiscard]] constexpr auto end() LIFETIMEBOUND -> iterator {
-        return std::begin(storage) + current_size;
+        return begin() + current_size;
     }
     [[nodiscard]] constexpr auto end() const LIFETIMEBOUND -> const_iterator {
-        return std::begin(storage) + current_size;
+        return begin() + current_size;
     }
     [[nodiscard]] constexpr auto cend() const LIFETIMEBOUND -> const_iterator {
-        return std::cbegin(storage) + current_size;
+        return cbegin() + current_size;
     }
 
     [[nodiscard]] constexpr auto size() const -> std::size_t {

--- a/include/stdx/cx_set.hpp
+++ b/include/stdx/cx_set.hpp
@@ -33,24 +33,24 @@ template <typename Key, std::size_t N> class cx_set {
     }
 
     [[nodiscard]] constexpr auto begin() LIFETIMEBOUND -> iterator {
-        return std::begin(storage);
+        return std::data(storage);
     }
     [[nodiscard]] constexpr auto begin() const LIFETIMEBOUND -> const_iterator {
-        return std::begin(storage);
+        return std::data(storage);
     }
     [[nodiscard]] constexpr auto
     cbegin() const LIFETIMEBOUND -> const_iterator {
-        return std::cbegin(storage);
+        return std::data(storage);
     }
 
     [[nodiscard]] constexpr auto end() LIFETIMEBOUND -> iterator {
-        return std::begin(storage) + current_size;
+        return begin() + current_size;
     }
     [[nodiscard]] constexpr auto end() const LIFETIMEBOUND -> const_iterator {
-        return std::begin(storage) + current_size;
+        return begin() + current_size;
     }
     [[nodiscard]] constexpr auto cend() const LIFETIMEBOUND -> const_iterator {
-        return std::cbegin(storage) + current_size;
+        return cbegin() + current_size;
     }
 
     [[nodiscard]] constexpr auto size() const -> size_type {

--- a/include/stdx/cx_vector.hpp
+++ b/include/stdx/cx_vector.hpp
@@ -40,24 +40,24 @@ template <typename T, std::size_t N> class cx_vector {
     }
 
     [[nodiscard]] constexpr auto begin() LIFETIMEBOUND -> iterator {
-        return std::begin(storage);
+        return std::data(storage);
     }
     [[nodiscard]] constexpr auto begin() const LIFETIMEBOUND -> const_iterator {
-        return std::begin(storage);
+        return std::data(storage);
     }
     [[nodiscard]] constexpr auto
     cbegin() const LIFETIMEBOUND -> const_iterator {
-        return std::cbegin(storage);
+        return std::data(storage);
     }
 
     [[nodiscard]] constexpr auto end() LIFETIMEBOUND -> iterator {
-        return std::begin(storage) + current_size;
+        return begin() + current_size;
     }
     [[nodiscard]] constexpr auto end() const LIFETIMEBOUND -> const_iterator {
-        return std::begin(storage) + current_size;
+        return begin() + current_size;
     }
     [[nodiscard]] constexpr auto cend() const LIFETIMEBOUND -> const_iterator {
-        return std::cbegin(storage) + current_size;
+        return cbegin() + current_size;
     }
 
     [[nodiscard]] constexpr auto rbegin() LIFETIMEBOUND -> reverse_iterator {


### PR DESCRIPTION
Problem:
- Container classes define `iterator` as a pointer type but return `begin()` or `end()` of the underlying `std::array`, which is an iterator type, not necessarily a pointer.

Solution:
- Use `data()` instead of `begin()` where necessary.