### PR TITLE
:sparkles: Add `same_any` and `same_none` concepts

### DIFF
--- a/include/stdx/concepts.hpp
+++ b/include/stdx/concepts.hpp
@@ -41,6 +41,12 @@ constexpr auto derived_from =
 template <typename T, typename U>
 constexpr auto same_as = std::is_same_v<T, U> and std::is_same_v<U, T>;
 
+template <typename T, typename... Us>
+constexpr auto same_any = (... or same_as<T, Us>);
+
+template <typename T, typename... Us>
+constexpr auto same_none = not same_any<T, Us...>;
+
 template <typename T, typename U>
 constexpr auto same_as_unqualified =
     is_same_unqualified_v<T, U> and is_same_unqualified_v<U, T>;
@@ -129,6 +135,12 @@ concept derived_from =
 
 template <typename T, typename U>
 concept same_as = std::is_same_v<T, U> and std::is_same_v<U, T>;
+
+template <typename T, typename... Us>
+constexpr auto same_any = (... or same_as<T, Us>);
+
+template <typename T, typename... Us>
+constexpr auto same_none = not same_any<T, Us...>;
 
 template <typename T, typename U>
 concept same_as_unqualified =
@@ -222,6 +234,11 @@ concept same_as_unqualified =
 template <typename T>
 concept structural = is_structural_v<T>;
 
+template <typename T, typename... Us>
+constexpr auto same_any = (... or same_as<T, Us>);
+
+template <typename T, typename... Us>
+constexpr auto same_none = not same_any<T, Us...>;
 } // namespace v1
 } // namespace stdx
 

--- a/test/concepts.cpp
+++ b/test/concepts.cpp
@@ -30,6 +30,16 @@ TEST_CASE("same_as", "[concepts]") {
     static_assert(not stdx::same_as<float, int>);
 }
 
+TEST_CASE("same_any", "[concepts]") {
+    static_assert(stdx::same_any<int, float, bool, int>);
+    static_assert(not stdx::same_any<float, char, bool, int>);
+}
+
+TEST_CASE("same_none", "[concepts]") {
+    static_assert(stdx::same_none<int, float, bool, char>);
+    static_assert(not stdx::same_none<float, bool, char, float>);
+}
+
 TEST_CASE("same_as_unqualified", "[concepts]") {
     static_assert(stdx::same_as_unqualified<int, int>);
     static_assert(not stdx::same_as_unqualified<int, void>);


### PR DESCRIPTION
Problem:
- There in no concept that expresses a variadic `same`-style check.

Solution:
- Add `same_any` and `same_none`.