### PR TITLE
:art: Preserve `ct_format` string types

### DIFF
--- a/include/stdx/ct_format.hpp
+++ b/include/stdx/ct_format.hpp
@@ -32,14 +32,24 @@ namespace stdx {
 inline namespace v1 {
 template <typename Str, typename Args> struct format_result {
     [[no_unique_address]] Str str;
-    [[no_unique_address]] Args args;
+    [[no_unique_address]] Args args{};
 
   private:
     friend constexpr auto operator==(format_result const &,
                                      format_result const &) -> bool = default;
 };
+
 template <typename Str, typename Args>
 format_result(Str, Args) -> format_result<Str, Args>;
+template <typename Str> format_result(Str) -> format_result<Str, tuple<>>;
+
+inline namespace literals {
+inline namespace ct_string_literals {
+template <ct_string S> CONSTEVAL auto operator""_fmt_res() {
+    return format_result{cts_t<S>{}};
+}
+} // namespace ct_string_literals
+} // namespace literals
 
 namespace detail {
 template <typename It> CONSTEVAL auto find_spec(It first, It last) -> It {
@@ -131,7 +141,7 @@ CONSTEVAL auto convert_input(auto s) {
     if constexpr (requires { ct_string_from_type(s); }) {
         return ct_string_from_type(s);
     } else {
-        return s;
+        return s.value;
     }
 }
 
@@ -139,43 +149,36 @@ template <ct_string S,
           template <typename T, T...> typename Output = detail::null_output>
 CONSTEVAL auto convert_output() {
     if constexpr (same_as<Output<char>, null_output<char>>) {
-        return S;
+        return cts_t<S>{};
     } else {
         return ct_string_to_type<S, Output>();
     }
 }
 
-template <ct_string Fmt,
-          template <typename T, T...> typename Output = detail::null_output,
-          typename Arg>
-constexpr auto format1(Arg arg) {
+template <ct_string Fmt, typename Arg> constexpr auto format1(Arg arg) {
     if constexpr (cx_value<Arg>) {
-        constexpr auto result = [&] {
+        return [&] {
             constexpr auto fmtstr = FMT_COMPILE(std::string_view{Fmt});
             constexpr auto a = arg_value(arg);
+            auto const f = []<std::size_t N>(auto s, auto v) {
+                ct_string<N + 1> cts{};
+                fmt::format_to(cts.begin(), s, v);
+                return cts;
+            };
             if constexpr (is_specialization_of_v<std::remove_cv_t<decltype(a)>,
                                                  format_result>) {
                 constexpr auto s = convert_input(a.str);
                 constexpr auto sz = fmt::formatted_size(fmtstr, s);
-                ct_string<sz + 1> cts{};
-                fmt::format_to(cts.begin(), fmtstr, s);
-                return format_result{cts, a.args};
+                constexpr auto cts = f.template operator()<sz>(fmtstr, s);
+                return format_result{cts_t<cts>{}, a.args};
             } else {
                 constexpr auto sz = fmt::formatted_size(fmtstr, a);
-                ct_string<sz + 1> cts{};
-                fmt::format_to(cts.begin(), fmtstr, a);
-                return cts;
+                constexpr auto cts = f.template operator()<sz>(fmtstr, a);
+                return format_result{cts_t<cts>{}};
             }
         }();
-        if constexpr (is_specialization_of_v<std::remove_cv_t<decltype(result)>,
-                                             format_result>) {
-            return format_result{convert_output<result.str, Output>(),
-                                 result.args};
-        } else {
-            return convert_output<result, Output>();
-        }
     } else {
-        return format_result{convert_output<Fmt, Output>(), tuple{arg}};
+        return format_result{cts_t<Fmt>{}, tuple{arg}};
     }
 }
 
@@ -188,10 +191,9 @@ concept ct_format_compatible = requires {
 
 template <ct_string Fmt> struct fmt_data {
     constexpr static auto fmt = std::string_view{Fmt};
-    constexpr static auto N = detail::count_specifiers(fmt);
-    constexpr static auto splits = detail::split_specifiers<N + 1>(fmt);
-    constexpr static auto last_cts =
-        detail::to_ct_string<splits[N].size()>(splits[N]);
+    constexpr static auto N = count_specifiers(fmt);
+    constexpr static auto splits = split_specifiers<N + 1>(fmt);
+    constexpr static auto last_cts = to_ct_string<splits[N].size()>(splits[N]);
 };
 } // namespace detail
 
@@ -207,13 +209,15 @@ constexpr auto ct_format = [](auto &&...args) {
     [[maybe_unused]] auto const format1 = [&]<std::size_t I>(auto &&arg) {
         constexpr auto cts =
             detail::to_ct_string<data::splits[I].size()>(data::splits[I]);
-        return detail::format1<cts, Output>(FWD(arg));
+        return detail::format1<cts>(FWD(arg));
     };
 
-    return [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+    auto const result = [&]<std::size_t... Is>(std::index_sequence<Is...>) {
         return (format1.template operator()<Is>(FWD(args)) + ... +
-                detail::convert_output<data::last_cts, Output>());
+                format_result{cts_t<data::last_cts>{}});
     }(std::make_index_sequence<data::N>{});
+    return format_result{detail::convert_output<result.str.value, Output>(),
+                         result.args};
 };
 } // namespace v1
 } // namespace stdx

--- a/include/stdx/ct_string.hpp
+++ b/include/stdx/ct_string.hpp
@@ -114,7 +114,7 @@ operator+(ct_string<N> const &lhs,
     return ret;
 }
 
-template <stdx::ct_string S> struct cts_t {
+template <ct_string S> struct cts_t {
     constexpr static auto value = S;
 };
 

--- a/include/stdx/ct_string.hpp
+++ b/include/stdx/ct_string.hpp
@@ -128,6 +128,8 @@ constexpr auto operator+(cts_t<X>, cts_t<Y>) {
     return cts_t<X + Y>{};
 }
 
+template <ct_string Value> CONSTEVAL auto ct() { return cts_t<Value>{}; }
+
 inline namespace literals {
 inline namespace ct_string_literals {
 template <ct_string S> CONSTEVAL auto operator""_cts() { return S; }

--- a/include/stdx/ct_string.hpp
+++ b/include/stdx/ct_string.hpp
@@ -58,10 +58,6 @@ template <std::size_t N> struct ct_string {
     std::array<char, N> value{};
 };
 
-template <stdx::ct_string S> struct cts_t {
-    constexpr static auto value = S;
-};
-
 template <std::size_t N, std::size_t M>
 [[nodiscard]] constexpr auto operator==(ct_string<N> const &lhs,
                                         ct_string<M> const &rhs) -> bool {
@@ -118,9 +114,25 @@ operator+(ct_string<N> const &lhs,
     return ret;
 }
 
+template <stdx::ct_string S> struct cts_t {
+    constexpr static auto value = S;
+};
+
+template <ct_string X, ct_string Y>
+constexpr auto operator==(cts_t<X>, cts_t<Y>) -> bool {
+    return X == Y;
+}
+
+template <ct_string X, ct_string Y>
+constexpr auto operator+(cts_t<X>, cts_t<Y>) {
+    return cts_t<X + Y>{};
+}
+
 inline namespace literals {
 inline namespace ct_string_literals {
 template <ct_string S> CONSTEVAL auto operator""_cts() { return S; }
+
+template <ct_string S> CONSTEVAL auto operator""_ctst() { return cts_t<S>{}; }
 } // namespace ct_string_literals
 } // namespace literals
 } // namespace v1

--- a/include/stdx/static_assert.hpp
+++ b/include/stdx/static_assert.hpp
@@ -31,7 +31,7 @@ template <ct_string Fmt, auto... Args> constexpr auto static_format() {
             return CX_VALUE(V);
         }
     };
-    return ct_format<Fmt>(make_ct.template operator()<Args>()...);
+    return ct_format<Fmt>(make_ct.template operator()<Args>()...).str.value;
 }
 } // namespace detail
 

--- a/include/stdx/utility.hpp
+++ b/include/stdx/utility.hpp
@@ -192,6 +192,11 @@ constexpr auto is_aligned_with = [](auto v) -> bool {
         return (static_cast<std::uintptr_t>(v) & mask) == 0;
     }
 };
+
+template <auto Value> CONSTEVAL auto ct() {
+    return std::integral_constant<decltype(Value), Value>{};
+}
+template <typename T> CONSTEVAL auto ct() { return type_identity<T>{}; }
 } // namespace v1
 } // namespace stdx
 

--- a/test/ct_format.cpp
+++ b/test/ct_format.cpp
@@ -34,7 +34,8 @@ TEST_CASE("format a static string", "[ct_format]") {
     static_assert(stdx::ct_format<"Hello">() == "Hello"_fmt_res);
 }
 
-TEST_CASE("format a compile-time stringish argument", "[ct_format]") {
+TEST_CASE("format a compile-time stringish argument (CX_VALUE)",
+          "[ct_format]") {
     using namespace std::string_view_literals;
     static_assert(stdx::ct_format<"Hello {}">(CX_VALUE("world"sv)) ==
                   "Hello world"_fmt_res);
@@ -44,13 +45,31 @@ TEST_CASE("format a compile-time stringish argument", "[ct_format]") {
                   "Hello world"_fmt_res);
 }
 
-TEST_CASE("format a compile-time integral argument", "[ct_format]") {
+TEST_CASE("format a compile-time stringish argument (ct)", "[ct_format]") {
+    using namespace std::string_view_literals;
+    static_assert(stdx::ct_format<"Hello {}">("world"_ctst) ==
+                  "Hello world"_fmt_res);
+    static_assert(stdx::ct_format<"Hello {}">(stdx::ct<"world">()) ==
+                  "Hello world"_fmt_res);
+}
+
+TEST_CASE("format a compile-time integral argument (CX_VALUE)", "[ct_format]") {
     static_assert(stdx::ct_format<"Hello {}">(CX_VALUE(42)) ==
                   "Hello 42"_fmt_res);
 }
 
-TEST_CASE("format a type argument", "[ct_format]") {
+TEST_CASE("format a compile-time integral argument (ct)", "[ct_format]") {
+    static_assert(stdx::ct_format<"Hello {}">(stdx::ct<42>()) ==
+                  "Hello 42"_fmt_res);
+}
+
+TEST_CASE("format a type argument (CX_VALUE)", "[ct_format]") {
     static_assert(stdx::ct_format<"Hello {}">(CX_VALUE(int)) ==
+                  "Hello int"_fmt_res);
+}
+
+TEST_CASE("format a type argument (ct)", "[ct_format]") {
+    static_assert(stdx::ct_format<"Hello {}">(stdx::ct<int>()) ==
                   "Hello int"_fmt_res);
 }
 
@@ -63,8 +82,13 @@ namespace {
 enum struct E { A };
 }
 
-TEST_CASE("format a compile-time enum argument", "[ct_format]") {
+TEST_CASE("format a compile-time enum argument (CX_VALUE)", "[ct_format]") {
     static_assert(stdx::ct_format<"Hello {}">(CX_VALUE(E::A)) ==
+                  "Hello A"_fmt_res);
+}
+
+TEST_CASE("format a compile-time enum argument (ct)", "[ct_format]") {
+    static_assert(stdx::ct_format<"Hello {}">(stdx::ct<E::A>()) ==
                   "Hello A"_fmt_res);
 }
 

--- a/test/ct_format.cpp
+++ b/test/ct_format.cpp
@@ -31,31 +31,32 @@ TEST_CASE("split format string by specifiers", "[ct_format]") {
 }
 
 TEST_CASE("format a static string", "[ct_format]") {
-    static_assert(stdx::ct_format<"Hello">() == "Hello"_cts);
+    static_assert(stdx::ct_format<"Hello">() == "Hello"_fmt_res);
 }
 
 TEST_CASE("format a compile-time stringish argument", "[ct_format]") {
     using namespace std::string_view_literals;
     static_assert(stdx::ct_format<"Hello {}">(CX_VALUE("world"sv)) ==
-                  "Hello world"_cts);
+                  "Hello world"_fmt_res);
     static_assert(stdx::ct_format<"Hello {}">(CX_VALUE("world"_cts)) ==
-                  "Hello world"_cts);
+                  "Hello world"_fmt_res);
     static_assert(stdx::ct_format<"Hello {}">(CX_VALUE("world")) ==
-                  "Hello world"_cts);
+                  "Hello world"_fmt_res);
 }
 
 TEST_CASE("format a compile-time integral argument", "[ct_format]") {
-    static_assert(stdx::ct_format<"Hello {}">(CX_VALUE(42)) == "Hello 42"_cts);
+    static_assert(stdx::ct_format<"Hello {}">(CX_VALUE(42)) ==
+                  "Hello 42"_fmt_res);
 }
 
 TEST_CASE("format a type argument", "[ct_format]") {
     static_assert(stdx::ct_format<"Hello {}">(CX_VALUE(int)) ==
-                  "Hello int"_cts);
+                  "Hello int"_fmt_res);
 }
 
 TEST_CASE("format a compile-time argument with fmt spec", "[ct_format]") {
     static_assert(stdx::ct_format<"Hello {:*>#6x}">(CX_VALUE(42)) ==
-                  "Hello **0x2a"_cts);
+                  "Hello **0x2a"_fmt_res);
 }
 
 namespace {
@@ -63,36 +64,38 @@ enum struct E { A };
 }
 
 TEST_CASE("format a compile-time enum argument", "[ct_format]") {
-    static_assert(stdx::ct_format<"Hello {}">(CX_VALUE(E::A)) == "Hello A"_cts);
+    static_assert(stdx::ct_format<"Hello {}">(CX_VALUE(E::A)) ==
+                  "Hello A"_fmt_res);
 }
 
 TEST_CASE("format a runtime argument", "[ct_format]") {
-    auto x = 17;
-    CHECK(stdx::ct_format<"Hello {}">(x) ==
-          stdx::format_result{"Hello {}"_cts, stdx::make_tuple(17)});
-    static_assert(stdx::ct_format<"Hello {}">(17) ==
-                  stdx::format_result{"Hello {}"_cts, stdx::make_tuple(17)});
+    constexpr auto x = 17;
+    constexpr auto expected =
+        stdx::format_result{"Hello {}"_ctst, stdx::make_tuple(x)};
+
+    CHECK(stdx::ct_format<"Hello {}">(x) == expected);
+    static_assert(stdx::ct_format<"Hello {}">(x) == expected);
 }
 
 TEST_CASE("format a compile-time and a runtime argument (1)", "[ct_format]") {
-    auto x = 17;
-    CHECK(stdx::ct_format<"Hello {} {}">(CX_VALUE(int), x) ==
-          stdx::format_result{"Hello int {}"_cts, stdx::make_tuple(17)});
-    static_assert(
-        stdx::ct_format<"Hello {} {}">(CX_VALUE(int), 17) ==
-        stdx::format_result{"Hello int {}"_cts, stdx::make_tuple(17)});
+    constexpr auto x = 17;
+    constexpr auto expected =
+        stdx::format_result{"Hello int {}"_ctst, stdx::make_tuple(x)};
+
+    CHECK(stdx::ct_format<"Hello {} {}">(CX_VALUE(int), x) == expected);
+    static_assert(stdx::ct_format<"Hello {} {}">(CX_VALUE(int), x) == expected);
 }
 
 TEST_CASE("format a compile-time and a runtime argument (2)", "[ct_format]") {
     static_assert(
         stdx::ct_format<"Hello {} {}">(42, CX_VALUE(int)) ==
-        stdx::format_result{"Hello {} int"_cts, stdx::make_tuple(42)});
+        stdx::format_result{"Hello {} int"_ctst, stdx::make_tuple(42)});
 }
 
 TEST_CASE("format multiple runtime arguments", "[ct_format]") {
     static_assert(
         stdx::ct_format<"Hello {} {}">(42, 17) ==
-        stdx::format_result{"Hello {} {}"_cts, stdx::make_tuple(42, 17)});
+        stdx::format_result{"Hello {} {}"_ctst, stdx::make_tuple(42, 17)});
 }
 
 TEST_CASE("format multiple mixed arguments", "[ct_format]") {
@@ -100,25 +103,25 @@ TEST_CASE("format multiple mixed arguments", "[ct_format]") {
     auto b = "B"sv;
     CHECK(stdx::ct_format<"Hello {} {} {} {} world">(42, CX_VALUE("A"sv), b,
                                                      CX_VALUE(int)) ==
-          stdx::format_result{"Hello {} A {} int world"_cts,
+          stdx::format_result{"Hello {} A {} int world"_ctst,
                               stdx::make_tuple(42, "B"sv)});
     static_assert(stdx::ct_format<"Hello {} {} {} {} world">(
                       42, CX_VALUE("A"sv), "B"sv, CX_VALUE(int)) ==
-                  stdx::format_result{"Hello {} A {} int world"_cts,
+                  stdx::format_result{"Hello {} A {} int world"_ctst,
                                       stdx::make_tuple(42, "B"sv)});
 }
 
 TEST_CASE("format a formatted string", "[ct_format]") {
     static_assert(stdx::ct_format<"The value is {}.">(
                       CX_VALUE(stdx::ct_format<"(year={})">(2022))) ==
-                  stdx::format_result{"The value is (year={})."_cts,
+                  stdx::format_result{"The value is (year={})."_ctst,
                                       stdx::make_tuple(2022)});
 }
 
 TEST_CASE("format a ct-formatted string", "[ct_format]") {
     constexpr static auto cts = stdx::ct_format<"(year={})">(CX_VALUE(2024));
     static_assert(stdx::ct_format<"The value is {}.">(CX_VALUE(cts)) ==
-                  "The value is (year=2024)."_cts);
+                  "The value is (year=2024)."_fmt_res);
 }
 
 namespace {
@@ -139,7 +142,7 @@ template <class T, T... Ls, T... Rs>
 TEST_CASE("format_to a different type", "[ct_format]") {
     using namespace std::string_view_literals;
     static_assert(stdx::ct_format<"{}", string_constant>(CX_VALUE("A"sv)) ==
-                  string_constant<char, 'A'>{});
+                  stdx::format_result{string_constant<char, 'A'>{}});
 
     auto x = 17;
     CHECK(stdx::ct_format<"{}", string_constant>(x) ==
@@ -152,7 +155,7 @@ TEST_CASE("format_to a different type", "[ct_format]") {
 
 TEST_CASE("format a string-type argument", "[ct_format]") {
     static_assert(stdx::ct_format<"Hello {}!">(string_constant<char, 'A'>{}) ==
-                  "Hello A!"_cts);
+                  "Hello A!"_fmt_res);
 }
 
 TEST_CASE("format a formatted string with different type", "[ct_format]") {
@@ -168,7 +171,8 @@ TEST_CASE("format a ct-formatted string with different type", "[ct_format]") {
         stdx::ct_format<"B{}C", string_constant>(CX_VALUE(2024));
     static_assert(
         stdx::ct_format<"A{}D", string_constant>(CX_VALUE(cts)) ==
-        string_constant<char, 'A', 'B', '2', '0', '2', '4', 'C', 'D'>{});
+        stdx::format_result{
+            string_constant<char, 'A', 'B', '2', '0', '2', '4', 'C', 'D'>{}});
 }
 
 TEST_CASE("format multiple mixed arguments with different type",

--- a/test/ct_string.cpp
+++ b/test/ct_string.cpp
@@ -136,3 +136,9 @@ TEST_CASE("wrap ct_string in type", "[ct_string]") {
     using S = stdx::cts_t<"Hello">;
     static_assert(S::value == "Hello"_cts);
 }
+
+TEST_CASE("ct (ct_string)", "[ct_string]") {
+    using namespace stdx::ct_string_literals;
+    constexpr auto v = stdx::ct<"Hello">();
+    static_assert(v == "Hello"_ctst);
+}

--- a/test/utility.cpp
+++ b/test/utility.cpp
@@ -203,3 +203,39 @@ TEST_CASE("is_aligned_with (pointer)", "[utility]") {
     CHECK(stdx::is_aligned_with<std::uint16_t>(p));
     CHECK(stdx::is_aligned_with<std::uint32_t>(p));
 }
+
+TEST_CASE("ct (integral)", "[utility]") {
+    constexpr auto vs = stdx::ct<42>();
+    static_assert(
+        std::is_same_v<decltype(vs), std::integral_constant<int, 42> const>);
+    constexpr auto vu = stdx::ct<42u>();
+    static_assert(
+        std::is_same_v<decltype(vu),
+                       std::integral_constant<unsigned int, 42> const>);
+}
+
+TEST_CASE("ct (bool)", "[utility]") {
+    constexpr auto v = stdx::ct<true>();
+    static_assert(std::is_same_v<decltype(v), std::bool_constant<true> const>);
+}
+
+TEST_CASE("ct (char)", "[utility]") {
+    constexpr auto v = stdx::ct<'A'>();
+    static_assert(
+        std::is_same_v<decltype(v), std::integral_constant<char, 'A'> const>);
+}
+
+namespace {
+enum struct E { A, B, C };
+}
+
+TEST_CASE("ct (enum)", "[utility]") {
+    constexpr auto v = stdx::ct<E::A>();
+    static_assert(
+        std::is_same_v<decltype(v), std::integral_constant<E, E::A> const>);
+}
+
+TEST_CASE("ct (type)", "[utility]") {
+    constexpr auto v = stdx::ct<int>();
+    static_assert(std::is_same_v<decltype(v), stdx::type_identity<int> const>);
+}


### PR DESCRIPTION
Problem:
- `ct_format` produces a type that is either a `ct_string` or a `format_result`, which means all client code needs to check that.
- `ct_format` works at compile-time but produces a string value that may lose its `constexpr` nature, so can't be put into a type.

Solution:
- Always return a `format_result` (possibly with an empty tuple).
- Wrap the returned `ct_string` in a type.