### PR TITLE
:sparkles: Add `nth_t` and `nth_v`

### DIFF
--- a/docs/type_traits.adoc
+++ b/docs/type_traits.adoc
@@ -155,6 +155,26 @@ NOTE: Detecting structurality of a type is not yet possible in the general case,
 so there are certain structural types for which this trait will be `false`. In
 practice those types should be rare, and there should be no false positives.
 
+=== `nth_t`
+
+`nth_t` is a type alias that extracts the nth element from a pack of types (starting at 0 of course):
+
+[source,cpp]
+----
+// nth_t<Index, Ts...>
+static_assert(std::is_same_v<stdx::nth_t<1, int, float, bool>, float>);
+----
+
+=== `nth_v`
+
+`nth_v` is a `constexpr` variable template that extracts the nth element from a pack of values (starting at 0 of course):
+
+[source,cpp]
+----
+// nth_v<Index, Vs...>
+static_assert(stdx::nth_v<1, 6, 28, 496> == 28);
+----
+
 === `template_for_each`
 
 A xref:type_traits.adoc#_type_list_and_value_list[`type_list` or a `value_list`]

--- a/include/stdx/env.hpp
+++ b/include/stdx/env.hpp
@@ -34,7 +34,7 @@ template <typename... Envs> struct env {
     CONSTEVAL static auto query(Q) noexcept {
         using I = boost::mp11::mp_find_if_q<boost::mp11::mp_list<Envs...>,
                                             _env::has_query<Q>>;
-        using E = boost::mp11::mp_at<boost::mp11::mp_list<Envs...>, I>;
+        using E = nth_t<I::value, Envs...>;
         return Q{}(E{});
     }
 };
@@ -61,18 +61,11 @@ template <std::size_t N> struct autowrap<str_lit_t<N>> {
 template <typename T> autowrap(T) -> autowrap<T>;
 template <std::size_t N> autowrap(str_lit_t<N>) -> autowrap<str_lit_t<N>>;
 
-template <auto V> struct wrap {
-    constexpr static auto value = V;
-};
-
 template <typename> struct for_each_pair;
 template <std::size_t... Is> struct for_each_pair<std::index_sequence<Is...>> {
     template <auto... Args>
-    using type = env<
-        _env::ct_prop<boost::mp11::mp_at_c<boost::mp11::mp_list<wrap<Args>...>,
-                                           2 * Is>::value.value,
-                      boost::mp11::mp_at_c<boost::mp11::mp_list<wrap<Args>...>,
-                                           (2 * Is) + 1>::value.value>...>;
+    using type = env<ct_prop<nth_v<2 * Is, Args...>.value,
+                             nth_v<(2 * Is) + 1, Args...>.value>...>;
 };
 
 template <envlike Env = env<>>

--- a/include/stdx/function_traits.hpp
+++ b/include/stdx/function_traits.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <stdx/type_traits.hpp>
+
 #include <boost/mp11/algorithm.hpp>
 #include <boost/mp11/utility.hpp>
 
@@ -21,11 +23,8 @@ struct function_traits<std::function<R(Args...)>> {
     using decayed_args = List<std::decay_t<Args>...>;
     using arity = std::integral_constant<std::size_t, sizeof...(Args)>;
 
-    template <auto N>
-    using nth_arg = boost::mp11::mp_at_c<args<boost::mp11::mp_list>, N>;
-    template <auto N>
-    using decayed_nth_arg =
-        boost::mp11::mp_at_c<decayed_args<boost::mp11::mp_list>, N>;
+    template <auto N> using nth_arg = nth_t<N, Args...>;
+    template <auto N> using decayed_nth_arg = std::decay_t<nth_arg<N>>;
 };
 } // namespace detail
 

--- a/test/type_traits.cpp
+++ b/test/type_traits.cpp
@@ -258,3 +258,14 @@ TEST_CASE("type shrinkage", "[type_traits]") {
     static_assert(std::same_as<stdx::expand_t<X>, C>);
 }
 #endif
+
+TEST_CASE("nth type in pack", "[type_traits]") {
+    static_assert(
+        std::is_same_v<stdx::nth_t<2, bool, char, float, int>, float>);
+}
+
+#if __cplusplus >= 202002L
+TEST_CASE("nth value in pack", "[type_traits]") {
+    static_assert(stdx::nth_v<2, 0, true, 'b', 3> == 'b');
+}
+#endif


### PR DESCRIPTION
Problem:
- It's annoying to make a type list just to index into it.
- Boost.MP11 doesn't provide `mp_at` that works on value lists.

Solution:
- Introduce `nth_t<Index, Ts...>` and `nth_v<Index, Vs...>` to give the nth type or value of a pack respectively.