### PR TITLE
:arrow_up: Update libfmt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ else()
 endif()
 
 add_versioned_package("gh:boostorg/mp11#boost-1.83.0")
-fmt_recipe(10.2.1)
+fmt_recipe(11.1.3)
 add_versioned_package("gh:intel/cpp-baremetal-concurrency#06e5901")
 
 if(NOT DEFINED CMAKE_CXX_STANDARD)

--- a/include/stdx/ct_format.hpp
+++ b/include/stdx/ct_format.hpp
@@ -19,17 +19,12 @@
 #include <string_view>
 #include <utility>
 
-template <std::size_t N>
-struct fmt::formatter<stdx::ct_string<N>> : fmt::formatter<std::string_view> {
-    template <typename Ctx>
-    constexpr auto format(stdx::ct_string<N> const &s, Ctx &ctx) const {
-        return fmt::formatter<std::string_view>::format(std::string_view{s},
-                                                        ctx);
-    }
-};
-
 namespace stdx {
 inline namespace v1 {
+template <std::size_t N> constexpr auto format_as(stdx::ct_string<N> const &s) {
+    return std::string_view{s};
+}
+
 template <typename Str, typename Args> struct format_result {
     CONSTEVAL static auto
     ct_string_convertible() -> std::bool_constant<Args::size() == 0>;


### PR DESCRIPTION
Problem:
- Specializing `fmt::formatter` is a lot of boilerplate. It also involves more template instantiations than necessary.

Solution:
- Use `format_as` instead. An overload found by ADL that compiles faster than instantiating formatter templates.