### PR TITLE
:sparkles: Add `byterator::advance`

### DIFF
--- a/docs/byterator.adoc
+++ b/docs/byterator.adoc
@@ -63,18 +63,22 @@ auto value = i.readu16();
 ----
 auto v8 = i.peeku8();   // read value without advancing
 v8 = i.readu8();        // read and advance
+i.advanceu8();          // advance only
 i.writeu8(v8);          // write and advance
 
 auto v16 = i.peeku16(); // read value without advancing
 v16 = i.readu16();      // read and advance
+i.advanceu16();         // advance only
 i.writeu16(v16);        // write and advance
 
 auto v32 = i.peeku32(); // read value without advancing
 v32 = i.readu32();      // read and advance
+i.advanceu32();         // advance only
 i.writeu32(v32);        // write and advance
 
 auto v64 = i.peeku64(); // read value without advancing
 v64 = i.readu64();      // read and advance
+i.advanceu64();         // advance only
 i.writeu64(v64);        // write and advance
 ----
 

--- a/test/byterator.cpp
+++ b/test/byterator.cpp
@@ -77,6 +77,22 @@ TEST_CASE("random access arithmetic", "[byterator]") {
     CHECK((i == b));
 }
 
+TEST_CASE("advance", "[byterator]") {
+    auto const a = std::array{stdx::to_be<std::uint16_t>(0x0102),
+                              stdx::to_be<std::uint16_t>(0x0304)};
+    auto const b = stdx::byterator{std::begin(a)};
+    auto i = b;
+    CHECK((i + 1 != b));
+    i.advance();
+    CHECK((i == b + 1));
+    CHECK(i - b == 1);
+    CHECK((i - 1 == b));
+    i.advance(-1);
+    CHECK((i == b));
+    static_assert(std::is_same_v<decltype(i.advance()),
+                                 stdx::byterator<std::uint16_t const> &>);
+}
+
 TEST_CASE("equality comparable", "[byterator]") {
     auto const a = std::array{1, 2, 3, 4};
     auto x = stdx::byterator{std::begin(a)};
@@ -142,6 +158,15 @@ TEST_CASE("peek uint8_t", "[byterator]") {
     CHECK((i == std::begin(a)));
 }
 
+TEST_CASE("advance uint8_t", "[byterator]") {
+    auto const a = std::array{stdx::to_be<std::uint16_t>(0x0102),
+                              stdx::to_be<std::uint16_t>(0x0304)};
+    auto i = stdx::byterator{std::begin(a)};
+    auto j = std::next(i);
+    i.advanceu8();
+    CHECK((i == j));
+}
+
 TEST_CASE("read uint8_t", "[byterator]") {
     auto const a = std::array{stdx::to_be<std::uint16_t>(0x0102),
                               stdx::to_be<std::uint16_t>(0x0304)};
@@ -169,6 +194,15 @@ TEST_CASE("peek uint16_t", "[byterator]") {
     static_assert(std::is_same_v<decltype(i.readu16()), std::uint16_t>);
     CHECK(i.peeku16() == stdx::to_be<std::uint16_t>(0x0102));
     CHECK((i == std::begin(a)));
+}
+
+TEST_CASE("advance uint16_t", "[byterator]") {
+    auto const a = std::array{stdx::to_be<std::uint16_t>(0x0102),
+                              stdx::to_be<std::uint16_t>(0x0304)};
+    auto i = stdx::byterator{std::begin(a)};
+    auto j = i + 2;
+    i.advanceu16();
+    CHECK((i == j));
 }
 
 TEST_CASE("read uint16_t", "[byterator]") {
@@ -200,6 +234,14 @@ TEST_CASE("peek uint32_t", "[byterator]") {
     CHECK((i == std::begin(a)));
 }
 
+TEST_CASE("advance uint32_t", "[byterator]") {
+    auto const a = std::array{stdx::to_be<std::uint16_t>(0x0102),
+                              stdx::to_be<std::uint16_t>(0x0304)};
+    auto i = stdx::byterator{std::begin(a)};
+    i.advanceu32();
+    CHECK((i == std::end(a)));
+}
+
 TEST_CASE("read uint32_t", "[byterator]") {
     auto const a = std::array{stdx::to_be<std::uint16_t>(0x0102),
                               stdx::to_be<std::uint16_t>(0x0304)};
@@ -227,6 +269,15 @@ TEST_CASE("peek uint64_t", "[byterator]") {
     static_assert(std::is_same_v<decltype(i.readu64()), std::uint64_t>);
     CHECK(i.peeku64() == stdx::to_be<std::uint64_t>(0x0102030405060708));
     CHECK((i == std::begin(a)));
+}
+
+TEST_CASE("advance uint64_t", "[byterator]") {
+    auto const a = std::array{
+        stdx::to_be<std::uint16_t>(0x0102), stdx::to_be<std::uint16_t>(0x0304),
+        stdx::to_be<std::uint16_t>(0x0506), stdx::to_be<std::uint16_t>(0x0708)};
+    auto i = stdx::byterator{std::begin(a)};
+    i.advanceu64();
+    CHECK((i == std::end(a)));
 }
 
 TEST_CASE("read uint64_t", "[byterator]") {
@@ -262,6 +313,15 @@ TEST_CASE("peek enum", "[byterator]") {
     auto i = stdx::byterator{std::begin(a)};
     static_assert(std::is_same_v<decltype(i.readu32()), std::uint32_t>);
     CHECK(i.peek<E>() == E::A);
+}
+
+TEST_CASE("advance enum", "[byterator]") {
+    auto const a = std::array{stdx::to_be<std::uint16_t>(0x0102),
+                              stdx::to_be<std::uint16_t>(0x0304)};
+    auto i = stdx::byterator{std::begin(a)};
+    auto j = std::next(i);
+    i.advance<E>();
+    CHECK(i == j);
 }
 
 TEST_CASE("read enum", "[byterator]") {


### PR DESCRIPTION
Problem:
- Sometimes we want to advance a `byterator`, particularly by the size of a type, and it's annoying to have to discard the result of `read` (which is marked `[[nodiscard]]`).

Solution:
- Implement `advance` and `advanceuXX` functions on `byterator`.

Note:
- It's also possible to use `std::advance`. But the `advanceuXX` functions match their `peek`, `read` and `write` counterparts.