### PR TITLE
:white_check_mark: Add tests for `to_underlying` with arithmetic types

### DIFF
--- a/test/to_underlying.cpp
+++ b/test/to_underlying.cpp
@@ -1,5 +1,6 @@
 #include <stdx/type_traits.hpp>
 
+#include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 #include <type_traits>
@@ -25,8 +26,18 @@ TEST_CASE("to_underlying values", "[type_traits]") {
     CHECK(stdx::to_underlying(ScopedEnum::Value5) == 5);
 }
 
-TEST_CASE("to_underlying works on integral types", "[type_traits]") {
-    constexpr int x = 0;
-    CHECK(std::is_same_v<decltype(stdx::to_underlying(x)), int>);
-    CHECK(stdx::to_underlying(x) == 0);
+TEMPLATE_TEST_CASE("to_underlying works on integral types", "[type_traits]",
+                   bool, char, signed char, unsigned char, short int,
+                   unsigned short int, int, unsigned int, long int,
+                   unsigned long int) {
+    constexpr TestType x{};
+    CHECK(std::is_same_v<decltype(stdx::to_underlying(x)), TestType>);
+    CHECK(stdx::to_underlying(x) == TestType{});
+}
+
+TEMPLATE_TEST_CASE("to_underlying works on floating point types",
+                   "[type_traits]", float, double) {
+    constexpr TestType x{};
+    CHECK(std::is_same_v<decltype(stdx::to_underlying(x)), TestType>);
+    CHECK(stdx::to_underlying(x) == TestType{});
 }


### PR DESCRIPTION
Problem:
- `to_underlying` works with many types, but is only tested with enums and `int`.

Solution:
- Add template tests for more integral and floating-point types.