### PR TITLE
:art: Keep environment types as small as possible

### DIFF
--- a/test/env.cpp
+++ b/test/env.cpp
@@ -1,6 +1,7 @@
 #include <stdx/ct_string.hpp>
 #include <stdx/env.hpp>
 
+#include <boost/mp11/algorithm.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 namespace {
@@ -49,4 +50,26 @@ TEST_CASE("environment converts string literals to ct_string", "[env]") {
 TEST_CASE("envlike concept", "[env]") {
     static_assert(stdx::envlike<stdx::env<>>);
     static_assert(stdx::envlike<stdx::make_env_t<custom, 17>>);
+}
+
+namespace {
+template <typename Q> struct match_query {
+    template <typename T> using fn = std::is_same<Q, typename T::query_t>;
+};
+} // namespace
+
+TEST_CASE("extending environment doesn't create duplicate keys", "[env]") {
+    using E1 = stdx::make_env_t<custom, 17>;
+    using E2 = stdx::extend_env_t<E1, custom, 18>;
+    static_assert(
+        boost::mp11::mp_count_if_q<E2, match_query<custom_t>>::value == 1);
+}
+
+TEST_CASE("appending environment doesn't create duplicate keys", "[env]") {
+    using E1 = stdx::make_env_t<custom, 17>;
+    using E2 = stdx::make_env_t<custom, 18>;
+    using E3 = stdx::make_env_t<custom, 19>;
+    using E = stdx::append_env_t<E1, E2, E3>;
+    static_assert(boost::mp11::mp_count_if_q<E, match_query<custom_t>>::value ==
+                  1);
 }


### PR DESCRIPTION
Problem:
- When extending or appending environments it's easy for the type to balloon in size.

Solution:
- Strip duplicate queries from an environment.