### PR TITLE
:sparkles: Add `num_fmt_specifiers`

### DIFF
--- a/include/stdx/ct_format.hpp
+++ b/include/stdx/ct_format.hpp
@@ -229,6 +229,10 @@ constexpr auto ct_format = [](auto &&...args) {
     return format_result{detail::convert_output<result.str.value, Output>(),
                          result.args};
 };
+
+template <ct_string Fmt>
+constexpr auto num_fmt_specifiers =
+    detail::count_specifiers(std::string_view{Fmt});
 } // namespace v1
 } // namespace stdx
 

--- a/test/ct_format.cpp
+++ b/test/ct_format.cpp
@@ -218,3 +218,8 @@ TEST_CASE("format multiple mixed arguments with different type",
                                               string_constant>(),
                       stdx::make_tuple(42, "B"sv)});
 }
+
+TEST_CASE("num fmt specifiers", "[ct_format]") {
+    static_assert(stdx::num_fmt_specifiers<"{}"> == 1u);
+    static_assert(stdx::num_fmt_specifiers<"{} {}"> == 2u);
+}


### PR DESCRIPTION
Problem:
- There is no way for a caller to easily know how many format specifiers are in a string. This is already known to `ct_format` internally, and is useful information to callers.

Solution:
- Add `num_fmt_specifiers`.

Note:
- This is a building block for `CIB_FATAL`, allowing extra arguments to be passed along to `stdx::panic`.