### PR TITLE
STATIC_PROOF fails compilation of a condition can't be proven

### DIFF
--- a/include/stdx/static_assert.hpp
+++ b/include/stdx/static_assert.hpp
@@ -46,3 +46,6 @@ template <ct_string Fmt, auto... Args> constexpr auto static_format() {
     }.template operator()<cond>()
 
 #endif
+
+#define STATIC_PROOF(cond) \
+    if (not (cond)) asm("compiler cannot prove (" #cond ") is always true");


### PR DESCRIPTION
Sometimes it is nice to require a condition to be proven at compile-time even though the exact value is not known at compile-time. STATIC_PROOF does this.

https://godbolt.org/z/9eG3f9vxa