### PR TITLE
:art: Allow implicit conversion of `format_result` to `ct_string`

### DIFF
--- a/.github/workflows/asciidoctor-ghpages.yml
+++ b/.github/workflows/asciidoctor-ghpages.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Install Mermaid
         run: |
-          sudo npm install -g @mermaid-js/mermaid-cli@11.2.1
+          npm install -g @mermaid-js/mermaid-cli@11.4.2
           npx puppeteer browsers install chrome-headless-shell
 
       - name: Install asciidoctor

--- a/include/stdx/ct_format.hpp
+++ b/include/stdx/ct_format.hpp
@@ -31,6 +31,9 @@ struct fmt::formatter<stdx::ct_string<N>> : fmt::formatter<std::string_view> {
 namespace stdx {
 inline namespace v1 {
 template <typename Str, typename Args> struct format_result {
+    CONSTEVAL static auto
+    ct_string_convertible() -> std::bool_constant<Args::size() == 0>;
+
     [[no_unique_address]] Str str;
     [[no_unique_address]] Args args{};
 

--- a/test/ct_format.cpp
+++ b/test/ct_format.cpp
@@ -143,6 +143,23 @@ TEST_CASE("format a format result", "[ct_format]") {
 }
 
 namespace {
+template <stdx::ct_string> constexpr auto conversion_success = true;
+} // namespace
+
+TEST_CASE("empty format_result can implicitly convert to ct_string",
+          "[ct_format]") {
+    using namespace std::string_view_literals;
+    static_assert(
+        stdx::detail::format_convertible<decltype(stdx::ct_format<"Hello">())>);
+    static_assert(stdx::detail::format_convertible<
+                  decltype(stdx::ct_format<"Hello {}">("world"_ctst))>);
+    static_assert(not stdx::detail::format_convertible<
+                  decltype(stdx::ct_format<"Hello {}">(42))>);
+
+    static_assert(conversion_success<stdx::ct_format<"Hello">()>);
+}
+
+namespace {
 template <typename T, T...> struct string_constant {
   private:
     friend constexpr auto operator==(string_constant const &,


### PR DESCRIPTION
Problem:
- `ct_format` produces a `format_result` in all cases. In some cases the runtime argument tuple is empty and it is convenient to be able to convert implicitly to a `ct_string`.

Solution:
- Allow implicit conversion from a `format_result` to a `ct_string` in the case where there are no runtime arguments and the `format_result` contains only a `ct_string`.