### PR TITLE
:art: Preserve enum values in bitset `for_each`

### DIFF
--- a/test/bitset.cpp
+++ b/test/bitset.cpp
@@ -474,6 +474,17 @@ TEST_CASE("use bitset with enum struct (place_bits construct)", "[bitset]") {
     static_assert(bs.to_natural() == 1);
 }
 
+TEST_CASE("use bitset with enum struct (for_each)", "[bitset]") {
+    constexpr auto bs = stdx::bitset<Bits::MAX>{stdx::all_bits};
+    for_each([](Bits) {}, bs);
+}
+
+TEST_CASE("use bitset with enum struct (transform_reduce)", "[bitset]") {
+    constexpr auto bs = stdx::bitset<Bits::MAX>{stdx::all_bits};
+    CHECK(transform_reduce([](Bits) { return true; }, std::logical_or{}, false,
+                           bs));
+}
+
 #if __cplusplus >= 202002L
 TEST_CASE("construct with a ct_string", "[bitset]") {
     using namespace stdx::literals;


### PR DESCRIPTION
When using a `bitset` with an `enum`, it makes sense that the function passed to `for_each` should take an `enum` value.