### PR TITLE
Ignore missing-braces warnings for AppleClang similar to Clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,10 @@ endif()
 add_library(stdx INTERFACE)
 target_compile_features(stdx INTERFACE cxx_std_${CMAKE_CXX_STANDARD})
 target_compile_options(
-    stdx INTERFACE $<$<CXX_COMPILER_ID:Clang>:-Wno-missing-braces>)
+    stdx
+    INTERFACE
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wno-missing-braces>
+)
 target_link_libraries_system(stdx INTERFACE concurrency boost_mp11
                              fmt::fmt-header-only)
 


### PR DESCRIPTION
AppleClang 
```
 /usr/bin/g++ --version
Apple clang version 16.0.0 (clang-1600.0.26.4)
Target: arm64-apple-darwin24.1.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
 /usr/bin/clang++ --version
Apple clang version 16.0.0 (clang-1600.0.26.4)
Target: arm64-apple-darwin24.1.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```
complains about missing braces as
```
[ 50%] Building CXX object test/cib/CMakeFiles/cib_nexus_test.dir/nexus.cpp.o
cd "build/Clang 16.0.0 arm64-apple-darwin24.1.0/test/cib" && /usr/bin/clang++ -DFMT_HEADER_ONLY=1 -Iinclude -isystem "build/Clang 16.0.0 arm64-apple-darwin24.1.0/_deps/catch2-src/src/catch2/.." -isystem "build/Clang 16.0.0 arm64-apple-darwin24.1.0/_deps/catch2-build/generated-includes" -isystem "build/Clang 16.0.0 arm64-apple-darwin24.1.0/_deps/rapidcheck-src/include" -isystem "build/Clang 16.0.0 arm64-apple-darwin24.1.0/_deps/rapidcheck-src/extras/catch/include" -isystem "build/Clang 16.0.0 arm64-apple-darwin24.1.0/_deps/mp11-src/include" -isystem "build/Clang 16.0.0 arm64-apple-darwin24.1.0/_deps/cpp-baremetal-concurrency-src/include" -isystem "build/Clang 16.0.0 arm64-apple-darwin24.1.0/_deps/fmt-src/include" -isystem "build/Clang 16.0.0 arm64-apple-darwin24.1.0/_deps/cpp-std-extensions-src/include" -isystem "build/Clang 16.0.0 arm64-apple-darwin24.1.0/_deps/cpp-baremetal-senders-and-receivers-src/include" -g -std=gnu++20 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX15.1.sdk -Wall -Wcast-align -Wconversion -Wdouble-promotion -Werror -Wextra -Wextra-semi -Wfatal-errors -Wformat=2 -Wold-style-cast -Woverloaded-virtual -Wshadow -Wunused -MD -MT test/cib/CMakeFiles/cib_nexus_test.dir/nexus.cpp.o -MF CMakeFiles/cib_nexus_test.dir/nexus.cpp.o.d -o CMakeFiles/cib_nexus_test.dir/nexus.cpp.o -c test/cib/nexus.cpp
In file included from test/cib/nexus.cpp:1:
In file included from include/cib/cib.hpp:40:
In file included from include/cib/config.hpp:5:
include/cib/detail/config_details.hpp:20:25: fatal error: suggest braces around initialization of subobject [-Wmissing-braces]
   20 |         : configs_tuple{configs...} {}
      |                         ^~~~~~~
      |                         {      }
include/cib/config.hpp:30:12: note: in instantiation of member function 'cib::detail::config<cib::detail::exports<TestCallback<0>>, cib::detail::extend<TestCallback<0>, SimpleConfig::(lambda at test/cib/nexus.cpp:22:38)>>::config' requested here
   30 |     return detail::config{configs...};
      |            ^
test/cib/nexus.cpp:20:41: note: in instantiation of function template specialization 'cib::config<cib::detail::exports<TestCallback<0>>, cib::detail::extend<TestCallback<0>, SimpleConfig::(lambda at test/cib/nexus.cpp:22:38)>>' requested here
   20 |     constexpr static auto config = cib::config(
      |                                         ^
1 error generated.
```

with the change compilation passes
```
[ 50%] Building CXX object test/cib/CMakeFiles/cib_nexus_test.dir/nexus.cpp.o
cd "build/Clang 16.0.0 arm64-apple-darwin24.1.0/test/cib" && /usr/bin/clang++ -DFMT_HEADER_ONLY=1 -Iinclude -isystem "build/Clang 16.0.0 arm64-apple-darwin24.1.0/_deps/catch2-src/src/catch2/.." -isystem "build/Clang 16.0.0 arm64-apple-darwin24.1.0/_deps/catch2-build/generated-includes" -isystem "build/Clang 16.0.0 arm64-apple-darwin24.1.0/_deps/rapidcheck-src/include" -isystem "build/Clang 16.0.0 arm64-apple-darwin24.1.0/_deps/rapidcheck-src/extras/catch/include" -isystem "build/Clang 16.0.0 arm64-apple-darwin24.1.0/_deps/mp11-src/include" -isystem "build/Clang 16.0.0 arm64-apple-darwin24.1.0/_deps/cpp-baremetal-concurrency-src/include" -isystem "build/Clang 16.0.0 arm64-apple-darwin24.1.0/_deps/fmt-src/include" -isystem "build/Clang 16.0.0 arm64-apple-darwin24.1.0/_deps/cpp-std-extensions-src/include" -isystem "build/Clang 16.0.0 arm64-apple-darwin24.1.0/_deps/cpp-baremetal-senders-and-receivers-src/include" -g -std=gnu++20 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX15.1.sdk -Wall -Wcast-align -Wconversion -Wdouble-promotion -Werror -Wextra -Wextra-semi -Wfatal-errors -Wformat=2 -Wold-style-cast -Woverloaded-virtual -Wshadow -Wunused -Wno-missing-braces -MD -MT test/cib/CMakeFiles/cib_nexus_test.dir/nexus.cpp.o -MF CMakeFiles/cib_nexus_test.dir/nexus.cpp.o.d -o CMakeFiles/cib_nexus_test.dir/nexus.cpp.o -c test/cib/nexus.cpp
```