### PR TITLE
:sparkles: Add useful things for environment handling

### DIFF
--- a/test/env.cpp
+++ b/test/env.cpp
@@ -21,11 +21,6 @@ TEST_CASE("lookup query with default", "[env]") {
     static_assert(custom(stdx::env<>{}) == 42);
 }
 
-TEST_CASE("lookup with single-value prop", "[env]") {
-    using E = stdx::ct_prop<custom, 17>;
-    static_assert(custom(E{}) == 17);
-}
-
 TEST_CASE("make an environment", "[env]") {
     using E = stdx::make_env_t<custom, 17>;
     static_assert(custom(E{}) == 17);
@@ -37,8 +32,21 @@ TEST_CASE("extend an environment", "[env]") {
     static_assert(custom(E2{}) == 18);
 }
 
+TEST_CASE("append an environment", "[env]") {
+    using E1 = stdx::make_env_t<custom, 17>;
+    using E2 = stdx::make_env_t<custom, 18>;
+    using E3 = stdx::make_env_t<custom, 19>;
+    using E = stdx::append_env_t<E1, E2, E3>;
+    static_assert(custom(E{}) == 19);
+}
+
 TEST_CASE("environment converts string literals to ct_string", "[env]") {
     using namespace stdx::literals;
     using E = stdx::make_env_t<custom, "hello">;
     static_assert(custom(E{}) == "hello"_cts);
+}
+
+TEST_CASE("envlike concept", "[env]") {
+    static_assert(stdx::envlike<stdx::env<>>);
+    static_assert(stdx::envlike<stdx::make_env_t<custom, 17>>);
 }


### PR DESCRIPTION
Problem:
- There is no way to override one environment with another.
- There is no concept to identify an environment type.

Solution:
- Add `append_env_t`.
- Add `envlike`.