### PR TITLE
:sparkles: Support C++26 `static_assert`

### DIFF
--- a/include/stdx/static_assert.hpp
+++ b/include/stdx/static_assert.hpp
@@ -38,6 +38,14 @@ template <ct_string Fmt, auto... Args> constexpr auto static_format() {
 } // namespace v1
 } // namespace stdx
 
+#if __cpp_static_assert >= 202306L
+#define STATIC_ASSERT(cond, ...)                                               \
+    []<bool B>() -> bool {                                                     \
+        static_assert(                                                         \
+            B, std::string_view{stdx::detail::static_format<__VA_ARGS__>()});  \
+        return B;                                                              \
+    }.template operator()<cond>()
+#else
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define STATIC_ASSERT(cond, ...)                                                       \
     []<bool B>() -> bool {                                                             \
@@ -45,4 +53,5 @@ template <ct_string Fmt, auto... Args> constexpr auto static_format() {
         return B;                                                                      \
     }.template operator()<cond>()
 
+#endif
 #endif

--- a/test/fail/CMakeLists.txt
+++ b/test/fail/CMakeLists.txt
@@ -32,6 +32,16 @@ function(add_formatted_error_tests)
     add_fail_tests(static_assert_format)
 endfunction()
 
+function(add_26_formatted_error_tests)
+    add_compile_fail_test("static_assert.cpp" NAME static_assert_26 LIBRARIES
+                          stdx)
+    add_compile_fail_test("static_assert_format.cpp" NAME
+                          static_assert_format_26 LIBRARIES stdx)
+    target_compile_features(EXPECT_FAIL.static_assert_26 PRIVATE cxx_std_26)
+    target_compile_features(EXPECT_FAIL.static_assert_format_26
+                            PRIVATE cxx_std_26)
+endfunction()
+
 if(${CMAKE_CXX_STANDARD} GREATER_EQUAL 20)
     if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang"
        AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL 15)
@@ -40,6 +50,10 @@ if(${CMAKE_CXX_STANDARD} GREATER_EQUAL 20)
     if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU" AND ${CMAKE_CXX_COMPILER_VERSION}
                                                    VERSION_GREATER_EQUAL 13.2)
         add_formatted_error_tests()
+    endif()
+
+    if("cxx_std_26" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+        add_26_formatted_error_tests()
     endif()
 
     add_fail_tests(


### PR DESCRIPTION
Problem:
- `STATIC_ASSERT` before C++26 relies on some interesting compiler behaviour; although it gives the right message, it's not obvious in the compilation output.

- When C++26 `static_assert` is available, use that. The resulting compiler output is typically much more straightforward.