### PR TITLE
:art: Add `ct_string_to_type_t`

### DIFF
--- a/include/stdx/ct_string.hpp
+++ b/include/stdx/ct_string.hpp
@@ -99,6 +99,9 @@ template <ct_string S, template <typename C, C...> typename T>
     }(std::make_index_sequence<S.size()>{});
 }
 
+template <ct_string S, template <typename C, C...> typename T>
+using ct_string_to_type_t = decltype(ct_string_to_type<S, T>());
+
 template <ct_string S, char C> [[nodiscard]] consteval auto split() {
     constexpr auto it = [] {
         for (auto i = S.value.cbegin(); i != S.value.cend(); ++i) {

--- a/test/ct_string.cpp
+++ b/test/ct_string.cpp
@@ -59,6 +59,12 @@ TEST_CASE("to type", "[ct_string]") {
                                  string_constant<char, 'A', 'B', 'C'> const>);
 }
 
+TEST_CASE("to type_t", "[ct_string]") {
+    constexpr auto s = stdx::ct_string{"ABC"};
+    using sc = stdx::ct_string_to_type_t<s, string_constant>;
+    static_assert(std::is_same_v<sc, string_constant<char, 'A', 'B', 'C'>>);
+}
+
 TEST_CASE("to string_view", "[ct_string]") {
     constexpr auto s = stdx::ct_string{"ABC"};
     auto const sv = static_cast<std::string_view>(s);


### PR DESCRIPTION
Problem:
- It's verbose to do `decltype(ct_string_to_type<S, T>()`.

Solution:
- Use `ct_string_to_type_t<S, T>` instead.