### PR TITLE
:white_check_mark: :sound: Improve `ct_format` help message

### DIFF
--- a/include/stdx/ct_format.hpp
+++ b/include/stdx/ct_format.hpp
@@ -221,6 +221,10 @@ constexpr auto ct_format = [](auto &&...args) {
 
     using data = detail::fmt_data<Fmt>;
 
+    static_assert(data::N == sizeof...(args),
+                  "Format string has a mismatch between the number of format "
+                  "specifiers and arguments.");
+
     [[maybe_unused]] auto const format1 = [&]<std::size_t I>(auto &&arg) {
         constexpr auto cts =
             detail::to_ct_string<data::splits[I].size()>(data::splits[I]);

--- a/test/fail/CMakeLists.txt
+++ b/test/fail/CMakeLists.txt
@@ -59,6 +59,7 @@ if(${CMAKE_CXX_STANDARD} GREATER_EQUAL 20)
 
     add_fail_tests(
         atomic_bool_dec
+        ct_format_mismatch
         dynamic_span_no_ct_capacity
         dynamic_container_no_ct_capacity
         tuple_index_out_of_bounds

--- a/test/fail/ct_format_mismatch.cpp
+++ b/test/fail/ct_format_mismatch.cpp
@@ -1,0 +1,5 @@
+#include <stdx/ct_format.hpp>
+
+// EXPECT: mismatch between the number of format specifiers and arguments
+
+auto main() -> int { [[maybe_unused]] auto x = stdx::ct_format<"Hello">(42); }


### PR DESCRIPTION
Problem:
- When a call to ct_format has a mismatch between the number of format specifiers and the number of arguments, the help message is obscure.

Solution:
- Provide a clearer help message.