### PR TITLE
:sparkles: Add uint64 support to `byterator`

### DIFF
--- a/include/stdx/byterator.hpp
+++ b/include/stdx/byterator.hpp
@@ -274,6 +274,16 @@ template <typename T> class byterator {
     template <typename V> [[nodiscard]] auto writeu32(V &&v) {
         return write(static_cast<std::uint32_t>(std::forward<V>(v)));
     }
+
+    template <typename V = std::uint64_t> [[nodiscard]] auto peeku64() {
+        return peek<std::uint64_t, V>();
+    }
+    template <typename V = std::uint64_t> [[nodiscard]] auto readu64() {
+        return read<std::uint64_t, V>();
+    }
+    template <typename V> [[nodiscard]] auto writeu64(V &&v) {
+        return write(static_cast<std::uint64_t>(std::forward<V>(v)));
+    }
 };
 
 template <typename It, std::enable_if_t<detail::is_byteratorish_v<It>, int> = 0>

--- a/test/byterator.cpp
+++ b/test/byterator.cpp
@@ -219,6 +219,39 @@ TEST_CASE("write uint32_t", "[byterator]") {
     CHECK((i == std::end(a)));
 }
 
+TEST_CASE("peek uint64_t", "[byterator]") {
+    auto const a = std::array{
+        stdx::to_be<std::uint16_t>(0x0102), stdx::to_be<std::uint16_t>(0x0304),
+        stdx::to_be<std::uint16_t>(0x0506), stdx::to_be<std::uint16_t>(0x0708)};
+    auto i = stdx::byterator{std::begin(a)};
+    static_assert(std::is_same_v<decltype(i.readu64()), std::uint64_t>);
+    CHECK(i.peeku64() == stdx::to_be<std::uint64_t>(0x0102030405060708));
+    CHECK((i == std::begin(a)));
+}
+
+TEST_CASE("read uint64_t", "[byterator]") {
+    auto const a = std::array{
+        stdx::to_be<std::uint16_t>(0x0102), stdx::to_be<std::uint16_t>(0x0304),
+        stdx::to_be<std::uint16_t>(0x0506), stdx::to_be<std::uint16_t>(0x0708)};
+    auto i = stdx::byterator{std::begin(a)};
+    static_assert(std::is_same_v<decltype(i.readu64()), std::uint64_t>);
+    CHECK(i.readu64() == stdx::to_be<std::uint64_t>(0x0102030405060708));
+    CHECK((i == std::end(a)));
+}
+
+TEST_CASE("write uint64_t", "[byterator]") {
+    auto a = std::array{
+        stdx::to_be<std::uint16_t>(0x0102), stdx::to_be<std::uint16_t>(0x0304),
+        stdx::to_be<std::uint16_t>(0x0506), stdx::to_be<std::uint16_t>(0x0708)};
+    auto i = stdx::byterator{std::begin(a)};
+    i.writeu64(stdx::to_be<std::uint64_t>(0x05060708090A0B0C));
+    CHECK(a[0] == stdx::to_be<std::uint16_t>(0x0506));
+    CHECK(a[1] == stdx::to_be<std::uint16_t>(0x0708));
+    CHECK(a[2] == stdx::to_be<std::uint16_t>(0x090A));
+    CHECK(a[3] == stdx::to_be<std::uint16_t>(0x0B0C));
+    CHECK((i == std::end(a)));
+}
+
 namespace {
 enum struct E : std::uint8_t { A = 1, B = 2, C = 3 };
 }


### PR DESCRIPTION
Problem:
- `byterator` doesn't support 64 bits operations.

Solution:
- Add readu64, peeku64 and writeu64 implementations.