### PR TITLE
:art: Add return type control to `byterator` peek/read aliases

### DIFF
--- a/include/stdx/byterator.hpp
+++ b/include/stdx/byterator.hpp
@@ -188,20 +188,32 @@ template <typename T> class byterator {
         ptr += sizeof(R);
     }
 
-    [[nodiscard]] auto peeku8() { return peek<std::uint8_t>(); }
-    [[nodiscard]] auto readu8() { return read<std::uint8_t>(); }
+    template <typename V = std::uint8_t> [[nodiscard]] auto peeku8() {
+        return peek<std::uint8_t, V>();
+    }
+    template <typename V = std::uint8_t> [[nodiscard]] auto readu8() {
+        return read<std::uint8_t, V>();
+    }
     template <typename V> [[nodiscard]] auto writeu8(V &&v) {
         return write(static_cast<std::uint8_t>(std::forward<V>(v)));
     }
 
-    [[nodiscard]] auto peeku16() { return peek<std::uint16_t>(); }
-    [[nodiscard]] auto readu16() { return read<std::uint16_t>(); }
+    template <typename V = std::uint16_t> [[nodiscard]] auto peeku16() {
+        return peek<std::uint16_t, V>();
+    }
+    template <typename V = std::uint16_t> [[nodiscard]] auto readu16() {
+        return read<std::uint16_t, V>();
+    }
     template <typename V> [[nodiscard]] auto writeu16(V &&v) {
         return write(static_cast<std::uint16_t>(std::forward<V>(v)));
     }
 
-    [[nodiscard]] auto peeku32() { return peek<std::uint32_t>(); }
-    [[nodiscard]] auto readu32() { return read<std::uint32_t>(); }
+    template <typename V = std::uint32_t> [[nodiscard]] auto peeku32() {
+        return peek<std::uint32_t, V>();
+    }
+    template <typename V = std::uint32_t> [[nodiscard]] auto readu32() {
+        return read<std::uint32_t, V>();
+    }
     template <typename V> [[nodiscard]] auto writeu32(V &&v) {
         return write(static_cast<std::uint32_t>(std::forward<V>(v)));
     }

--- a/test/byterator.cpp
+++ b/test/byterator.cpp
@@ -258,3 +258,21 @@ TEST_CASE("write enum (constrained size)", "[byterator]") {
     CHECK(a[0] == stdx::to_be<std::uint16_t>(0x0302));
     CHECK((i == j));
 }
+
+TEST_CASE("peek enum (constrained size alias)", "[byterator]") {
+    auto const a = std::array{stdx::to_be<std::uint16_t>(0x0102),
+                              stdx::to_be<std::uint16_t>(0x0304)};
+    auto i = stdx::byterator{std::begin(a)};
+    static_assert(std::is_same_v<decltype(i.readu32()), std::uint32_t>);
+    CHECK(i.peeku8<E2>() == E2::A);
+}
+
+TEST_CASE("read enum (constrained size alias)", "[byterator]") {
+    auto const a = std::array{stdx::to_be<std::uint16_t>(0x0102),
+                              stdx::to_be<std::uint16_t>(0x0304)};
+    auto i = stdx::byterator{std::begin(a)};
+    auto j = std::next(i);
+    static_assert(std::is_same_v<decltype(i.readu32()), std::uint32_t>);
+    CHECK(i.readu8<E2>() == E2::A);
+    CHECK((i == j));
+}


### PR DESCRIPTION
Problem:
- Byterator supports e.g. `peek<std::uint8_t, E>()` but not `peeku8<E>()`.

Solution:
- Add return type control to the alias functions.