### PR TITLE
:bug: Fix ambiguity with `ct`

### DIFF
--- a/include/stdx/ct_string.hpp
+++ b/include/stdx/ct_string.hpp
@@ -3,6 +3,7 @@
 #if __cplusplus >= 202002L
 
 #include <stdx/compiler.hpp>
+#include <stdx/utility.hpp>
 
 #include <array>
 #include <cstddef>
@@ -127,6 +128,10 @@ template <ct_string X, ct_string Y>
 constexpr auto operator+(cts_t<X>, cts_t<Y>) {
     return cts_t<X + Y>{};
 }
+
+namespace detail {
+template <std::size_t N> struct ct_helper<ct_string<N>>;
+} // namespace detail
 
 template <ct_string Value> CONSTEVAL auto ct() { return cts_t<Value>{}; }
 

--- a/include/stdx/utility.hpp
+++ b/include/stdx/utility.hpp
@@ -193,10 +193,23 @@ constexpr auto is_aligned_with = [](auto v) -> bool {
     }
 };
 
-template <auto Value> CONSTEVAL auto ct() {
-    return std::integral_constant<decltype(Value), Value>{};
+#if __cplusplus >= 202002L
+
+namespace detail {
+template <typename T> struct ct_helper {
+    // NOLINTNEXTLINE(google-explicit-constructor)
+    CONSTEVAL ct_helper(T t) : value(t) {}
+    T value;
+};
+template <typename T> ct_helper(T) -> ct_helper<T>;
+} // namespace detail
+
+template <detail::ct_helper Value> CONSTEVAL auto ct() {
+    return std::integral_constant<decltype(Value.value), Value.value>{};
 }
 template <typename T> CONSTEVAL auto ct() { return type_identity<T>{}; }
+
+#endif
 } // namespace v1
 } // namespace stdx
 

--- a/test/ct_string.cpp
+++ b/test/ct_string.cpp
@@ -139,6 +139,8 @@ TEST_CASE("wrap ct_string in type", "[ct_string]") {
 
 TEST_CASE("ct (ct_string)", "[ct_string]") {
     using namespace stdx::ct_string_literals;
-    constexpr auto v = stdx::ct<"Hello">();
-    static_assert(v == "Hello"_ctst);
+    constexpr auto v1 = stdx::ct<"Hello">();
+    static_assert(v1 == "Hello"_ctst);
+    constexpr auto v2 = stdx::ct<"Hello"_cts>();
+    static_assert(v2 == "Hello"_ctst);
 }

--- a/test/utility.cpp
+++ b/test/utility.cpp
@@ -204,6 +204,8 @@ TEST_CASE("is_aligned_with (pointer)", "[utility]") {
     CHECK(stdx::is_aligned_with<std::uint32_t>(p));
 }
 
+#if __cplusplus >= 202002L
+
 TEST_CASE("ct (integral)", "[utility]") {
     constexpr auto vs = stdx::ct<42>();
     static_assert(
@@ -239,3 +241,5 @@ TEST_CASE("ct (type)", "[utility]") {
     constexpr auto v = stdx::ct<int>();
     static_assert(std::is_same_v<decltype(v), stdx::type_identity<int> const>);
 }
+
+#endif


### PR DESCRIPTION
Problem:
- `ct` must use a function template to obtain overloads for both type template parameters and NTTPs. However when using `ct` with an NTTP placeholder type there is an ambiguity if the NTTP is not deduced: both the `auto` overload and the `ct_string` overloads match.

Solution:
- Introduce another NTTP placeholder type, `ct_helper` that can be partially specialized without definition to disable the primary template specialization.