### PR TITLE
:bug: Make `atomic` config work with scoped enumerations

### DIFF
--- a/include/stdx/atomic.hpp
+++ b/include/stdx/atomic.hpp
@@ -27,12 +27,22 @@ template <typename T> class atomic {
     using elem_t = ::atomic::atomic_type_t<T>;
     constexpr static auto alignment = ::atomic::alignment_of<T>;
 
-    static_assert(std::is_convertible_v<elem_t, T>,
+    static_assert(std::is_trivially_copyable_v<T>,
+                  "value_type of atomic<T> must be trivially_copyable");
+    static_assert(std::is_trivially_copyable_v<elem_t>,
                   "::atomic::atomic_type_t specialization result must be "
-                  "convertible to T");
-    static_assert(std::is_convertible_v<T, elem_t>,
+                  "trivially_copyable");
+
+    static_assert(sizeof(elem_t) >= sizeof(T),
+                  "::atomic::atomic_type_t specialization result must be at "
+                  "least as big as T");
+    static_assert(alignof(elem_t) >= alignof(T),
                   "::atomic::atomic_type_t specialization result must be "
-                  "convertible from T");
+                  "alignment-compatible with T");
+
+    static_assert(alignof(elem_t) <= alignment,
+                  "::atomic::atomic_type_t specialization result must be "
+                  "alignment-compatible with alignment_of<T>");
 
     alignas(alignment) elem_t value;
 

--- a/test/atomic_override.cpp
+++ b/test/atomic_override.cpp
@@ -24,3 +24,9 @@ TEST_CASE("atomic works with overridden type", "[atomic_override]") {
     CHECK(!bs.exchange(true));
     CHECK(bs);
 }
+
+TEST_CASE("atomic config works with partial specialization",
+          "[atomic_override]") {
+    using elem_t = ::atomic::atomic_type_t<int *>;
+    static_assert(std::is_same_v<elem_t, uintptr_t>);
+}

--- a/test/atomic_override.cpp
+++ b/test/atomic_override.cpp
@@ -30,3 +30,15 @@ TEST_CASE("atomic config works with partial specialization",
     using elem_t = ::atomic::atomic_type_t<int *>;
     static_assert(std::is_same_v<elem_t, uintptr_t>);
 }
+
+#if __cplusplus >= 202002L
+namespace {
+enum E : std::uint8_t {};
+}
+
+TEST_CASE("atomic config works with enum", "[atomic_override]") {
+    auto bs = stdx::atomic<E>{};
+    static_assert(sizeof(decltype(bs)) == sizeof(std::uint32_t));
+    static_assert(alignof(decltype(bs)) == alignof(std::uint32_t));
+}
+#endif

--- a/test/detail/atomic_cfg.hpp
+++ b/test/detail/atomic_cfg.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <type_traits>
 
 template <> struct atomic::atomic_type<std::uint8_t> {
     using type = std::uint32_t;
@@ -13,3 +14,10 @@ template <> struct atomic::atomic_type<bool> {
 template <typename T> struct atomic::atomic_type<T *> {
     using type = std::uintptr_t;
 };
+
+#if __cplusplus >= 202002L
+template <typename T>
+    requires(std::is_enum_v<T>)
+struct atomic::atomic_type<T> : atomic::atomic_type<std::underlying_type_t<T>> {
+};
+#endif

--- a/test/detail/atomic_cfg.hpp
+++ b/test/detail/atomic_cfg.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include <type_traits>
 
 template <> struct atomic::atomic_type<std::uint8_t> {
     using type = std::uint32_t;
@@ -9,4 +8,8 @@ template <> struct atomic::atomic_type<std::uint8_t> {
 
 template <> struct atomic::atomic_type<bool> {
     using type = std::uint32_t;
+};
+
+template <typename T> struct atomic::atomic_type<T *> {
+    using type = std::uintptr_t;
 };


### PR DESCRIPTION
Problem:
- Configuring `stdx::atomic` for scoped enumerations doesn't work because a scoped enumeration is not convertible to its configured underlying type.

Solution:
- Instead of requiring convertibility, require the types to be trivially copyable, and that the size & alignment is compatible.
