### PR TITLE
:sparkles: Allow user-defined formatting with `ct_format`

### DIFF
--- a/include/stdx/ct_format.hpp
+++ b/include/stdx/ct_format.hpp
@@ -205,6 +205,11 @@ template <ct_string Fmt> struct fmt_data {
     constexpr static auto splits = split_specifiers<N + 1>(fmt);
     constexpr static auto last_cts = to_ct_string<splits[N].size()>(splits[N]);
 };
+
+template <typename T>
+constexpr auto ct_format_as(T const &t) -> decltype(auto) {
+    return (t);
+}
 } // namespace detail
 
 template <ct_string Fmt,
@@ -223,7 +228,8 @@ constexpr auto ct_format = [](auto &&...args) {
     };
 
     auto const result = [&]<std::size_t... Is>(std::index_sequence<Is...>) {
-        return (format1.template operator()<Is>(FWD(args)) + ... +
+        using detail::ct_format_as;
+        return (format1.template operator()<Is>(ct_format_as(FWD(args))) + ... +
                 format_result{cts_t<data::last_cts>{}});
     }(std::make_index_sequence<data::N>{});
     return format_result{detail::convert_output<result.str.value, Output>(),

--- a/test/ct_format.cpp
+++ b/test/ct_format.cpp
@@ -223,3 +223,18 @@ TEST_CASE("num fmt specifiers", "[ct_format]") {
     static_assert(stdx::num_fmt_specifiers<"{}"> == 1u);
     static_assert(stdx::num_fmt_specifiers<"{} {}"> == 2u);
 }
+
+namespace user {
+struct S {
+    int x;
+};
+
+constexpr auto ct_format_as(S const &s) {
+    return stdx::ct_format<"S: {}">(s.x);
+}
+} // namespace user
+
+TEST_CASE("user-defined formatting", "[ct_format]") {
+    auto r = stdx::ct_format<"Hello {}">(user::S{42});
+    CHECK(r == stdx::format_result{"Hello S: {}"_ctst, stdx::make_tuple(42)});
+}


### PR DESCRIPTION
Problem:
- `ct_format` does not allow for compile-time formatting of user-defined types.

Solution:
- Add `ct_format_as` customization point that allows user-defined types to be given customized compile-time formatting.