### PR TITLE
:sparkles: Add `transform_reduce` on bitset

### DIFF
--- a/docs/bitset.adoc
+++ b/docs/bitset.adoc
@@ -103,3 +103,12 @@ objects, `lowest_unset` is also provided:
 auto bs = stdx::bitset<8>{0b11'0111ul};
 auto i = bs.lowest_unset(); // i == 3
 ----
+
+`transform_reduce` is also provided for bitsets:
+[source,cpp]
+----
+auto bs = stdx::bitset<8>{0b1010'1010ul};
+auto result = transform_reduce([](auto i) { return i * 2 },
+                               std::plus{}, std::size_t{}, bs);
+// result is 1*2 + 3*2 + 5*2 + 7*2
+----

--- a/test/bitset.cpp
+++ b/test/bitset.cpp
@@ -331,6 +331,20 @@ TEMPLATE_TEST_CASE("for_each iterates in order lsb to msb", "[bitset]",
     CHECK(result == bs);
 }
 
+TEMPLATE_TEST_CASE("transform_reduce", "[bitset]", std::uint8_t, std::uint16_t,
+                   std::uint32_t, std::uint64_t) {
+    constexpr auto bs = stdx::bitset<8, TestType>{0b10101010ul};
+    int calls{};
+    auto const result = transform_reduce(
+        [&](auto i) {
+            ++calls;
+            return i == 3 and calls == 2;
+        },
+        std::logical_or{}, false, bs);
+    CHECK(result);
+    CHECK(calls == bs.count());
+}
+
 TEMPLATE_TEST_CASE("set range of bits (lsb, length)", "[bitset]", std::uint8_t,
                    std::uint16_t, std::uint32_t, std::uint64_t) {
     using namespace stdx::literals;


### PR DESCRIPTION
Problem:
- It is relatively common to want to do for_each on a bitset, but also capture whether or not the action succeeded at all, e.g. when handling a message with an indexed handler.

Solution:
- Add `transform_reduce` on bitset.

Note:
- Both `for_each` and `transform_reduce` are applicable variadically, however this is not yet implemented. But this is the reason that the bitset is the final argument.
- There are some differences (for the better) from the `std::transform_reduce` API.
  - The transform function comes before the reduction function. `std::transform_reduce` is confusing, because the transform happens first but is given second.
  - The type of the `init` value can be easily given in a template argument; this is helpful for avoiding warnings when passing `0` (an `int`) to accumulate potentially larger integral types.