### PR TITLE
:sparkles: Add iterator comparisons to `byterator`

### DIFF
--- a/include/stdx/byterator.hpp
+++ b/include/stdx/byterator.hpp
@@ -38,7 +38,6 @@ template <typename T> class byterator {
                                                    byterator const &y) -> bool {
         return x.ptr == y.ptr;
     }
-
     template <typename It,
               std::enable_if_t<std::is_same_v<detail::iterator_value_t<It>, T>,
                                int> = 0>
@@ -49,20 +48,27 @@ template <typename T> class byterator {
     }
 
 #if __cpp_impl_three_way_comparison >= 201907L
-    [[nodiscard]] constexpr friend auto operator<=>(byterator const &x,
+    [[nodiscard]] friend constexpr auto operator<=>(byterator const &x,
                                                     byterator const &y) {
         return x.ptr <=> y.ptr;
     }
+    template <typename It,
+              std::enable_if_t<std::is_same_v<detail::iterator_value_t<It>, T>,
+                               int> = 0>
+    [[nodiscard]] friend constexpr auto operator<=>(byterator const &x, It y) {
+        return static_cast<void const *>(x.ptr) <=>
+               static_cast<void const *>(stdx::to_address(y));
+    }
 #else
-    [[nodiscard]] constexpr friend auto operator!=(byterator const &x,
-                                                   byterator const &y) -> bool {
-        return not(x == y);
+    template <typename It>
+    [[nodiscard]] friend constexpr auto operator==(It x, byterator const &y)
+        -> bool {
+        return y == x;
     }
 
-    template <typename It>
-    [[nodiscard]] friend constexpr auto operator==(It y, byterator const &x)
-        -> bool {
-        return x == y;
+    [[nodiscard]] friend constexpr auto operator!=(byterator const &x,
+                                                   byterator const &y) -> bool {
+        return not(x == y);
     }
     template <typename It>
     [[nodiscard]] friend constexpr auto operator!=(byterator const &x, It y)
@@ -70,26 +76,75 @@ template <typename T> class byterator {
         return not(x == y);
     }
     template <typename It>
-    [[nodiscard]] friend constexpr auto operator!=(It y, byterator const &x)
+    [[nodiscard]] friend constexpr auto operator!=(It x, byterator const &y)
         -> bool {
-        return not(x == y);
+        return y != x;
     }
 
     [[nodiscard]] friend constexpr auto operator<(byterator const &x,
                                                   byterator const &y) -> bool {
         return std::less{}(x.ptr, y.ptr);
     }
+    template <typename It,
+              std::enable_if_t<std::is_same_v<detail::iterator_value_t<It>, T>,
+                               int> = 0>
+    [[nodiscard]] friend constexpr auto operator<(byterator const &x, It y)
+        -> bool {
+        return std::less{}(static_cast<void const *>(x.ptr),
+                           static_cast<void const *>(stdx::to_address(y)));
+    }
+    template <typename It,
+              std::enable_if_t<std::is_same_v<detail::iterator_value_t<It>, T>,
+                               int> = 0>
+    [[nodiscard]] friend constexpr auto operator<(It x, byterator const &y)
+        -> bool {
+        return std::less{}(static_cast<void const *>(stdx::to_address(x)),
+                           static_cast<void const *>(y.ptr));
+    }
+
     [[nodiscard]] friend constexpr auto operator<=(byterator const &x,
                                                    byterator const &y) -> bool {
-        return std::less_equal{}(x.ptr, y.ptr);
+        return not(y < x);
     }
+    template <typename It>
+    [[nodiscard]] friend constexpr auto operator<=(byterator const &x, It y)
+        -> bool {
+        return not(y < x);
+    }
+    template <typename It>
+    [[nodiscard]] friend constexpr auto operator<=(It x, byterator const &y)
+        -> bool {
+        return not(y < x);
+    }
+
     [[nodiscard]] friend constexpr auto operator>(byterator const &x,
                                                   byterator const &y) -> bool {
-        return std::greater{}(x.ptr, y.ptr);
+        return y < x;
     }
+    template <typename It>
+    [[nodiscard]] friend constexpr auto operator>(byterator const &x, It y)
+        -> bool {
+        return y < x;
+    }
+    template <typename It>
+    [[nodiscard]] friend constexpr auto operator>(It x, byterator const &y)
+        -> bool {
+        return y < x;
+    }
+
     [[nodiscard]] friend constexpr auto operator>=(byterator const &x,
                                                    byterator const &y) -> bool {
-        return std::greater_equal{}(x.ptr, y.ptr);
+        return not(x < y);
+    }
+    template <typename It>
+    [[nodiscard]] friend constexpr auto operator>=(byterator const &x, It y)
+        -> bool {
+        return not(x < y);
+    }
+    template <typename It>
+    [[nodiscard]] friend constexpr auto operator>=(It x, byterator const &y)
+        -> bool {
+        return not(x < y);
     }
 #endif
 

--- a/test/byterator.cpp
+++ b/test/byterator.cpp
@@ -21,6 +21,26 @@ TEST_CASE("equality comparable to iterator", "[byterator]") {
     CHECK((std::end(a) != b));
 }
 
+TEST_CASE("comparable to iterator", "[byterator]") {
+    auto const a = std::array{1, 2, 3, 4};
+    auto const b = stdx::byterator{std::begin(a)};
+    auto const c = std::next(b);
+
+    CHECK((b < std::end(a)));
+    CHECK((std::begin(a) < c));
+    CHECK((b <= std::end(a)));
+    CHECK((std::begin(a) <= c));
+    CHECK((b <= std::begin(a)));
+    CHECK((std::begin(a) <= b));
+
+    CHECK((std::end(a) > b));
+    CHECK((c > std::begin(a)));
+    CHECK((std::end(a) >= b));
+    CHECK((c >= std::begin(a)));
+    CHECK((b >= std::begin(a)));
+    CHECK((std::begin(a) >= b));
+}
+
 TEST_CASE("copy constructible", "[byterator]") {
     auto const a = std::array{stdx::to_be<std::uint16_t>(0x0102),
                               stdx::to_be<std::uint16_t>(0x0304)};


### PR DESCRIPTION
Problem:
- A `byterator` can be equality-compared with a regular iterator, but it cannot be compared for less/greater.

Solution:
- Add comparison operators between `byterator` and corresponding iterators.