### PR TITLE
:white_check_mark: Use `STATIC_REQUIRE` instead of `static_assert`

### DIFF
--- a/test/atomic.cpp
+++ b/test/atomic.cpp
@@ -10,15 +10,15 @@ TEMPLATE_TEST_CASE("atomic size and alignment is the same as the data",
                    "[atomic]", bool, char, signed char, unsigned char,
                    short int, unsigned short int, int, unsigned int, long int,
                    unsigned long int) {
-    static_assert(sizeof(stdx::atomic<TestType>) == sizeof(TestType));
-    static_assert(alignof(stdx::atomic<TestType>) == alignof(TestType));
+    STATIC_REQUIRE(sizeof(stdx::atomic<TestType>) == sizeof(TestType));
+    STATIC_REQUIRE(alignof(stdx::atomic<TestType>) == alignof(TestType));
 }
 
 TEMPLATE_TEST_CASE("atomic is default constructible when data is", "[atomic]",
                    bool, char, signed char, unsigned char, short int,
                    unsigned short int, int, unsigned int, long int,
                    unsigned long int) {
-    static_assert(std::is_default_constructible_v<stdx::atomic<TestType>>);
+    STATIC_REQUIRE(std::is_default_constructible_v<stdx::atomic<TestType>>);
 }
 
 namespace {
@@ -29,22 +29,22 @@ struct non_dc {
 
 #if __cplusplus >= 202002L
 TEST_CASE("atomic is not default constructible when data is not", "[atomic]") {
-    static_assert(not std::is_default_constructible_v<stdx::atomic<non_dc>>);
+    STATIC_REQUIRE(not std::is_default_constructible_v<stdx::atomic<non_dc>>);
 }
 #endif
 
 TEST_CASE("atomic is not copyable or movable", "[atomic]") {
-    static_assert(not std::is_copy_constructible_v<stdx::atomic<int>>);
-    static_assert(not std::is_move_constructible_v<stdx::atomic<int>>);
-    static_assert(not std::is_copy_assignable_v<stdx::atomic<int>>);
-    static_assert(not std::is_move_assignable_v<stdx::atomic<int>>);
+    STATIC_REQUIRE(not std::is_copy_constructible_v<stdx::atomic<int>>);
+    STATIC_REQUIRE(not std::is_move_constructible_v<stdx::atomic<int>>);
+    STATIC_REQUIRE(not std::is_copy_assignable_v<stdx::atomic<int>>);
+    STATIC_REQUIRE(not std::is_move_assignable_v<stdx::atomic<int>>);
 }
 
 TEMPLATE_TEST_CASE("atomic supports value initialization", "[atomic]", bool,
                    char, signed char, unsigned char, short int,
                    unsigned short int, int, unsigned int, long int,
                    unsigned long int) {
-    static_assert(std::is_constructible_v<stdx::atomic<TestType>, TestType>);
+    STATIC_REQUIRE(std::is_constructible_v<stdx::atomic<TestType>, TestType>);
     [[maybe_unused]] auto x = stdx::atomic<TestType>{TestType{}};
 }
 

--- a/test/atomic_bitset.cpp
+++ b/test/atomic_bitset.cpp
@@ -9,34 +9,34 @@
 
 TEST_CASE("atomic_bitset with explicit storage element type",
           "[atomic_bitset]") {
-    static_assert(sizeof(stdx::atomic_bitset<1, std::uint8_t>) ==
-                  sizeof(std::uint8_t));
-    static_assert(sizeof(stdx::atomic_bitset<8, std::uint8_t>) ==
-                  sizeof(std::uint8_t));
-    static_assert(sizeof(stdx::atomic_bitset<1, std::uint16_t>) ==
-                  sizeof(std::uint16_t));
-    static_assert(sizeof(stdx::atomic_bitset<16, std::uint16_t>) ==
-                  sizeof(std::uint16_t));
-    static_assert(sizeof(stdx::atomic_bitset<1, std::uint32_t>) ==
-                  sizeof(std::uint32_t));
-    static_assert(sizeof(stdx::atomic_bitset<32, std::uint32_t>) ==
-                  sizeof(std::uint32_t));
-    static_assert(sizeof(stdx::atomic_bitset<1, std::uint64_t>) ==
-                  sizeof(std::uint64_t));
-    static_assert(sizeof(stdx::atomic_bitset<64, std::uint64_t>) ==
-                  sizeof(std::uint64_t));
+    STATIC_REQUIRE(sizeof(stdx::atomic_bitset<1, std::uint8_t>) ==
+                   sizeof(std::uint8_t));
+    STATIC_REQUIRE(sizeof(stdx::atomic_bitset<8, std::uint8_t>) ==
+                   sizeof(std::uint8_t));
+    STATIC_REQUIRE(sizeof(stdx::atomic_bitset<1, std::uint16_t>) ==
+                   sizeof(std::uint16_t));
+    STATIC_REQUIRE(sizeof(stdx::atomic_bitset<16, std::uint16_t>) ==
+                   sizeof(std::uint16_t));
+    STATIC_REQUIRE(sizeof(stdx::atomic_bitset<1, std::uint32_t>) ==
+                   sizeof(std::uint32_t));
+    STATIC_REQUIRE(sizeof(stdx::atomic_bitset<32, std::uint32_t>) ==
+                   sizeof(std::uint32_t));
+    STATIC_REQUIRE(sizeof(stdx::atomic_bitset<1, std::uint64_t>) ==
+                   sizeof(std::uint64_t));
+    STATIC_REQUIRE(sizeof(stdx::atomic_bitset<64, std::uint64_t>) ==
+                   sizeof(std::uint64_t));
 }
 
 TEST_CASE("atomic_bitset with implicit storage element type",
           "[atomic_bitset]") {
-    static_assert(sizeof(stdx::atomic_bitset<1>) == sizeof(std::uint8_t));
-    static_assert(sizeof(stdx::atomic_bitset<8>) == sizeof(std::uint8_t));
-    static_assert(sizeof(stdx::atomic_bitset<9>) == sizeof(std::uint16_t));
-    static_assert(sizeof(stdx::atomic_bitset<16>) == sizeof(std::uint16_t));
-    static_assert(sizeof(stdx::atomic_bitset<17>) == sizeof(std::uint32_t));
-    static_assert(sizeof(stdx::atomic_bitset<32>) == sizeof(std::uint32_t));
-    static_assert(sizeof(stdx::atomic_bitset<33>) == sizeof(std::uint64_t));
-    static_assert(sizeof(stdx::atomic_bitset<64>) == sizeof(std::uint64_t));
+    STATIC_REQUIRE(sizeof(stdx::atomic_bitset<1>) == sizeof(std::uint8_t));
+    STATIC_REQUIRE(sizeof(stdx::atomic_bitset<8>) == sizeof(std::uint8_t));
+    STATIC_REQUIRE(sizeof(stdx::atomic_bitset<9>) == sizeof(std::uint16_t));
+    STATIC_REQUIRE(sizeof(stdx::atomic_bitset<16>) == sizeof(std::uint16_t));
+    STATIC_REQUIRE(sizeof(stdx::atomic_bitset<17>) == sizeof(std::uint32_t));
+    STATIC_REQUIRE(sizeof(stdx::atomic_bitset<32>) == sizeof(std::uint32_t));
+    STATIC_REQUIRE(sizeof(stdx::atomic_bitset<33>) == sizeof(std::uint64_t));
+    STATIC_REQUIRE(sizeof(stdx::atomic_bitset<64>) == sizeof(std::uint64_t));
 }
 
 TEMPLATE_TEST_CASE("index operation", "[atomic_bitset]", std::uint8_t,
@@ -162,7 +162,7 @@ TEST_CASE("to_natural returns smallest_uint", "[atomic_bitset]") {
     auto bs = stdx::atomic_bitset<4>{stdx::all_bits};
     auto value = bs.to_natural();
     CHECK(value == 0b1111);
-    static_assert(std::is_same_v<decltype(value), std::uint8_t>);
+    STATIC_REQUIRE(std::is_same_v<decltype(value), std::uint8_t>);
 }
 
 TEMPLATE_TEST_CASE("construct with a string_view", "[atomic_bitset]",
@@ -301,7 +301,7 @@ enum struct Bits : std::uint8_t { ZERO, ONE, TWO, THREE, MAX };
 
 TEST_CASE("use atomic_bitset with enum struct (construct)", "[atomic_bitset]") {
     constexpr auto bs = stdx::atomic_bitset<Bits::MAX>{};
-    static_assert(bs.size() == stdx::to_underlying(Bits::MAX));
+    STATIC_REQUIRE(bs.size() == stdx::to_underlying(Bits::MAX));
 }
 
 TEST_CASE("use atomic_bitset with enum struct (to)", "[atomic_bitset]") {

--- a/test/atomic_bitset_override.cpp
+++ b/test/atomic_bitset_override.cpp
@@ -8,13 +8,13 @@
 TEST_CASE("atomic_bitset works with overridden type",
           "[atomic_bitset_override]") {
     auto bs = stdx::atomic_bitset<4>{};
-    static_assert(sizeof(decltype(bs)) == sizeof(std::uint32_t));
-    static_assert(alignof(decltype(bs)) == alignof(std::uint32_t));
+    STATIC_REQUIRE(sizeof(decltype(bs)) == sizeof(std::uint32_t));
+    STATIC_REQUIRE(alignof(decltype(bs)) == alignof(std::uint32_t));
 }
 
 TEST_CASE("to_natural returns smallest_uint", "[atomic_bitset_override]") {
     auto bs = stdx::atomic_bitset<4>{stdx::all_bits};
     auto value = bs.to_natural();
     CHECK(value == 0b1111);
-    static_assert(std::is_same_v<decltype(value), std::uint8_t>);
+    STATIC_REQUIRE(std::is_same_v<decltype(value), std::uint8_t>);
 }

--- a/test/atomic_override.cpp
+++ b/test/atomic_override.cpp
@@ -8,14 +8,14 @@
 TEST_CASE("atomic with overridden type is correctly sized/aligned",
           "[atomic_override]") {
     auto bs = stdx::atomic<bool>{};
-    static_assert(sizeof(decltype(bs)) == sizeof(std::uint32_t));
-    static_assert(alignof(decltype(bs)) == alignof(std::uint32_t));
+    STATIC_REQUIRE(sizeof(decltype(bs)) == sizeof(std::uint32_t));
+    STATIC_REQUIRE(alignof(decltype(bs)) == alignof(std::uint32_t));
 }
 
 TEST_CASE("atomic with overridden type presents interface of original type",
           "[atomic_override]") {
     auto bs = stdx::atomic<bool>{};
-    static_assert(std::is_same_v<decltype(bs.load()), bool>);
+    STATIC_REQUIRE(std::is_same_v<decltype(bs.load()), bool>);
 }
 
 TEST_CASE("atomic works with overridden type", "[atomic_override]") {
@@ -28,7 +28,7 @@ TEST_CASE("atomic works with overridden type", "[atomic_override]") {
 TEST_CASE("atomic config works with partial specialization",
           "[atomic_override]") {
     using elem_t = ::atomic::atomic_type_t<int *>;
-    static_assert(std::is_same_v<elem_t, uintptr_t>);
+    STATIC_REQUIRE(std::is_same_v<elem_t, uintptr_t>);
 }
 
 #if __cplusplus >= 202002L
@@ -38,7 +38,7 @@ enum E : std::uint8_t {};
 
 TEST_CASE("atomic config works with enum", "[atomic_override]") {
     auto bs = stdx::atomic<E>{};
-    static_assert(sizeof(decltype(bs)) == sizeof(std::uint32_t));
-    static_assert(alignof(decltype(bs)) == alignof(std::uint32_t));
+    STATIC_REQUIRE(sizeof(decltype(bs)) == sizeof(std::uint32_t));
+    STATIC_REQUIRE(alignof(decltype(bs)) == alignof(std::uint32_t));
 }
 #endif

--- a/test/bind.cpp
+++ b/test/bind.cpp
@@ -8,7 +8,7 @@
 
 TEST_CASE("bind_front basic operation", "[bind]") {
     constexpr auto f = stdx::bind_front([](int x, int y) { return x - y; }, 42);
-    static_assert(f(17) == 25);
+    STATIC_REQUIRE(f(17) == 25);
 }
 
 TEST_CASE("bind_front with rvalue", "[bind]") {
@@ -35,7 +35,7 @@ TEST_CASE("bind_front with lambda template argument", "[bind]") {
 
 TEST_CASE("bind_back basic operation", "[bind]") {
     constexpr auto f = stdx::bind_back([](int x, int y) { return x - y; }, 17);
-    static_assert(f(42) == 25);
+    STATIC_REQUIRE(f(42) == 25);
 }
 
 TEST_CASE("bind_back with rvalue", "[bind]") {

--- a/test/bit.cpp
+++ b/test/bit.cpp
@@ -9,15 +9,15 @@
 #include <type_traits>
 
 TEST_CASE("byteswap", "[bit]") {
-    static_assert(stdx::byteswap(std::uint8_t{1u}) == 1u);
-    static_assert(stdx::byteswap(std::uint16_t{0x0102u}) == 0x0201u);
-    static_assert(stdx::byteswap(std::uint32_t{0x01020304ul}) == 0x04030201ul);
-    static_assert(stdx::byteswap(std::uint64_t{0x01020304'05060708ull}) ==
-                  0x08070605'04030201ull);
+    STATIC_REQUIRE(stdx::byteswap(std::uint8_t{1u}) == 1u);
+    STATIC_REQUIRE(stdx::byteswap(std::uint16_t{0x0102u}) == 0x0201u);
+    STATIC_REQUIRE(stdx::byteswap(std::uint32_t{0x01020304ul}) == 0x04030201ul);
+    STATIC_REQUIRE(stdx::byteswap(std::uint64_t{0x01020304'05060708ull}) ==
+                   0x08070605'04030201ull);
 }
 
 TEST_CASE("to little endian", "[bit]") {
-    static_assert(stdx::to_le(std::uint8_t{1u}) == 1u);
+    STATIC_REQUIRE(stdx::to_le(std::uint8_t{1u}) == 1u);
 
     [[maybe_unused]] constexpr std::uint16_t u16{0x1234};
     [[maybe_unused]] constexpr std::uint32_t u32{0x1234'5678};
@@ -35,7 +35,7 @@ TEST_CASE("to little endian", "[bit]") {
 }
 
 TEST_CASE("to big endian", "[bit]") {
-    static_assert(stdx::to_be(std::uint8_t{1u}) == 1u);
+    STATIC_REQUIRE(stdx::to_be(std::uint8_t{1u}) == 1u);
 
     [[maybe_unused]] constexpr std::uint16_t u16{0x1234};
     [[maybe_unused]] constexpr std::uint32_t u32{0x1234'5678};
@@ -53,7 +53,7 @@ TEST_CASE("to big endian", "[bit]") {
 }
 
 TEST_CASE("from little endian", "[bit]") {
-    static_assert(stdx::from_le(std::uint8_t{1u}) == 1u);
+    STATIC_REQUIRE(stdx::from_le(std::uint8_t{1u}) == 1u);
 
     [[maybe_unused]] constexpr std::uint16_t u16{0x1234};
     [[maybe_unused]] constexpr std::uint32_t u32{0x1234'5678};
@@ -71,7 +71,7 @@ TEST_CASE("from little endian", "[bit]") {
 }
 
 TEST_CASE("from big endian", "[bit]") {
-    static_assert(stdx::from_be(std::uint8_t{1u}) == 1u);
+    STATIC_REQUIRE(stdx::from_be(std::uint8_t{1u}) == 1u);
 
     [[maybe_unused]] constexpr std::uint16_t u16{0x1234};
     [[maybe_unused]] constexpr std::uint32_t u32{0x1234'5678};
@@ -90,164 +90,167 @@ TEST_CASE("from big endian", "[bit]") {
 
 TEMPLATE_TEST_CASE("popcount", "[bit]", std::uint8_t, std::uint16_t,
                    std::uint32_t, std::uint64_t) {
-    static_assert(stdx::popcount(TestType{}) == 0);
+    STATIC_REQUIRE(stdx::popcount(TestType{}) == 0);
 
     constexpr TestType x = 0b10101;
-    static_assert(stdx::popcount(x) == 3);
+    STATIC_REQUIRE(stdx::popcount(x) == 3);
 
     constexpr TestType max = std::numeric_limits<TestType>::max();
-    static_assert(stdx::popcount(max) == std::numeric_limits<TestType>::digits);
+    STATIC_REQUIRE(stdx::popcount(max) ==
+                   std::numeric_limits<TestType>::digits);
 }
 
 TEMPLATE_TEST_CASE("has_single_bit", "[bit]", std::uint8_t, std::uint16_t,
                    std::uint32_t, std::uint64_t) {
-    static_assert(not stdx::has_single_bit(TestType{}));
-    static_assert(stdx::has_single_bit(TestType{1u}));
+    STATIC_REQUIRE(not stdx::has_single_bit(TestType{}));
+    STATIC_REQUIRE(stdx::has_single_bit(TestType{1u}));
 
     constexpr TestType x = 0b10101;
-    static_assert(not stdx::has_single_bit(x));
+    STATIC_REQUIRE(not stdx::has_single_bit(x));
 }
 
 TEMPLATE_TEST_CASE("countl_zero", "[bit]", std::uint8_t, std::uint16_t,
                    std::uint32_t, std::uint64_t) {
     constexpr auto d = std::numeric_limits<TestType>::digits;
-    static_assert(stdx::countl_zero(TestType{}) == d);
-    static_assert(stdx::countl_zero(TestType{1u}) == d - 1);
-    static_assert(stdx::countl_zero(TestType{2u}) == d - 2);
+    STATIC_REQUIRE(stdx::countl_zero(TestType{}) == d);
+    STATIC_REQUIRE(stdx::countl_zero(TestType{1u}) == d - 1);
+    STATIC_REQUIRE(stdx::countl_zero(TestType{2u}) == d - 2);
 }
 
 TEMPLATE_TEST_CASE("countr_zero", "[bit]", std::uint8_t, std::uint16_t,
                    std::uint32_t, std::uint64_t) {
     constexpr auto d = std::numeric_limits<TestType>::digits;
-    static_assert(stdx::countr_zero(TestType{}) == d);
-    static_assert(stdx::countr_zero(TestType{1u}) == 0);
-    static_assert(stdx::countr_zero(TestType{2u}) == 1);
+    STATIC_REQUIRE(stdx::countr_zero(TestType{}) == d);
+    STATIC_REQUIRE(stdx::countr_zero(TestType{1u}) == 0);
+    STATIC_REQUIRE(stdx::countr_zero(TestType{2u}) == 1);
 }
 
 TEMPLATE_TEST_CASE("countl_one", "[bit]", std::uint8_t, std::uint16_t,
                    std::uint32_t, std::uint64_t) {
     constexpr auto d = std::numeric_limits<TestType>::digits;
     constexpr auto max = std::numeric_limits<TestType>::max();
-    static_assert(stdx::countl_one(TestType{}) == 0);
-    static_assert(stdx::countl_one(TestType{1u}) == 0);
-    static_assert(stdx::countl_one(max) == d);
-    static_assert(stdx::countl_one(TestType(max - 1)) == d - 1);
+    STATIC_REQUIRE(stdx::countl_one(TestType{}) == 0);
+    STATIC_REQUIRE(stdx::countl_one(TestType{1u}) == 0);
+    STATIC_REQUIRE(stdx::countl_one(max) == d);
+    STATIC_REQUIRE(stdx::countl_one(TestType(max - 1)) == d - 1);
 }
 
 TEMPLATE_TEST_CASE("countr_one", "[bit]", std::uint8_t, std::uint16_t,
                    std::uint32_t, std::uint64_t) {
     constexpr auto d = std::numeric_limits<TestType>::digits;
     constexpr auto max = std::numeric_limits<TestType>::max();
-    static_assert(stdx::countr_one(TestType{}) == 0);
-    static_assert(stdx::countr_one(TestType{1u}) == 1);
-    static_assert(stdx::countr_one(max) == d);
-    static_assert(stdx::countr_one(TestType(max - 1)) == 0);
+    STATIC_REQUIRE(stdx::countr_one(TestType{}) == 0);
+    STATIC_REQUIRE(stdx::countr_one(TestType{1u}) == 1);
+    STATIC_REQUIRE(stdx::countr_one(max) == d);
+    STATIC_REQUIRE(stdx::countr_one(TestType(max - 1)) == 0);
 }
 
 TEMPLATE_TEST_CASE("bit_width", "[bit]", std::uint8_t, std::uint16_t,
                    std::uint32_t, std::uint64_t) {
-    static_assert(stdx::bit_width(TestType{}) == 0);
-    static_assert(stdx::bit_width(TestType{1u}) == 1);
-    static_assert(stdx::bit_width(TestType{3u}) == 2);
+    STATIC_REQUIRE(stdx::bit_width(TestType{}) == 0);
+    STATIC_REQUIRE(stdx::bit_width(TestType{1u}) == 1);
+    STATIC_REQUIRE(stdx::bit_width(TestType{3u}) == 2);
 
     constexpr TestType max = std::numeric_limits<TestType>::max();
-    static_assert(stdx::bit_width(TestType{max}) ==
-                  std::numeric_limits<TestType>::digits);
+    STATIC_REQUIRE(stdx::bit_width(TestType{max}) ==
+                   std::numeric_limits<TestType>::digits);
 }
 
 TEMPLATE_TEST_CASE("bit_ceil", "[bit]", std::uint8_t, std::uint16_t,
                    std::uint32_t, std::uint64_t) {
-    static_assert(stdx::bit_ceil(TestType{}) == 1);
-    static_assert(stdx::bit_ceil(TestType{1u}) == 1);
-    static_assert(stdx::bit_ceil(TestType{45u}) == 64);
+    STATIC_REQUIRE(stdx::bit_ceil(TestType{}) == 1);
+    STATIC_REQUIRE(stdx::bit_ceil(TestType{1u}) == 1);
+    STATIC_REQUIRE(stdx::bit_ceil(TestType{45u}) == 64);
 }
 
 TEMPLATE_TEST_CASE("bit_floor", "[bit]", std::uint8_t, std::uint16_t,
                    std::uint32_t, std::uint64_t) {
-    static_assert(stdx::bit_floor(TestType{}) == 0);
-    static_assert(stdx::bit_floor(TestType{1u}) == 1);
-    static_assert(stdx::bit_floor(TestType{45u}) == 32);
+    STATIC_REQUIRE(stdx::bit_floor(TestType{}) == 0);
+    STATIC_REQUIRE(stdx::bit_floor(TestType{1u}) == 1);
+    STATIC_REQUIRE(stdx::bit_floor(TestType{45u}) == 32);
 }
 
 TEST_CASE("bit_cast", "[bit]") {
     constexpr float f = 1.0f;
     constexpr auto x = stdx::bit_cast<std::uint32_t>(f);
-    static_assert(x == 0x3f80'0000);
+    STATIC_REQUIRE(x == 0x3f80'0000);
 }
 
 TEMPLATE_TEST_CASE("rotl", "[bit]", std::uint8_t, std::uint16_t, std::uint32_t,
                    std::uint64_t) {
     constexpr auto d = std::numeric_limits<TestType>::digits;
-    static_assert(stdx::rotl(TestType{1u}, 1) == TestType{2u});
-    static_assert(stdx::rotl(TestType(TestType{1u} << (d - 1)), 1) ==
-                  TestType{1u});
+    STATIC_REQUIRE(stdx::rotl(TestType{1u}, 1) == TestType{2u});
+    STATIC_REQUIRE(stdx::rotl(TestType(TestType{1u} << (d - 1)), 1) ==
+                   TestType{1u});
 }
 
 TEMPLATE_TEST_CASE("rotr", "[bit]", std::uint8_t, std::uint16_t, std::uint32_t,
                    std::uint64_t) {
     constexpr auto d = std::numeric_limits<TestType>::digits;
-    static_assert(stdx::rotr(TestType{2u}, 1) == TestType{1u});
-    static_assert(stdx::rotr(TestType{1u}, 1) == TestType{1u} << (d - 1));
+    STATIC_REQUIRE(stdx::rotr(TestType{2u}, 1) == TestType{1u});
+    STATIC_REQUIRE(stdx::rotr(TestType{1u}, 1) == TestType{1u} << (d - 1));
 }
 
 TEST_CASE("bit_pack 2x8 -> 16", "[bit]") {
-    static_assert(stdx::bit_pack<std::uint16_t>(0x12, 0x34) == 0x1234);
+    STATIC_REQUIRE(stdx::bit_pack<std::uint16_t>(0x12, 0x34) == 0x1234);
 }
 
 TEST_CASE("bit_pack 2x16 -> 32", "[bit]") {
-    static_assert(stdx::bit_pack<std::uint32_t>(0x1234, 0x5678) == 0x1234'5678);
+    STATIC_REQUIRE(stdx::bit_pack<std::uint32_t>(0x1234, 0x5678) ==
+                   0x1234'5678);
 }
 
 TEST_CASE("bit_pack 4x8 -> 32", "[bit]") {
-    static_assert(stdx::bit_pack<std::uint32_t>(0x12, 0x34, 0x56, 0x78) ==
-                  0x1234'5678);
+    STATIC_REQUIRE(stdx::bit_pack<std::uint32_t>(0x12, 0x34, 0x56, 0x78) ==
+                   0x1234'5678);
 }
 
 TEST_CASE("bit_pack 2x32 -> 64", "[bit]") {
-    static_assert(stdx::bit_pack<std::uint64_t>(0x1234'5678, 0x9abc'def0) ==
-                  0x1234'5678'9abc'def0);
+    STATIC_REQUIRE(stdx::bit_pack<std::uint64_t>(0x1234'5678, 0x9abc'def0) ==
+                   0x1234'5678'9abc'def0);
 }
 
 TEST_CASE("bit_pack 4x16 -> 64", "[bit]") {
-    static_assert(stdx::bit_pack<std::uint64_t>(
-                      0x1234, 0x5678, 0x9abc, 0xdef0) == 0x1234'5678'9abc'def0);
+    STATIC_REQUIRE(
+        stdx::bit_pack<std::uint64_t>(0x1234, 0x5678, 0x9abc, 0xdef0) ==
+        0x1234'5678'9abc'def0);
 }
 
 TEST_CASE("bit_pack 8x8 -> 64", "[bit]") {
-    static_assert(stdx::bit_pack<std::uint64_t>(0x12, 0x34, 0x56, 0x78, 0x9a,
-                                                0xbc, 0xde,
-                                                0xf0) == 0x1234'5678'9abc'def0);
+    STATIC_REQUIRE(stdx::bit_pack<std::uint64_t>(0x12, 0x34, 0x56, 0x78, 0x9a,
+                                                 0xbc, 0xde, 0xf0) ==
+                   0x1234'5678'9abc'def0);
 }
 
 TEST_CASE("template bit_mask (whole range)", "[bit]") {
     constexpr auto m = stdx::bit_mask<std::uint64_t>();
-    static_assert(m == std::numeric_limits<std::uint64_t>::max());
-    static_assert(m == stdx::bit_mask<std::uint64_t, 63>());
-    static_assert(m == stdx::bit_mask<std::uint64_t, 63, 0>());
+    STATIC_REQUIRE(m == std::numeric_limits<std::uint64_t>::max());
+    STATIC_REQUIRE(m == stdx::bit_mask<std::uint64_t, 63>());
+    STATIC_REQUIRE(m == stdx::bit_mask<std::uint64_t, 63, 0>());
 }
 
 TEST_CASE("template bit_mask (low bits)", "[bit]") {
     constexpr auto m = stdx::bit_mask<std::uint8_t, 1, 0>();
-    static_assert(m == 0b0000'0011);
-    static_assert(std::is_same_v<decltype(m), std::uint8_t const>);
+    STATIC_REQUIRE(m == 0b0000'0011);
+    STATIC_REQUIRE(std::is_same_v<decltype(m), std::uint8_t const>);
 }
 
 TEST_CASE("template bit_mask (mid bits)", "[bit]") {
     constexpr auto m = stdx::bit_mask<std::uint8_t, 4, 3>();
-    static_assert(m == 0b0001'1000);
-    static_assert(std::is_same_v<decltype(m), std::uint8_t const>);
+    STATIC_REQUIRE(m == 0b0001'1000);
+    STATIC_REQUIRE(std::is_same_v<decltype(m), std::uint8_t const>);
 }
 
 TEST_CASE("template bit_mask (high bits)", "[bit]") {
     constexpr auto m = stdx::bit_mask<std::uint8_t, 7, 6>();
-    static_assert(m == 0b1100'0000);
-    static_assert(std::is_same_v<decltype(m), std::uint8_t const>);
+    STATIC_REQUIRE(m == 0b1100'0000);
+    STATIC_REQUIRE(std::is_same_v<decltype(m), std::uint8_t const>);
 }
 
 TEST_CASE("template bit_mask (single bit)", "[bit]") {
     constexpr auto m = stdx::bit_mask<std::uint8_t, 5, 5>();
-    static_assert(m == 0b0010'0000);
-    static_assert(std::is_same_v<decltype(m), std::uint8_t const>);
+    STATIC_REQUIRE(m == 0b0010'0000);
+    STATIC_REQUIRE(std::is_same_v<decltype(m), std::uint8_t const>);
 }
 
 TEST_CASE("template bit_mask (array type whole range)", "[bit]") {
@@ -295,39 +298,39 @@ TEST_CASE("template bit_mask (large array type)", "[bit]") {
 
 TEST_CASE("arg bit_mask (whole range)", "[bit]") {
     constexpr auto m = stdx::bit_mask<std::uint64_t>(63);
-    static_assert(m == std::numeric_limits<std::uint64_t>::max());
-    static_assert(m == stdx::bit_mask<std::uint64_t>(63, 0));
+    STATIC_REQUIRE(m == std::numeric_limits<std::uint64_t>::max());
+    STATIC_REQUIRE(m == stdx::bit_mask<std::uint64_t>(63, 0));
 }
 
 TEST_CASE("arg bit_mask (low bits)", "[bit]") {
     constexpr auto m = stdx::bit_mask<std::uint8_t>(1, 0);
-    static_assert(m == 0b0000'0011);
-    static_assert(std::is_same_v<decltype(m), std::uint8_t const>);
+    STATIC_REQUIRE(m == 0b0000'0011);
+    STATIC_REQUIRE(std::is_same_v<decltype(m), std::uint8_t const>);
 }
 
 TEST_CASE("arg bit_mask (mid bits)", "[bit]") {
     constexpr auto m = stdx::bit_mask<std::uint8_t>(4, 3);
-    static_assert(m == 0b0001'1000);
-    static_assert(std::is_same_v<decltype(m), std::uint8_t const>);
+    STATIC_REQUIRE(m == 0b0001'1000);
+    STATIC_REQUIRE(std::is_same_v<decltype(m), std::uint8_t const>);
 }
 
 TEST_CASE("arg bit_mask (high bits)", "[bit]") {
     constexpr auto m = stdx::bit_mask<std::uint8_t>(7, 6);
-    static_assert(m == 0b1100'0000);
-    static_assert(std::is_same_v<decltype(m), std::uint8_t const>);
+    STATIC_REQUIRE(m == 0b1100'0000);
+    STATIC_REQUIRE(std::is_same_v<decltype(m), std::uint8_t const>);
 }
 
 TEST_CASE("arg bit_mask (single bit)", "[bit]") {
     constexpr auto m = stdx::bit_mask<std::uint8_t>(5, 5);
-    static_assert(m == 0b0010'0000);
-    static_assert(std::is_same_v<decltype(m), std::uint8_t const>);
+    STATIC_REQUIRE(m == 0b0010'0000);
+    STATIC_REQUIRE(std::is_same_v<decltype(m), std::uint8_t const>);
 }
 
 TEMPLATE_TEST_CASE("bit_size", "[bit]", std::uint8_t, std::uint16_t,
                    std::uint32_t, std::uint64_t, std::int8_t, std::int16_t,
                    std::int32_t, std::int64_t) {
-    static_assert(stdx::bit_size<TestType>() ==
-                  std::numeric_limits<std::make_unsigned_t<TestType>>::digits);
+    STATIC_REQUIRE(stdx::bit_size<TestType>() ==
+                   std::numeric_limits<std::make_unsigned_t<TestType>>::digits);
 }
 
 TEST_CASE("bit_unpack 64 -> 2x32", "[bit]") {

--- a/test/bitset.cpp
+++ b/test/bitset.cpp
@@ -8,35 +8,35 @@
 #include <type_traits>
 
 TEST_CASE("bitset storage rounds up to nearest element size", "[bitset]") {
-    static_assert(sizeof(stdx::bitset<1, std::uint8_t>) == 1);
-    static_assert(sizeof(stdx::bitset<8, std::uint8_t>) == 1);
-    static_assert(sizeof(stdx::bitset<9, std::uint8_t>) == 2);
+    STATIC_REQUIRE(sizeof(stdx::bitset<1, std::uint8_t>) == 1);
+    STATIC_REQUIRE(sizeof(stdx::bitset<8, std::uint8_t>) == 1);
+    STATIC_REQUIRE(sizeof(stdx::bitset<9, std::uint8_t>) == 2);
 
-    static_assert(sizeof(stdx::bitset<1, std::uint16_t>) == 2);
-    static_assert(sizeof(stdx::bitset<16, std::uint16_t>) == 2);
-    static_assert(sizeof(stdx::bitset<17, std::uint16_t>) == 4);
+    STATIC_REQUIRE(sizeof(stdx::bitset<1, std::uint16_t>) == 2);
+    STATIC_REQUIRE(sizeof(stdx::bitset<16, std::uint16_t>) == 2);
+    STATIC_REQUIRE(sizeof(stdx::bitset<17, std::uint16_t>) == 4);
 }
 
 TEST_CASE("bitset with implicit storage element type", "[bitset]") {
-    static_assert(sizeof(stdx::bitset<1>) == 1);
-    static_assert(sizeof(stdx::bitset<8>) == 1);
-    static_assert(sizeof(stdx::bitset<9>) == 2);
-    static_assert(sizeof(stdx::bitset<16>) == 2);
-    static_assert(sizeof(stdx::bitset<17>) == 4);
-    static_assert(sizeof(stdx::bitset<32>) == 4);
-    static_assert(sizeof(stdx::bitset<33>) == 8);
-    static_assert(sizeof(stdx::bitset<64>) == 8);
+    STATIC_REQUIRE(sizeof(stdx::bitset<1>) == 1);
+    STATIC_REQUIRE(sizeof(stdx::bitset<8>) == 1);
+    STATIC_REQUIRE(sizeof(stdx::bitset<9>) == 2);
+    STATIC_REQUIRE(sizeof(stdx::bitset<16>) == 2);
+    STATIC_REQUIRE(sizeof(stdx::bitset<17>) == 4);
+    STATIC_REQUIRE(sizeof(stdx::bitset<32>) == 4);
+    STATIC_REQUIRE(sizeof(stdx::bitset<33>) == 8);
+    STATIC_REQUIRE(sizeof(stdx::bitset<64>) == 8);
 }
 
 TEMPLATE_TEST_CASE("bitset size", "[bitset]", std::uint8_t, std::uint16_t,
                    std::uint32_t, std::uint64_t) {
-    static_assert(stdx::bitset<1, TestType>{}.size() == 1);
-    static_assert(stdx::bitset<8, TestType>{}.size() == 8);
+    STATIC_REQUIRE(stdx::bitset<1, TestType>{}.size() == 1);
+    STATIC_REQUIRE(stdx::bitset<8, TestType>{}.size() == 8);
 }
 
 TEMPLATE_TEST_CASE("index operation", "[bitset]", std::uint8_t, std::uint16_t,
                    std::uint32_t, std::uint64_t) {
-    static_assert(not stdx::bitset<1, TestType>{}[0]);
+    STATIC_REQUIRE(not stdx::bitset<1, TestType>{}[0]);
 }
 
 TEMPLATE_TEST_CASE("set single bit", "[bitset]", std::uint8_t, std::uint16_t,
@@ -100,34 +100,34 @@ TEMPLATE_TEST_CASE("flip all bits", "[bitset]", std::uint8_t, std::uint16_t,
 TEMPLATE_TEST_CASE("construct with a value", "[bitset]", std::uint8_t,
                    std::uint16_t, std::uint32_t, std::uint64_t) {
     constexpr auto bs1 = stdx::bitset<1, TestType>{1ul};
-    static_assert(bs1[0]);
+    STATIC_REQUIRE(bs1[0]);
 
     constexpr auto bs2 = stdx::bitset<3, TestType>{255ul};
-    static_assert(bs2[0]);
-    static_assert(bs2[1]);
+    STATIC_REQUIRE(bs2[0]);
+    STATIC_REQUIRE(bs2[1]);
 }
 
 TEMPLATE_TEST_CASE("construct with values for bits", "[bitset]", std::uint8_t,
                    std::uint16_t, std::uint32_t, std::uint64_t) {
     constexpr auto bs = stdx::bitset<8, TestType>{stdx::place_bits, 1, 3, 5};
-    static_assert(not bs[0]);
-    static_assert(bs[1]);
-    static_assert(bs[3]);
-    static_assert(bs[5]);
+    STATIC_REQUIRE(not bs[0]);
+    STATIC_REQUIRE(bs[1]);
+    STATIC_REQUIRE(bs[3]);
+    STATIC_REQUIRE(bs[5]);
 }
 
 TEMPLATE_TEST_CASE("construct with a string_view", "[bitset]", std::uint8_t,
                    std::uint16_t, std::uint32_t, std::uint64_t) {
     using namespace std::string_view_literals;
-    static_assert(stdx::bitset<4, TestType>{"1010"sv} ==
-                  stdx::bitset<4, TestType>{0b1010ul});
+    STATIC_REQUIRE(stdx::bitset<4, TestType>{"1010"sv} ==
+                   stdx::bitset<4, TestType>{0b1010ul});
 }
 
 TEMPLATE_TEST_CASE("construct with a substring", "[bitset]", std::uint8_t,
                    std::uint16_t, std::uint32_t, std::uint64_t) {
     using namespace std::string_view_literals;
-    static_assert(stdx::bitset<4, TestType>{"XOXOXO"sv, 2, 4, 'X'} ==
-                  stdx::bitset<4, TestType>{0b1010ul});
+    STATIC_REQUIRE(stdx::bitset<4, TestType>{"XOXOXO"sv, 2, 4, 'X'} ==
+                   stdx::bitset<4, TestType>{0b1010ul});
 }
 
 TEMPLATE_TEST_CASE("convert to unsigned integral type (same underlying type)",
@@ -135,8 +135,8 @@ TEMPLATE_TEST_CASE("convert to unsigned integral type (same underlying type)",
                    std::uint64_t) {
     constexpr auto bs = stdx::bitset<3, TestType>{255ul};
     constexpr auto val = bs.template to<TestType>();
-    static_assert(std::is_same_v<decltype(val), TestType const>);
-    static_assert(val == 7u);
+    STATIC_REQUIRE(std::is_same_v<decltype(val), TestType const>);
+    STATIC_REQUIRE(val == 7u);
 }
 
 TEMPLATE_TEST_CASE(
@@ -145,100 +145,100 @@ TEMPLATE_TEST_CASE(
     constexpr auto bs =
         stdx::bitset<11, std::uint8_t>{stdx::place_bits, 3, 7, 10};
     constexpr auto val = bs.to<TestType>();
-    static_assert(std::is_same_v<decltype(val), TestType const>);
-    static_assert(val == 0b100'1000'1000u);
+    STATIC_REQUIRE(std::is_same_v<decltype(val), TestType const>);
+    STATIC_REQUIRE(val == 0b100'1000'1000u);
 }
 
 TEST_CASE("convert to type that fits", "[bitset]") {
     constexpr auto bs =
         stdx::bitset<11, std::uint8_t>{stdx::place_bits, 3, 7, 10};
     constexpr auto val = bs.to_natural();
-    static_assert(std::is_same_v<decltype(val), std::uint16_t const>);
-    static_assert(val == 0b100'1000'1000u);
+    STATIC_REQUIRE(std::is_same_v<decltype(val), std::uint16_t const>);
+    STATIC_REQUIRE(val == 0b100'1000'1000u);
 }
 
 TEMPLATE_TEST_CASE("all", "[bitset]", std::uint8_t, std::uint16_t,
                    std::uint32_t, std::uint64_t) {
     constexpr auto bs1 =
         stdx::bitset<8, TestType>{std::numeric_limits<TestType>::max()};
-    static_assert(bs1.all());
+    STATIC_REQUIRE(bs1.all());
 
     constexpr auto bs2 = stdx::bitset<9, TestType>{0x1fful};
-    static_assert(bs2.all());
+    STATIC_REQUIRE(bs2.all());
 
     constexpr auto bs3 = stdx::bitset<8, TestType>{0xf7ul};
-    static_assert(not bs3.all());
+    STATIC_REQUIRE(not bs3.all());
 }
 
 TEMPLATE_TEST_CASE("any", "[bitset]", std::uint8_t, std::uint16_t,
                    std::uint32_t, std::uint64_t) {
     constexpr auto bs1 = stdx::bitset<8, TestType>{8ul};
-    static_assert(bs1.any());
+    STATIC_REQUIRE(bs1.any());
 
     constexpr auto bs2 = stdx::bitset<9, TestType>{0xfful};
-    static_assert(bs2.any());
+    STATIC_REQUIRE(bs2.any());
 
     constexpr auto bs3 = stdx::bitset<8, TestType>{};
-    static_assert(not bs3.any());
+    STATIC_REQUIRE(not bs3.any());
 }
 
 TEMPLATE_TEST_CASE("none", "[bitset]", std::uint8_t, std::uint16_t,
                    std::uint32_t, std::uint64_t) {
     constexpr auto bs1 = stdx::bitset<8, TestType>{};
-    static_assert(bs1.none());
+    STATIC_REQUIRE(bs1.none());
 
     constexpr auto bs2 = stdx::bitset<8, TestType>{8ul};
-    static_assert(not bs2.none());
+    STATIC_REQUIRE(not bs2.none());
 }
 
 TEMPLATE_TEST_CASE("count", "[bitset]", std::uint8_t, std::uint16_t,
                    std::uint32_t, std::uint64_t) {
     constexpr auto bs1 = stdx::bitset<8, TestType>{};
-    static_assert(bs1.count() == 0u);
+    STATIC_REQUIRE(bs1.count() == 0u);
 
     constexpr auto bs2 = stdx::bitset<8, TestType>{0b10101ul};
-    static_assert(bs2.count() == 3u);
+    STATIC_REQUIRE(bs2.count() == 3u);
 }
 
 TEMPLATE_TEST_CASE("or", "[bitset]", std::uint8_t, std::uint16_t, std::uint32_t,
                    std::uint64_t) {
     constexpr auto bs1 = stdx::bitset<3, TestType>{0b101ul};
     constexpr auto bs2 = stdx::bitset<3, TestType>{0b010ul};
-    static_assert((bs1 | bs2) == stdx::bitset<3, TestType>{0b111ul});
+    STATIC_REQUIRE((bs1 | bs2) == stdx::bitset<3, TestType>{0b111ul});
 }
 
 TEMPLATE_TEST_CASE("and", "[bitset]", std::uint8_t, std::uint16_t,
                    std::uint32_t, std::uint64_t) {
     constexpr auto bs1 = stdx::bitset<3, TestType>{0b101ul};
     constexpr auto bs2 = stdx::bitset<3, TestType>{0b100ul};
-    static_assert((bs1 & bs2) == stdx::bitset<3, TestType>{0b100ul});
+    STATIC_REQUIRE((bs1 & bs2) == stdx::bitset<3, TestType>{0b100ul});
 }
 
 TEMPLATE_TEST_CASE("xor", "[bitset]", std::uint8_t, std::uint16_t,
                    std::uint32_t, std::uint64_t) {
     constexpr auto bs1 = stdx::bitset<3, TestType>{0b101ul};
     constexpr auto bs2 = stdx::bitset<3, TestType>{0b010ul};
-    static_assert((bs1 ^ bs2) == stdx::bitset<3, TestType>{0b111ul});
+    STATIC_REQUIRE((bs1 ^ bs2) == stdx::bitset<3, TestType>{0b111ul});
 }
 
 TEMPLATE_TEST_CASE("not", "[bitset]", std::uint8_t, std::uint16_t,
                    std::uint32_t, std::uint64_t) {
     constexpr auto bs = stdx::bitset<3, TestType>{0b101ul};
-    static_assert(~bs == stdx::bitset<3, TestType>{0b10ul});
+    STATIC_REQUIRE(~bs == stdx::bitset<3, TestType>{0b10ul});
 }
 
 TEMPLATE_TEST_CASE("difference", "[bitset]", std::uint8_t, std::uint16_t,
                    std::uint32_t, std::uint64_t) {
     constexpr auto bs1 = stdx::bitset<3, TestType>{0b101ul};
     constexpr auto bs2 = stdx::bitset<3, TestType>{0b011ul};
-    static_assert(bs1 - bs2 == stdx::bitset<3, TestType>{0b100ul});
+    STATIC_REQUIRE(bs1 - bs2 == stdx::bitset<3, TestType>{0b100ul});
 }
 
 TEMPLATE_TEST_CASE("left shift", "[bitset]", std::uint8_t, std::uint16_t,
                    std::uint32_t, std::uint64_t) {
     constexpr auto bs = stdx::bitset<3, TestType>{0b101ul};
-    static_assert(bs << 1u == stdx::bitset<3, TestType>{0b10ul});
-    static_assert(bs << 2u == stdx::bitset<3, TestType>{0b100ul});
+    STATIC_REQUIRE(bs << 1u == stdx::bitset<3, TestType>{0b10ul});
+    STATIC_REQUIRE(bs << 2u == stdx::bitset<3, TestType>{0b100ul});
 }
 
 TEMPLATE_TEST_CASE("left shift (equal to type size)", "[bitset]", std::uint8_t,
@@ -256,7 +256,7 @@ TEMPLATE_TEST_CASE("left shift (equal to type size)", "[bitset]", std::uint8_t,
 TEMPLATE_TEST_CASE("left shift (off end)", "[bitset]", std::uint8_t,
                    std::uint16_t, std::uint32_t, std::uint64_t) {
     constexpr auto bs = stdx::bitset<3, TestType>{0b101ul};
-    static_assert(bs << 3u == stdx::bitset<3, TestType>{});
+    STATIC_REQUIRE(bs << 3u == stdx::bitset<3, TestType>{});
 }
 
 TEMPLATE_TEST_CASE("left shift (large shift)", "[bitset]", std::uint8_t,
@@ -264,17 +264,17 @@ TEMPLATE_TEST_CASE("left shift (large shift)", "[bitset]", std::uint8_t,
     constexpr auto sz = std::numeric_limits<TestType>::digits * 2;
     constexpr auto shift_amount = std::numeric_limits<TestType>::digits + 1;
     constexpr auto bs = stdx::bitset<sz, TestType>{0b101ul} << shift_amount;
-    static_assert(not bs[0]);
-    static_assert(bs[shift_amount]);
-    static_assert(not bs[shift_amount + 1]);
-    static_assert(bs[shift_amount + 2]);
+    STATIC_REQUIRE(not bs[0]);
+    STATIC_REQUIRE(bs[shift_amount]);
+    STATIC_REQUIRE(not bs[shift_amount + 1]);
+    STATIC_REQUIRE(bs[shift_amount + 2]);
 }
 
 TEMPLATE_TEST_CASE("right shift", "[bitset]", std::uint8_t, std::uint16_t,
                    std::uint32_t, std::uint64_t) {
     constexpr auto bs = stdx::bitset<3, TestType>{0b101ul};
-    static_assert(bs >> 1u == stdx::bitset<3, TestType>{0b10ul});
-    static_assert(bs >> 2u == stdx::bitset<3, TestType>{0b1ul});
+    STATIC_REQUIRE(bs >> 1u == stdx::bitset<3, TestType>{0b10ul});
+    STATIC_REQUIRE(bs >> 2u == stdx::bitset<3, TestType>{0b1ul});
 }
 
 TEMPLATE_TEST_CASE("right shift (equal to type size)", "[bitset]", std::uint8_t,
@@ -292,7 +292,7 @@ TEMPLATE_TEST_CASE("right shift (equal to type size)", "[bitset]", std::uint8_t,
 TEMPLATE_TEST_CASE("right shift (off end)", "[bitset]", std::uint8_t,
                    std::uint16_t, std::uint32_t, std::uint64_t) {
     constexpr auto bs = stdx::bitset<3, TestType>{0b101ul};
-    static_assert(bs >> 3u == stdx::bitset<3, TestType>{});
+    STATIC_REQUIRE(bs >> 3u == stdx::bitset<3, TestType>{});
 }
 
 TEMPLATE_TEST_CASE("right shift (large shift)", "[bitset]", std::uint8_t,
@@ -372,7 +372,7 @@ TEMPLATE_TEST_CASE("set range of bits (lsb, msb)", "[bitset]", std::uint8_t,
 TEMPLATE_TEST_CASE("construct with all bits set", "[bitset]", std::uint8_t,
                    std::uint16_t, std::uint32_t, std::uint64_t) {
     constexpr auto bs = stdx::bitset<9, TestType>{stdx::all_bits};
-    static_assert(bs.all());
+    STATIC_REQUIRE(bs.all());
 }
 
 TEMPLATE_TEST_CASE("reset range of bits (lsb, length)", "[bitset]",
@@ -405,8 +405,8 @@ TEMPLATE_TEST_CASE("set/reset all bits with size at type capacity", "[bitset]",
     constexpr auto expected = std::numeric_limits<TestType>::max();
 
     constexpr auto bs1 = stdx::bitset<sz, TestType>{stdx::all_bits};
-    static_assert(bs1.all());
-    static_assert(bs1.template to<TestType>() == expected);
+    STATIC_REQUIRE(bs1.all());
+    STATIC_REQUIRE(bs1.template to<TestType>() == expected);
 
     auto bs2 = stdx::bitset<sz, TestType>{};
     bs2.set();
@@ -419,7 +419,7 @@ TEMPLATE_TEST_CASE("set/reset all bits with size at type capacity", "[bitset]",
 TEMPLATE_TEST_CASE("find lowest unset bit (element 0)", "[bitset]",
                    std::uint8_t, std::uint16_t, std::uint32_t, std::uint64_t) {
     constexpr auto bs = stdx::bitset<4, TestType>{stdx::place_bits, 0, 1, 3};
-    static_assert(bs.lowest_unset() == 2);
+    STATIC_REQUIRE(bs.lowest_unset() == 2);
 }
 
 TEMPLATE_TEST_CASE("find lowest unset bit (element > 0)", "[bitset]",
@@ -434,7 +434,7 @@ TEMPLATE_TEST_CASE("find lowest unset bit (full)", "[bitset]", std::uint8_t,
                    std::uint16_t, std::uint32_t, std::uint64_t) {
     constexpr auto sz = std::numeric_limits<TestType>::digits;
     constexpr auto bs = stdx::bitset<sz, TestType>{stdx::all_bits};
-    static_assert(bs.lowest_unset() == sz);
+    STATIC_REQUIRE(bs.lowest_unset() == sz);
 }
 
 namespace {
@@ -443,12 +443,12 @@ enum struct Bits : std::uint8_t { ZERO, ONE, TWO, THREE, MAX };
 
 TEST_CASE("use bitset with enum struct (default construct)", "[bitset]") {
     constexpr auto bs = stdx::bitset<Bits::MAX>{};
-    static_assert(bs.size() == stdx::to_underlying(Bits::MAX));
+    STATIC_REQUIRE(bs.size() == stdx::to_underlying(Bits::MAX));
 }
 
 TEST_CASE("use bitset with enum struct (to)", "[bitset]") {
     constexpr auto bs = stdx::bitset<Bits::MAX>{stdx::all_bits};
-    static_assert(bs.to<Bits>() == static_cast<Bits>(0b1111));
+    STATIC_REQUIRE(bs.to<Bits>() == static_cast<Bits>(0b1111));
 }
 
 TEST_CASE("use bitset with enum struct (set/flip)", "[bitset]") {
@@ -463,15 +463,15 @@ TEST_CASE("use bitset with enum struct (set/flip)", "[bitset]") {
 
 TEST_CASE("use bitset with enum struct (read index)", "[bitset]") {
     constexpr auto bs = stdx::bitset<Bits::MAX>{stdx::all_bits};
-    static_assert(bs[Bits::ZERO]);
-    static_assert(bs[Bits::ONE]);
-    static_assert(bs[Bits::TWO]);
-    static_assert(bs[Bits::THREE]);
+    STATIC_REQUIRE(bs[Bits::ZERO]);
+    STATIC_REQUIRE(bs[Bits::ONE]);
+    STATIC_REQUIRE(bs[Bits::TWO]);
+    STATIC_REQUIRE(bs[Bits::THREE]);
 }
 
 TEST_CASE("use bitset with enum struct (place_bits construct)", "[bitset]") {
     constexpr auto bs = stdx::bitset<Bits::MAX>{stdx::place_bits, Bits::ZERO};
-    static_assert(bs.to_natural() == 1);
+    STATIC_REQUIRE(bs.to_natural() == 1);
 }
 
 TEST_CASE("use bitset with enum struct (for_each)", "[bitset]") {
@@ -493,9 +493,9 @@ TEST_CASE("use bitset with enum struct (lowest_unset)", "[bitset]") {
 #if __cplusplus >= 202002L
 TEST_CASE("construct with a ct_string", "[bitset]") {
     using namespace stdx::literals;
-    static_assert(stdx::bitset{"1010"_cts} ==
-                  stdx::bitset<4ul, std::uint8_t>{0b1010ul});
-    static_assert(stdx::bitset{"101010101"_cts} ==
-                  stdx::bitset<9ul, std::uint16_t>{0b101010101ul});
+    STATIC_REQUIRE(stdx::bitset{"1010"_cts} ==
+                   stdx::bitset<4ul, std::uint8_t>{0b1010ul});
+    STATIC_REQUIRE(stdx::bitset{"101010101"_cts} ==
+                   stdx::bitset<9ul, std::uint16_t>{0b101010101ul});
 }
 #endif

--- a/test/byterator.cpp
+++ b/test/byterator.cpp
@@ -89,14 +89,14 @@ TEST_CASE("advance", "[byterator]") {
     CHECK((i - 1 == b));
     i.advance(-1);
     CHECK((i == b));
-    static_assert(std::is_same_v<decltype(i.advance()),
-                                 stdx::byterator<std::uint16_t const> &>);
+    STATIC_REQUIRE(std::is_same_v<decltype(i.advance()),
+                                  stdx::byterator<std::uint16_t const> &>);
 }
 
 TEST_CASE("equality comparable", "[byterator]") {
     auto const a = std::array{1, 2, 3, 4};
     auto x = stdx::byterator{std::begin(a)};
-    static_assert(stdx::equality_comparable<decltype(x)>);
+    STATIC_REQUIRE(stdx::equality_comparable<decltype(x)>);
     auto y = x;
     CHECK(x == y);
     ++y;
@@ -106,7 +106,7 @@ TEST_CASE("equality comparable", "[byterator]") {
 TEST_CASE("totally ordered", "[byterator]") {
     auto const a = std::array{1, 2, 3, 4};
     auto x = stdx::byterator{std::begin(a)};
-    static_assert(stdx::totally_ordered<decltype(x)>);
+    STATIC_REQUIRE(stdx::totally_ordered<decltype(x)>);
     auto y = std::next(x);
     CHECK(x < y);
     CHECK(x <= y);
@@ -153,7 +153,7 @@ TEST_CASE("peek uint8_t", "[byterator]") {
     auto const a = std::array{stdx::to_be<std::uint16_t>(0x0102),
                               stdx::to_be<std::uint16_t>(0x0304)};
     auto i = stdx::byterator{std::begin(a)};
-    static_assert(std::is_same_v<decltype(i.readu8()), std::uint8_t>);
+    STATIC_REQUIRE(std::is_same_v<decltype(i.readu8()), std::uint8_t>);
     CHECK(i.peeku8() == 1);
     CHECK((i == std::begin(a)));
 }
@@ -172,7 +172,7 @@ TEST_CASE("read uint8_t", "[byterator]") {
                               stdx::to_be<std::uint16_t>(0x0304)};
     auto i = stdx::byterator{std::begin(a)};
     auto j = std::next(i);
-    static_assert(std::is_same_v<decltype(i.readu8()), std::uint8_t>);
+    STATIC_REQUIRE(std::is_same_v<decltype(i.readu8()), std::uint8_t>);
     CHECK(i.readu8() == 1);
     CHECK((i == j));
 }
@@ -191,7 +191,7 @@ TEST_CASE("peek uint16_t", "[byterator]") {
     auto const a = std::array{stdx::to_be<std::uint16_t>(0x0102),
                               stdx::to_be<std::uint16_t>(0x0304)};
     auto i = stdx::byterator{std::begin(a)};
-    static_assert(std::is_same_v<decltype(i.readu16()), std::uint16_t>);
+    STATIC_REQUIRE(std::is_same_v<decltype(i.readu16()), std::uint16_t>);
     CHECK(i.peeku16() == stdx::to_be<std::uint16_t>(0x0102));
     CHECK((i == std::begin(a)));
 }
@@ -210,7 +210,7 @@ TEST_CASE("read uint16_t", "[byterator]") {
                               stdx::to_be<std::uint16_t>(0x0304)};
     auto i = stdx::byterator{std::begin(a)};
     auto j = i + 2;
-    static_assert(std::is_same_v<decltype(i.readu16()), std::uint16_t>);
+    STATIC_REQUIRE(std::is_same_v<decltype(i.readu16()), std::uint16_t>);
     CHECK(i.readu16() == stdx::to_be<std::uint16_t>(0x0102));
     CHECK((i == j));
 }
@@ -229,7 +229,7 @@ TEST_CASE("peek uint32_t", "[byterator]") {
     auto const a = std::array{stdx::to_be<std::uint16_t>(0x0102),
                               stdx::to_be<std::uint16_t>(0x0304)};
     auto i = stdx::byterator{std::begin(a)};
-    static_assert(std::is_same_v<decltype(i.readu32()), std::uint32_t>);
+    STATIC_REQUIRE(std::is_same_v<decltype(i.readu32()), std::uint32_t>);
     CHECK(i.peeku32() == stdx::to_be<std::uint32_t>(0x01020304));
     CHECK((i == std::begin(a)));
 }
@@ -246,7 +246,7 @@ TEST_CASE("read uint32_t", "[byterator]") {
     auto const a = std::array{stdx::to_be<std::uint16_t>(0x0102),
                               stdx::to_be<std::uint16_t>(0x0304)};
     auto i = stdx::byterator{std::begin(a)};
-    static_assert(std::is_same_v<decltype(i.readu32()), std::uint32_t>);
+    STATIC_REQUIRE(std::is_same_v<decltype(i.readu32()), std::uint32_t>);
     CHECK(i.readu32() == stdx::to_be<std::uint32_t>(0x01020304));
     CHECK((i == std::end(a)));
 }
@@ -266,7 +266,7 @@ TEST_CASE("peek uint64_t", "[byterator]") {
         stdx::to_be<std::uint16_t>(0x0102), stdx::to_be<std::uint16_t>(0x0304),
         stdx::to_be<std::uint16_t>(0x0506), stdx::to_be<std::uint16_t>(0x0708)};
     auto i = stdx::byterator{std::begin(a)};
-    static_assert(std::is_same_v<decltype(i.readu64()), std::uint64_t>);
+    STATIC_REQUIRE(std::is_same_v<decltype(i.readu64()), std::uint64_t>);
     CHECK(i.peeku64() == stdx::to_be<std::uint64_t>(0x0102030405060708));
     CHECK((i == std::begin(a)));
 }
@@ -285,7 +285,7 @@ TEST_CASE("read uint64_t", "[byterator]") {
         stdx::to_be<std::uint16_t>(0x0102), stdx::to_be<std::uint16_t>(0x0304),
         stdx::to_be<std::uint16_t>(0x0506), stdx::to_be<std::uint16_t>(0x0708)};
     auto i = stdx::byterator{std::begin(a)};
-    static_assert(std::is_same_v<decltype(i.readu64()), std::uint64_t>);
+    STATIC_REQUIRE(std::is_same_v<decltype(i.readu64()), std::uint64_t>);
     CHECK(i.readu64() == stdx::to_be<std::uint64_t>(0x0102030405060708));
     CHECK((i == std::end(a)));
 }
@@ -311,7 +311,7 @@ TEST_CASE("peek enum", "[byterator]") {
     auto const a = std::array{stdx::to_be<std::uint16_t>(0x0102),
                               stdx::to_be<std::uint16_t>(0x0304)};
     auto i = stdx::byterator{std::begin(a)};
-    static_assert(std::is_same_v<decltype(i.readu32()), std::uint32_t>);
+    STATIC_REQUIRE(std::is_same_v<decltype(i.readu32()), std::uint32_t>);
     CHECK(i.peek<E>() == E::A);
 }
 
@@ -328,7 +328,7 @@ TEST_CASE("read enum", "[byterator]") {
     auto const a = std::array{stdx::to_be<std::uint16_t>(0x0102),
                               stdx::to_be<std::uint16_t>(0x0304)};
     auto i = stdx::byterator{std::begin(a)};
-    static_assert(std::is_same_v<decltype(i.readu32()), std::uint32_t>);
+    STATIC_REQUIRE(std::is_same_v<decltype(i.readu32()), std::uint32_t>);
     CHECK(i.read<E>() == E::A);
 }
 
@@ -348,7 +348,7 @@ TEST_CASE("peek enum (constrained size)", "[byterator]") {
     auto const a = std::array{stdx::to_be<std::uint16_t>(0x0102),
                               stdx::to_be<std::uint16_t>(0x0304)};
     auto i = stdx::byterator{std::begin(a)};
-    static_assert(std::is_same_v<decltype(i.readu32()), std::uint32_t>);
+    STATIC_REQUIRE(std::is_same_v<decltype(i.readu32()), std::uint32_t>);
     CHECK(i.peek<std::uint8_t, E2>() == E2::A);
 }
 
@@ -357,7 +357,7 @@ TEST_CASE("read enum (constrained size)", "[byterator]") {
                               stdx::to_be<std::uint16_t>(0x0304)};
     auto i = stdx::byterator{std::begin(a)};
     auto j = std::next(i);
-    static_assert(std::is_same_v<decltype(i.readu32()), std::uint32_t>);
+    STATIC_REQUIRE(std::is_same_v<decltype(i.readu32()), std::uint32_t>);
     CHECK(i.read<std::uint8_t, E2>() == E2::A);
     CHECK((i == j));
 }
@@ -376,7 +376,7 @@ TEST_CASE("peek enum (constrained size alias)", "[byterator]") {
     auto const a = std::array{stdx::to_be<std::uint16_t>(0x0102),
                               stdx::to_be<std::uint16_t>(0x0304)};
     auto i = stdx::byterator{std::begin(a)};
-    static_assert(std::is_same_v<decltype(i.readu32()), std::uint32_t>);
+    STATIC_REQUIRE(std::is_same_v<decltype(i.readu32()), std::uint32_t>);
     CHECK(i.peeku8<E2>() == E2::A);
 }
 
@@ -385,7 +385,7 @@ TEST_CASE("read enum (constrained size alias)", "[byterator]") {
                               stdx::to_be<std::uint16_t>(0x0304)};
     auto i = stdx::byterator{std::begin(a)};
     auto j = std::next(i);
-    static_assert(std::is_same_v<decltype(i.readu32()), std::uint32_t>);
+    STATIC_REQUIRE(std::is_same_v<decltype(i.readu32()), std::uint32_t>);
     CHECK(i.readu8<E2>() == E2::A);
     CHECK((i == j));
 }

--- a/test/cached.cpp
+++ b/test/cached.cpp
@@ -10,12 +10,12 @@ TEST_CASE("construction", "[cached]") {
 
 TEST_CASE("exposed value_type", "[cached]") {
     auto c = stdx::cached{[] { return 42; }};
-    static_assert(std::is_same_v<typename decltype(c)::value_type, int>);
+    STATIC_REQUIRE(std::is_same_v<typename decltype(c)::value_type, int>);
 }
 
 TEST_CASE("cached_value_t", "[cached]") {
     auto const c = stdx::cached{[] { return 42; }};
-    static_assert(std::is_same_v<stdx::cached_value_t<decltype(c)>, int>);
+    STATIC_REQUIRE(std::is_same_v<stdx::cached_value_t<decltype(c)>, int>);
 }
 
 TEST_CASE("automatic population", "[cached]") {
@@ -63,7 +63,7 @@ TEST_CASE("refresh immediately repopulates value", "[cached]") {
 
 TEST_CASE("refresh returns a reference to value", "[cached]") {
     auto c = stdx::cached{[] { return 42; }};
-    static_assert(std::is_same_v<decltype(c.refresh()), int &>);
+    STATIC_REQUIRE(std::is_same_v<decltype(c.refresh()), int &>);
     CHECK(c.refresh() == 42);
 }
 
@@ -94,12 +94,12 @@ TEST_CASE("non-movable value", "[cached]") {
 TEST_CASE("preserving value categories", "[cached]") {
     {
         auto c = stdx::cached{[] { return 42; }};
-        static_assert(std::is_same_v<int const &, decltype(*c)>);
-        static_assert(std::is_same_v<int const &&, decltype(*std::move(c))>);
+        STATIC_REQUIRE(std::is_same_v<int const &, decltype(*c)>);
+        STATIC_REQUIRE(std::is_same_v<int const &&, decltype(*std::move(c))>);
     }
     {
         auto const c = stdx::cached{[] { return 42; }};
-        static_assert(std::is_same_v<int const &, decltype(*c)>);
-        static_assert(std::is_same_v<int const &&, decltype(*std::move(c))>);
+        STATIC_REQUIRE(std::is_same_v<int const &, decltype(*c)>);
+        STATIC_REQUIRE(std::is_same_v<int const &&, decltype(*std::move(c))>);
     }
 }

--- a/test/callable.cpp
+++ b/test/callable.cpp
@@ -18,37 +18,37 @@ struct T {
 
 TEST_CASE("is_function", "[type_traits]") {
     auto x = []() {};
-    static_assert(not stdx::is_function_v<int>);
-    static_assert(not stdx::is_function_v<int &>);
-    static_assert(not stdx::is_function_v<decltype(x)>);
-    static_assert(stdx::is_function_v<decltype(func_no_args)>);
-    static_assert(stdx::is_function_v<decltype(func_one_arg)>);
+    STATIC_REQUIRE(not stdx::is_function_v<int>);
+    STATIC_REQUIRE(not stdx::is_function_v<int &>);
+    STATIC_REQUIRE(not stdx::is_function_v<decltype(x)>);
+    STATIC_REQUIRE(stdx::is_function_v<decltype(func_no_args)>);
+    STATIC_REQUIRE(stdx::is_function_v<decltype(func_one_arg)>);
 }
 
 TEST_CASE("is_function_object", "[type_traits]") {
     auto x = []() {};
     auto y = [](int) {};
     auto z = [](auto) {};
-    static_assert(not stdx::is_function_object_v<int>);
-    static_assert(not stdx::is_function_object_v<decltype(func_no_args)>);
-    static_assert(not stdx::is_function_object_v<decltype(func_one_arg)>);
-    static_assert(stdx::is_function_object_v<decltype(x)>);
-    static_assert(stdx::is_function_object_v<decltype(y)>);
-    static_assert(stdx::is_function_object_v<decltype(z)>);
-    static_assert(stdx::is_function_object_v<S>);
-    static_assert(stdx::is_function_object_v<T>);
+    STATIC_REQUIRE(not stdx::is_function_object_v<int>);
+    STATIC_REQUIRE(not stdx::is_function_object_v<decltype(func_no_args)>);
+    STATIC_REQUIRE(not stdx::is_function_object_v<decltype(func_one_arg)>);
+    STATIC_REQUIRE(stdx::is_function_object_v<decltype(x)>);
+    STATIC_REQUIRE(stdx::is_function_object_v<decltype(y)>);
+    STATIC_REQUIRE(stdx::is_function_object_v<decltype(z)>);
+    STATIC_REQUIRE(stdx::is_function_object_v<S>);
+    STATIC_REQUIRE(stdx::is_function_object_v<T>);
 }
 
 TEST_CASE("is_callable", "[type_traits]") {
     auto x = []() {};
     auto y = [](int) {};
     auto z = [](auto) {};
-    static_assert(not stdx::is_callable_v<int>);
-    static_assert(stdx::is_callable_v<decltype(func_no_args)>);
-    static_assert(stdx::is_callable_v<decltype(func_one_arg)>);
-    static_assert(stdx::is_callable_v<decltype(x)>);
-    static_assert(stdx::is_callable_v<decltype(y)>);
-    static_assert(stdx::is_callable_v<decltype(z)>);
-    static_assert(stdx::is_callable_v<S>);
-    static_assert(stdx::is_callable_v<T>);
+    STATIC_REQUIRE(not stdx::is_callable_v<int>);
+    STATIC_REQUIRE(stdx::is_callable_v<decltype(func_no_args)>);
+    STATIC_REQUIRE(stdx::is_callable_v<decltype(func_one_arg)>);
+    STATIC_REQUIRE(stdx::is_callable_v<decltype(x)>);
+    STATIC_REQUIRE(stdx::is_callable_v<decltype(y)>);
+    STATIC_REQUIRE(stdx::is_callable_v<decltype(z)>);
+    STATIC_REQUIRE(stdx::is_callable_v<S>);
+    STATIC_REQUIRE(stdx::is_callable_v<T>);
 }

--- a/test/concepts.cpp
+++ b/test/concepts.cpp
@@ -6,56 +6,56 @@
 #include <type_traits>
 
 TEST_CASE("integral", "[concepts]") {
-    static_assert(stdx::integral<int>);
-    static_assert(not stdx::integral<float>);
+    STATIC_REQUIRE(stdx::integral<int>);
+    STATIC_REQUIRE(not stdx::integral<float>);
 }
 
 TEST_CASE("floating_point", "[concepts]") {
-    static_assert(stdx::floating_point<float>);
-    static_assert(not stdx::floating_point<int>);
+    STATIC_REQUIRE(stdx::floating_point<float>);
+    STATIC_REQUIRE(not stdx::floating_point<int>);
 }
 
 TEST_CASE("signed_integral", "[concepts]") {
-    static_assert(stdx::signed_integral<int>);
-    static_assert(not stdx::signed_integral<unsigned int>);
+    STATIC_REQUIRE(stdx::signed_integral<int>);
+    STATIC_REQUIRE(not stdx::signed_integral<unsigned int>);
 }
 
 TEST_CASE("unsigned_integral", "[concepts]") {
-    static_assert(stdx::unsigned_integral<unsigned int>);
-    static_assert(not stdx::unsigned_integral<int>);
+    STATIC_REQUIRE(stdx::unsigned_integral<unsigned int>);
+    STATIC_REQUIRE(not stdx::unsigned_integral<int>);
 }
 
 TEST_CASE("same_as", "[concepts]") {
-    static_assert(stdx::same_as<int, int>);
-    static_assert(not stdx::same_as<float, int>);
+    STATIC_REQUIRE(stdx::same_as<int, int>);
+    STATIC_REQUIRE(not stdx::same_as<float, int>);
 }
 
 TEST_CASE("same_any", "[concepts]") {
-    static_assert(stdx::same_any<int, float, bool, int>);
-    static_assert(not stdx::same_any<float, char, bool, int>);
+    STATIC_REQUIRE(stdx::same_any<int, float, bool, int>);
+    STATIC_REQUIRE(not stdx::same_any<float, char, bool, int>);
 }
 
 TEST_CASE("same_none", "[concepts]") {
-    static_assert(stdx::same_none<int, float, bool, char>);
-    static_assert(not stdx::same_none<float, bool, char, float>);
+    STATIC_REQUIRE(stdx::same_none<int, float, bool, char>);
+    STATIC_REQUIRE(not stdx::same_none<float, bool, char, float>);
 }
 
 TEST_CASE("same_as_unqualified", "[concepts]") {
-    static_assert(stdx::same_as_unqualified<int, int>);
-    static_assert(not stdx::same_as_unqualified<int, void>);
-    static_assert(stdx::same_as_unqualified<int, int &>);
-    static_assert(stdx::same_as_unqualified<int, int const &>);
-    static_assert(stdx::same_as_unqualified<int, int &&>);
-    static_assert(stdx::same_as_unqualified<int, int const &&>);
-    static_assert(stdx::same_as_unqualified<int &, int>);
-    static_assert(stdx::same_as_unqualified<int const &, int>);
-    static_assert(stdx::same_as_unqualified<int &&, int>);
-    static_assert(stdx::same_as_unqualified<int const &&, int>);
+    STATIC_REQUIRE(stdx::same_as_unqualified<int, int>);
+    STATIC_REQUIRE(not stdx::same_as_unqualified<int, void>);
+    STATIC_REQUIRE(stdx::same_as_unqualified<int, int &>);
+    STATIC_REQUIRE(stdx::same_as_unqualified<int, int const &>);
+    STATIC_REQUIRE(stdx::same_as_unqualified<int, int &&>);
+    STATIC_REQUIRE(stdx::same_as_unqualified<int, int const &&>);
+    STATIC_REQUIRE(stdx::same_as_unqualified<int &, int>);
+    STATIC_REQUIRE(stdx::same_as_unqualified<int const &, int>);
+    STATIC_REQUIRE(stdx::same_as_unqualified<int &&, int>);
+    STATIC_REQUIRE(stdx::same_as_unqualified<int const &&, int>);
 }
 
 TEST_CASE("convertible_to", "[concepts]") {
-    static_assert(stdx::convertible_to<char, int>);
-    static_assert(not stdx::convertible_to<float *, int *>);
+    STATIC_REQUIRE(stdx::convertible_to<char, int>);
+    STATIC_REQUIRE(not stdx::convertible_to<float *, int *>);
 }
 
 namespace {
@@ -63,13 +63,13 @@ struct S {};
 } // namespace
 
 TEST_CASE("equality_comparable", "[concepts]") {
-    static_assert(stdx::equality_comparable<int>);
-    static_assert(not stdx::equality_comparable<S>);
+    STATIC_REQUIRE(stdx::equality_comparable<int>);
+    STATIC_REQUIRE(not stdx::equality_comparable<S>);
 }
 
 TEST_CASE("totally_ordered", "[concepts]") {
-    static_assert(stdx::totally_ordered<int>);
-    static_assert(not stdx::totally_ordered<S>);
+    STATIC_REQUIRE(stdx::totally_ordered<int>);
+    STATIC_REQUIRE(not stdx::totally_ordered<S>);
 }
 
 namespace {
@@ -79,10 +79,10 @@ struct C : private A {};
 } // namespace
 
 TEST_CASE("derived_from", "[concepts]") {
-    static_assert(stdx::derived_from<A, A>);
-    static_assert(stdx::derived_from<B, A>);
-    static_assert(not stdx::derived_from<C, A>);
-    static_assert(not stdx::derived_from<int, int>);
+    STATIC_REQUIRE(stdx::derived_from<A, A>);
+    STATIC_REQUIRE(stdx::derived_from<B, A>);
+    STATIC_REQUIRE(not stdx::derived_from<C, A>);
+    STATIC_REQUIRE(not stdx::derived_from<int, int>);
 }
 
 TEST_CASE("invocable", "[concepts]") {
@@ -91,15 +91,15 @@ TEST_CASE("invocable", "[concepts]") {
     [[maybe_unused]] constexpr auto l_invocable_no_args = [] {};
     [[maybe_unused]] constexpr auto l_invocable_int = [](int) {};
 
-    static_assert(not stdx::invocable<int>);
-    static_assert(stdx::invocable<invocable_no_args>);
-    static_assert(not stdx::invocable<invocable_no_args, int>);
-    static_assert(stdx::invocable<invocable_int, int>);
-    static_assert(not stdx::invocable<invocable_int>);
-    static_assert(stdx::invocable<decltype(l_invocable_no_args)>);
-    static_assert(not stdx::invocable<decltype(l_invocable_no_args), int>);
-    static_assert(stdx::invocable<decltype(l_invocable_int), int>);
-    static_assert(not stdx::invocable<decltype(l_invocable_int)>);
+    STATIC_REQUIRE(not stdx::invocable<int>);
+    STATIC_REQUIRE(stdx::invocable<invocable_no_args>);
+    STATIC_REQUIRE(not stdx::invocable<invocable_no_args, int>);
+    STATIC_REQUIRE(stdx::invocable<invocable_int, int>);
+    STATIC_REQUIRE(not stdx::invocable<invocable_int>);
+    STATIC_REQUIRE(stdx::invocable<decltype(l_invocable_no_args)>);
+    STATIC_REQUIRE(not stdx::invocable<decltype(l_invocable_no_args), int>);
+    STATIC_REQUIRE(stdx::invocable<decltype(l_invocable_int), int>);
+    STATIC_REQUIRE(not stdx::invocable<decltype(l_invocable_int)>);
 }
 
 TEST_CASE("predicate (negative cases)", "[concepts]") {
@@ -108,10 +108,10 @@ TEST_CASE("predicate (negative cases)", "[concepts]") {
     [[maybe_unused]] constexpr auto l_not_predicate_no_args = [] {};
     [[maybe_unused]] constexpr auto l_not_predicate_int = [](int) {};
 
-    static_assert(not stdx::predicate<not_predicate_no_args>);
-    static_assert(not stdx::predicate<not_predicate_int, int>);
-    static_assert(not stdx::predicate<decltype(l_not_predicate_no_args)>);
-    static_assert(not stdx::predicate<decltype(l_not_predicate_int), int>);
+    STATIC_REQUIRE(not stdx::predicate<not_predicate_no_args>);
+    STATIC_REQUIRE(not stdx::predicate<not_predicate_int, int>);
+    STATIC_REQUIRE(not stdx::predicate<decltype(l_not_predicate_no_args)>);
+    STATIC_REQUIRE(not stdx::predicate<decltype(l_not_predicate_int), int>);
 }
 
 TEST_CASE("predicate (positive cases)", "[concepts]") {
@@ -126,12 +126,12 @@ TEST_CASE("predicate (positive cases)", "[concepts]") {
         return std::true_type{};
     };
 
-    static_assert(stdx::predicate<predicate_no_args>);
-    static_assert(stdx::predicate<predicate_int, int>);
-    static_assert(stdx::predicate<decltype(l_predicate_no_args)>);
-    static_assert(stdx::predicate<decltype(l_predicate_int), int>);
-    static_assert(stdx::predicate<decltype(convert_predicate_no_args)>);
-    static_assert(stdx::predicate<decltype(convert_predicate_int), int>);
+    STATIC_REQUIRE(stdx::predicate<predicate_no_args>);
+    STATIC_REQUIRE(stdx::predicate<predicate_int, int>);
+    STATIC_REQUIRE(stdx::predicate<decltype(l_predicate_no_args)>);
+    STATIC_REQUIRE(stdx::predicate<decltype(l_predicate_int), int>);
+    STATIC_REQUIRE(stdx::predicate<decltype(convert_predicate_no_args)>);
+    STATIC_REQUIRE(stdx::predicate<decltype(convert_predicate_int), int>);
 }
 
 namespace {
@@ -151,19 +151,19 @@ TEST_CASE("callable", "[concepts]") {
     [[maybe_unused]] constexpr auto l_callable_int = [](int) {};
     [[maybe_unused]] constexpr auto l_callable_generic = [](auto) {};
 
-    static_assert(not stdx::callable<int>);
-    static_assert(stdx::callable<decltype(func_no_args)>);
-    static_assert(stdx::callable<decltype(func_one_arg)>);
-    static_assert(stdx::callable<funcobj>);
-    static_assert(stdx::callable<generic_funcobj>);
-    static_assert(stdx::callable<decltype(l_callable_no_args)>);
-    static_assert(stdx::callable<decltype(l_callable_int)>);
-    static_assert(stdx::callable<decltype(l_callable_generic)>);
+    STATIC_REQUIRE(not stdx::callable<int>);
+    STATIC_REQUIRE(stdx::callable<decltype(func_no_args)>);
+    STATIC_REQUIRE(stdx::callable<decltype(func_one_arg)>);
+    STATIC_REQUIRE(stdx::callable<funcobj>);
+    STATIC_REQUIRE(stdx::callable<generic_funcobj>);
+    STATIC_REQUIRE(stdx::callable<decltype(l_callable_no_args)>);
+    STATIC_REQUIRE(stdx::callable<decltype(l_callable_int)>);
+    STATIC_REQUIRE(stdx::callable<decltype(l_callable_generic)>);
 }
 
 TEST_CASE("models_trait", "[concepts]") {
-    static_assert(stdx::has_trait<int *, std::is_pointer>);
-    static_assert(not stdx::has_trait<int, std::is_pointer>);
+    STATIC_REQUIRE(stdx::has_trait<int *, std::is_pointer>);
+    STATIC_REQUIRE(not stdx::has_trait<int, std::is_pointer>);
 }
 
 namespace {
@@ -173,6 +173,6 @@ struct non_structural {
 } // namespace
 
 TEST_CASE("structural", "[type_traits]") {
-    static_assert(stdx::structural<int>);
-    static_assert(not stdx::structural<non_structural>);
+    STATIC_REQUIRE(stdx::structural<int>);
+    STATIC_REQUIRE(not stdx::structural<non_structural>);
 }

--- a/test/ct_conversions.cpp
+++ b/test/ct_conversions.cpp
@@ -9,9 +9,9 @@ struct incomplete;
 
 TEST_CASE("type as string", "[ct_conversion]") {
     using namespace std::string_view_literals;
-    static_assert(stdx::type_as_string<int>() == "int"sv);
-    static_assert(stdx::type_as_string<complete>() == "complete"sv);
-    static_assert(stdx::type_as_string<incomplete>() == "incomplete"sv);
+    STATIC_REQUIRE(stdx::type_as_string<int>() == "int"sv);
+    STATIC_REQUIRE(stdx::type_as_string<complete>() == "complete"sv);
+    STATIC_REQUIRE(stdx::type_as_string<incomplete>() == "incomplete"sv);
 }
 
 namespace {
@@ -21,6 +21,6 @@ enum struct B { Y };
 
 TEST_CASE("enum as string", "[ct_conversion]") {
     using namespace std::string_view_literals;
-    static_assert(stdx::enum_as_string<X>() == "X"sv);
-    static_assert(stdx::enum_as_string<B::Y>() == "Y"sv);
+    STATIC_REQUIRE(stdx::enum_as_string<X>() == "X"sv);
+    STATIC_REQUIRE(stdx::enum_as_string<B::Y>() == "Y"sv);
 }

--- a/test/ct_format.cpp
+++ b/test/ct_format.cpp
@@ -7,75 +7,75 @@ using namespace stdx::ct_string_literals;
 
 TEST_CASE("detect string format specifiers", "[ct_format]") {
     using namespace std::string_view_literals;
-    static_assert(stdx::detail::count_specifiers("{}"sv) == 1u);
-    static_assert(stdx::detail::count_specifiers("{} {}"sv) == 2u);
-    static_assert(stdx::detail::count_specifiers("{"sv) == 0u);
-    static_assert(stdx::detail::count_specifiers("{{"sv) == 0u);
-    static_assert(stdx::detail::count_specifiers("{{{}"sv) == 1u);
-    static_assert(stdx::detail::count_specifiers("{{}}"sv) == 0u);
-    static_assert(stdx::detail::count_specifiers("{{{{"sv) == 0u);
+    STATIC_REQUIRE(stdx::detail::count_specifiers("{}"sv) == 1u);
+    STATIC_REQUIRE(stdx::detail::count_specifiers("{} {}"sv) == 2u);
+    STATIC_REQUIRE(stdx::detail::count_specifiers("{"sv) == 0u);
+    STATIC_REQUIRE(stdx::detail::count_specifiers("{{"sv) == 0u);
+    STATIC_REQUIRE(stdx::detail::count_specifiers("{{{}"sv) == 1u);
+    STATIC_REQUIRE(stdx::detail::count_specifiers("{{}}"sv) == 0u);
+    STATIC_REQUIRE(stdx::detail::count_specifiers("{{{{"sv) == 0u);
 }
 
 TEST_CASE("split format string by specifiers", "[ct_format]") {
     using namespace std::string_view_literals;
-    static_assert(stdx::detail::split_specifiers<1>("hello"sv) ==
-                  std::array{"hello"sv});
-    static_assert(stdx::detail::split_specifiers<2>("{}"sv) ==
-                  std::array{"{}"sv, ""sv});
-    static_assert(stdx::detail::split_specifiers<3>("{} {}"sv) ==
-                  std::array{"{}"sv, " {}"sv, ""sv});
-    static_assert(stdx::detail::split_specifiers<2>("{{{}"sv) ==
-                  std::array{"{{{}"sv, ""sv});
-    static_assert(stdx::detail::split_specifiers<2>("{} hello"sv) ==
-                  std::array{"{}"sv, " hello"sv});
+    STATIC_REQUIRE(stdx::detail::split_specifiers<1>("hello"sv) ==
+                   std::array{"hello"sv});
+    STATIC_REQUIRE(stdx::detail::split_specifiers<2>("{}"sv) ==
+                   std::array{"{}"sv, ""sv});
+    STATIC_REQUIRE(stdx::detail::split_specifiers<3>("{} {}"sv) ==
+                   std::array{"{}"sv, " {}"sv, ""sv});
+    STATIC_REQUIRE(stdx::detail::split_specifiers<2>("{{{}"sv) ==
+                   std::array{"{{{}"sv, ""sv});
+    STATIC_REQUIRE(stdx::detail::split_specifiers<2>("{} hello"sv) ==
+                   std::array{"{}"sv, " hello"sv});
 }
 
 TEST_CASE("format a static string", "[ct_format]") {
-    static_assert(stdx::ct_format<"Hello">() == "Hello"_fmt_res);
+    STATIC_REQUIRE(stdx::ct_format<"Hello">() == "Hello"_fmt_res);
 }
 
 TEST_CASE("format a compile-time stringish argument (CX_VALUE)",
           "[ct_format]") {
     using namespace std::string_view_literals;
-    static_assert(stdx::ct_format<"Hello {}">(CX_VALUE("world"sv)) ==
-                  "Hello world"_fmt_res);
-    static_assert(stdx::ct_format<"Hello {}">(CX_VALUE("world"_cts)) ==
-                  "Hello world"_fmt_res);
-    static_assert(stdx::ct_format<"Hello {}">(CX_VALUE("world")) ==
-                  "Hello world"_fmt_res);
+    STATIC_REQUIRE(stdx::ct_format<"Hello {}">(CX_VALUE("world"sv)) ==
+                   "Hello world"_fmt_res);
+    STATIC_REQUIRE(stdx::ct_format<"Hello {}">(CX_VALUE("world"_cts)) ==
+                   "Hello world"_fmt_res);
+    STATIC_REQUIRE(stdx::ct_format<"Hello {}">(CX_VALUE("world")) ==
+                   "Hello world"_fmt_res);
 }
 
 TEST_CASE("format a compile-time stringish argument (ct)", "[ct_format]") {
     using namespace std::string_view_literals;
-    static_assert(stdx::ct_format<"Hello {}">("world"_ctst) ==
-                  "Hello world"_fmt_res);
-    static_assert(stdx::ct_format<"Hello {}">(stdx::ct<"world">()) ==
-                  "Hello world"_fmt_res);
+    STATIC_REQUIRE(stdx::ct_format<"Hello {}">("world"_ctst) ==
+                   "Hello world"_fmt_res);
+    STATIC_REQUIRE(stdx::ct_format<"Hello {}">(stdx::ct<"world">()) ==
+                   "Hello world"_fmt_res);
 }
 
 TEST_CASE("format a compile-time integral argument (CX_VALUE)", "[ct_format]") {
-    static_assert(stdx::ct_format<"Hello {}">(CX_VALUE(42)) ==
-                  "Hello 42"_fmt_res);
+    STATIC_REQUIRE(stdx::ct_format<"Hello {}">(CX_VALUE(42)) ==
+                   "Hello 42"_fmt_res);
 }
 
 TEST_CASE("format a compile-time integral argument (ct)", "[ct_format]") {
-    static_assert(stdx::ct_format<"Hello {}">(stdx::ct<42>()) ==
-                  "Hello 42"_fmt_res);
+    STATIC_REQUIRE(stdx::ct_format<"Hello {}">(stdx::ct<42>()) ==
+                   "Hello 42"_fmt_res);
 }
 
 TEST_CASE("format a type argument (CX_VALUE)", "[ct_format]") {
-    static_assert(stdx::ct_format<"Hello {}">(CX_VALUE(int)) ==
-                  "Hello int"_fmt_res);
+    STATIC_REQUIRE(stdx::ct_format<"Hello {}">(CX_VALUE(int)) ==
+                   "Hello int"_fmt_res);
 }
 
 TEST_CASE("format a type argument (ct)", "[ct_format]") {
-    static_assert(stdx::ct_format<"Hello {}">(stdx::ct<int>()) ==
-                  "Hello int"_fmt_res);
+    STATIC_REQUIRE(stdx::ct_format<"Hello {}">(stdx::ct<int>()) ==
+                   "Hello int"_fmt_res);
 }
 
 TEST_CASE("format a compile-time argument with fmt spec", "[ct_format]") {
-    static_assert(stdx::ct_format<"Hello {:*>#6x}">(CX_VALUE(42)) ==
-                  "Hello **0x2a"_fmt_res);
+    STATIC_REQUIRE(stdx::ct_format<"Hello {:*>#6x}">(CX_VALUE(42)) ==
+                   "Hello **0x2a"_fmt_res);
 }
 
 namespace {
@@ -83,13 +83,13 @@ enum struct E { A };
 }
 
 TEST_CASE("format a compile-time enum argument (CX_VALUE)", "[ct_format]") {
-    static_assert(stdx::ct_format<"Hello {}">(CX_VALUE(E::A)) ==
-                  "Hello A"_fmt_res);
+    STATIC_REQUIRE(stdx::ct_format<"Hello {}">(CX_VALUE(E::A)) ==
+                   "Hello A"_fmt_res);
 }
 
 TEST_CASE("format a compile-time enum argument (ct)", "[ct_format]") {
-    static_assert(stdx::ct_format<"Hello {}">(stdx::ct<E::A>()) ==
-                  "Hello A"_fmt_res);
+    STATIC_REQUIRE(stdx::ct_format<"Hello {}">(stdx::ct<E::A>()) ==
+                   "Hello A"_fmt_res);
 }
 
 TEST_CASE("format a runtime argument", "[ct_format]") {
@@ -98,7 +98,7 @@ TEST_CASE("format a runtime argument", "[ct_format]") {
         stdx::format_result{"Hello {}"_ctst, stdx::make_tuple(x)};
 
     CHECK(stdx::ct_format<"Hello {}">(x) == expected);
-    static_assert(stdx::ct_format<"Hello {}">(x) == expected);
+    STATIC_REQUIRE(stdx::ct_format<"Hello {}">(x) == expected);
 }
 
 TEST_CASE("format a compile-time and a runtime argument (1)", "[ct_format]") {
@@ -107,17 +107,18 @@ TEST_CASE("format a compile-time and a runtime argument (1)", "[ct_format]") {
         stdx::format_result{"Hello int {}"_ctst, stdx::make_tuple(x)};
 
     CHECK(stdx::ct_format<"Hello {} {}">(CX_VALUE(int), x) == expected);
-    static_assert(stdx::ct_format<"Hello {} {}">(CX_VALUE(int), x) == expected);
+    STATIC_REQUIRE(stdx::ct_format<"Hello {} {}">(CX_VALUE(int), x) ==
+                   expected);
 }
 
 TEST_CASE("format a compile-time and a runtime argument (2)", "[ct_format]") {
-    static_assert(
+    STATIC_REQUIRE(
         stdx::ct_format<"Hello {} {}">(42, CX_VALUE(int)) ==
         stdx::format_result{"Hello {} int"_ctst, stdx::make_tuple(42)});
 }
 
 TEST_CASE("format multiple runtime arguments", "[ct_format]") {
-    static_assert(
+    STATIC_REQUIRE(
         stdx::ct_format<"Hello {} {}">(42, 17) ==
         stdx::format_result{"Hello {} {}"_ctst, stdx::make_tuple(42, 17)});
 }
@@ -129,17 +130,17 @@ TEST_CASE("format multiple mixed arguments", "[ct_format]") {
                                                      CX_VALUE(int)) ==
           stdx::format_result{"Hello {} A {} int world"_ctst,
                               stdx::make_tuple(42, "B"sv)});
-    static_assert(stdx::ct_format<"Hello {} {} {} {} world">(
-                      42, CX_VALUE("A"sv), "B"sv, CX_VALUE(int)) ==
-                  stdx::format_result{"Hello {} A {} int world"_ctst,
-                                      stdx::make_tuple(42, "B"sv)});
+    STATIC_REQUIRE(stdx::ct_format<"Hello {} {} {} {} world">(
+                       42, CX_VALUE("A"sv), "B"sv, CX_VALUE(int)) ==
+                   stdx::format_result{"Hello {} A {} int world"_ctst,
+                                       stdx::make_tuple(42, "B"sv)});
 }
 
 TEST_CASE("format a format result", "[ct_format]") {
-    static_assert(stdx::ct_format<"The value is {}.">(
-                      stdx::ct_format<"(year={})">(2022)) ==
-                  stdx::format_result{"The value is (year={})."_ctst,
-                                      stdx::make_tuple(2022)});
+    STATIC_REQUIRE(stdx::ct_format<"The value is {}.">(
+                       stdx::ct_format<"(year={})">(2022)) ==
+                   stdx::format_result{"The value is (year={})."_ctst,
+                                       stdx::make_tuple(2022)});
 }
 
 namespace {
@@ -149,14 +150,14 @@ template <stdx::ct_string> constexpr auto conversion_success = true;
 TEST_CASE("empty format_result can implicitly convert to ct_string",
           "[ct_format]") {
     using namespace std::string_view_literals;
-    static_assert(
+    STATIC_REQUIRE(
         stdx::detail::format_convertible<decltype(stdx::ct_format<"Hello">())>);
-    static_assert(stdx::detail::format_convertible<
-                  decltype(stdx::ct_format<"Hello {}">("world"_ctst))>);
-    static_assert(not stdx::detail::format_convertible<
-                  decltype(stdx::ct_format<"Hello {}">(42))>);
+    STATIC_REQUIRE(stdx::detail::format_convertible<
+                   decltype(stdx::ct_format<"Hello {}">("world"_ctst))>);
+    STATIC_REQUIRE(not stdx::detail::format_convertible<
+                   decltype(stdx::ct_format<"Hello {}">(42))>);
 
-    static_assert(conversion_success<stdx::ct_format<"Hello">()>);
+    STATIC_REQUIRE(conversion_success<stdx::ct_format<"Hello">()>);
 }
 
 namespace {
@@ -176,29 +177,29 @@ template <class T, T... Ls, T... Rs>
 
 TEST_CASE("format_to a different type", "[ct_format]") {
     using namespace std::string_view_literals;
-    static_assert(stdx::ct_format<"{}", string_constant>(CX_VALUE("A"sv)) ==
-                  stdx::format_result{string_constant<char, 'A'>{}});
+    STATIC_REQUIRE(stdx::ct_format<"{}", string_constant>(CX_VALUE("A"sv)) ==
+                   stdx::format_result{string_constant<char, 'A'>{}});
 
     auto x = 17;
     CHECK(stdx::ct_format<"{}", string_constant>(x) ==
           stdx::format_result{string_constant<char, '{', '}'>{},
                               stdx::make_tuple(17)});
-    static_assert(stdx::ct_format<"{}", string_constant>(17) ==
-                  stdx::format_result{string_constant<char, '{', '}'>{},
-                                      stdx::make_tuple(17)});
+    STATIC_REQUIRE(stdx::ct_format<"{}", string_constant>(17) ==
+                   stdx::format_result{string_constant<char, '{', '}'>{},
+                                       stdx::make_tuple(17)});
 }
 
 TEST_CASE("format a string-type argument", "[ct_format]") {
-    static_assert(stdx::ct_format<"Hello {}!">(string_constant<char, 'A'>{}) ==
-                  "Hello A!"_fmt_res);
+    STATIC_REQUIRE(stdx::ct_format<"Hello {}!">(string_constant<char, 'A'>{}) ==
+                   "Hello A!"_fmt_res);
 }
 
 TEST_CASE("format a format result with different type", "[ct_format]") {
-    static_assert(stdx::ct_format<"A{}D", string_constant>(
-                      stdx::ct_format<"B{}C", string_constant>(2022)) ==
-                  stdx::format_result{
-                      string_constant<char, 'A', 'B', '{', '}', 'C', 'D'>{},
-                      stdx::make_tuple(2022)});
+    STATIC_REQUIRE(stdx::ct_format<"A{}D", string_constant>(
+                       stdx::ct_format<"B{}C", string_constant>(2022)) ==
+                   stdx::format_result{
+                       string_constant<char, 'A', 'B', '{', '}', 'C', 'D'>{},
+                       stdx::make_tuple(2022)});
 }
 
 TEST_CASE("format multiple mixed arguments with different type",
@@ -211,17 +212,17 @@ TEST_CASE("format multiple mixed arguments with different type",
               stdx::ct_string_to_type<"Hello {} A {} int world"_cts,
                                       string_constant>(),
               stdx::make_tuple(42, "B"sv)});
-    static_assert(stdx::ct_format<"Hello {} {} {} {} world", string_constant>(
-                      42, CX_VALUE("A"sv), "B"sv, CX_VALUE(int)) ==
-                  stdx::format_result{
-                      stdx::ct_string_to_type<"Hello {} A {} int world"_cts,
-                                              string_constant>(),
-                      stdx::make_tuple(42, "B"sv)});
+    STATIC_REQUIRE(stdx::ct_format<"Hello {} {} {} {} world", string_constant>(
+                       42, CX_VALUE("A"sv), "B"sv, CX_VALUE(int)) ==
+                   stdx::format_result{
+                       stdx::ct_string_to_type<"Hello {} A {} int world"_cts,
+                                               string_constant>(),
+                       stdx::make_tuple(42, "B"sv)});
 }
 
 TEST_CASE("num fmt specifiers", "[ct_format]") {
-    static_assert(stdx::num_fmt_specifiers<"{}"> == 1u);
-    static_assert(stdx::num_fmt_specifiers<"{} {}"> == 2u);
+    STATIC_REQUIRE(stdx::num_fmt_specifiers<"{}"> == 1u);
+    STATIC_REQUIRE(stdx::num_fmt_specifiers<"{} {}"> == 2u);
 }
 
 namespace user {

--- a/test/ct_string.cpp
+++ b/test/ct_string.cpp
@@ -22,47 +22,47 @@ TEST_CASE("UDL", "[ct_string]") {
 
 TEST_CASE("empty", "[ct_string]") {
     constexpr auto s1 = stdx::ct_string{""};
-    static_assert(s1.empty());
+    STATIC_REQUIRE(s1.empty());
     constexpr auto s2 = stdx::ct_string{"A"};
-    static_assert(not s2.empty());
+    STATIC_REQUIRE(not s2.empty());
 }
 
 TEST_CASE("size", "[ct_string]") {
     constexpr auto s = stdx::ct_string{"ABC"};
-    static_assert(s.size() == 3u);
-    static_assert(not s.empty());
+    STATIC_REQUIRE(s.size() == 3u);
+    STATIC_REQUIRE(not s.empty());
 }
 
 TEST_CASE("equality", "[ct_string]") {
     constexpr auto s1 = stdx::ct_string{"ABC"};
     constexpr auto s2 = stdx::ct_string{"ABC"};
     constexpr auto s3 = stdx::ct_string{"ABD"};
-    static_assert(s1 == s2);
-    static_assert(s1 != s3);
+    STATIC_REQUIRE(s1 == s2);
+    STATIC_REQUIRE(s1 != s3);
 }
 
 TEST_CASE("explicit length construction", "[ct_string]") {
     constexpr auto s = stdx::ct_string<3u>{"ABC", 2};
-    static_assert(s == stdx::ct_string{"AB"});
+    STATIC_REQUIRE(s == stdx::ct_string{"AB"});
 }
 
 TEST_CASE("from type", "[ct_string]") {
     using T = string_constant<char, 'A', 'B', 'C'>;
     constexpr auto s = stdx::ct_string_from_type(T{});
-    static_assert(s == stdx::ct_string{"ABC"});
+    STATIC_REQUIRE(s == stdx::ct_string{"ABC"});
 }
 
 TEST_CASE("to type", "[ct_string]") {
     constexpr auto s = stdx::ct_string{"ABC"};
     constexpr auto sc = stdx::ct_string_to_type<s, string_constant>();
-    static_assert(std::is_same_v<decltype(sc),
-                                 string_constant<char, 'A', 'B', 'C'> const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(sc),
+                                  string_constant<char, 'A', 'B', 'C'> const>);
 }
 
 TEST_CASE("to type_t", "[ct_string]") {
     constexpr auto s = stdx::ct_string{"ABC"};
     using sc = stdx::ct_string_to_type_t<s, string_constant>;
-    static_assert(std::is_same_v<sc, string_constant<char, 'A', 'B', 'C'>>);
+    STATIC_REQUIRE(std::is_same_v<sc, string_constant<char, 'A', 'B', 'C'>>);
 }
 
 TEST_CASE("to string_view", "[ct_string]") {
@@ -74,38 +74,38 @@ TEST_CASE("to string_view", "[ct_string]") {
 TEST_CASE("string split (character present)", "[ct_string]") {
     constexpr auto s = stdx::ct_string{"A.B"};
     constexpr auto p = stdx::split<s, '.'>();
-    static_assert(p.first == stdx::ct_string{"A"});
-    static_assert(p.second == stdx::ct_string{"B"});
+    STATIC_REQUIRE(p.first == stdx::ct_string{"A"});
+    STATIC_REQUIRE(p.second == stdx::ct_string{"B"});
 }
 
 TEST_CASE("string split (character not present)", "[ct_string]") {
     constexpr auto s = stdx::ct_string{"A"};
     constexpr auto p = stdx::split<s, '.'>();
-    static_assert(p.first == stdx::ct_string{"A"});
-    static_assert(p.second.empty());
+    STATIC_REQUIRE(p.first == stdx::ct_string{"A"});
+    STATIC_REQUIRE(p.second.empty());
 }
 
 TEST_CASE("string concat (lhs empty)", "[ct_string]") {
     constexpr auto s1 = stdx::ct_string{""};
     constexpr auto s2 = stdx::ct_string{"def"};
-    static_assert(s1 + s2 == stdx::ct_string{"def"});
+    STATIC_REQUIRE(s1 + s2 == stdx::ct_string{"def"});
 }
 
 TEST_CASE("string concat (rhs empty)", "[ct_string]") {
     constexpr auto s1 = stdx::ct_string{"abc"};
     constexpr auto s2 = stdx::ct_string{""};
-    static_assert(s1 + s2 == stdx::ct_string{"abc"});
+    STATIC_REQUIRE(s1 + s2 == stdx::ct_string{"abc"});
 }
 
 TEST_CASE("string concat", "[ct_string]") {
     constexpr auto s1 = stdx::ct_string{"abc"};
     constexpr auto s2 = stdx::ct_string{"def"};
-    static_assert(s1 + s2 == stdx::ct_string{"abcdef"});
+    STATIC_REQUIRE(s1 + s2 == stdx::ct_string{"abcdef"});
 }
 
 TEST_CASE("ct_string as iterable", "[ct_string]") {
     constexpr auto s = stdx::ct_string{"abc"};
-    static_assert(std::next(std::begin(s), std::size(s)) == std::end(s));
+    STATIC_REQUIRE(std::next(std::begin(s), std::size(s)) == std::end(s));
 
     auto it = std::cbegin(s);
     CHECK(*it++ == 'a');
@@ -116,7 +116,7 @@ TEST_CASE("ct_string as iterable", "[ct_string]") {
 
 TEST_CASE("ct_string as reverse iterable", "[ct_string]") {
     constexpr auto s = stdx::ct_string{"abc"};
-    static_assert(std::next(std::rbegin(s), std::size(s)) == std::rend(s));
+    STATIC_REQUIRE(std::next(std::rbegin(s), std::size(s)) == std::rend(s));
 
     auto it = std::crbegin(s);
     CHECK(*it++ == 'c');
@@ -134,19 +134,19 @@ template <stdx::ct_string S> constexpr auto to_cx_value() {
 TEST_CASE("template argument as CX_VALUE", "[ct_string]") {
     using namespace stdx::ct_string_literals;
     constexpr auto s = to_cx_value<"Hello">();
-    static_assert(s() == "Hello"_cts);
+    STATIC_REQUIRE(s() == "Hello"_cts);
 }
 
 TEST_CASE("wrap ct_string in type", "[ct_string]") {
     using namespace stdx::ct_string_literals;
     using S = stdx::cts_t<"Hello">;
-    static_assert(S::value == "Hello"_cts);
+    STATIC_REQUIRE(S::value == "Hello"_cts);
 }
 
 TEST_CASE("ct (ct_string)", "[ct_string]") {
     using namespace stdx::ct_string_literals;
     constexpr auto v1 = stdx::ct<"Hello">();
-    static_assert(v1 == "Hello"_ctst);
+    STATIC_REQUIRE(v1 == "Hello"_ctst);
     constexpr auto v2 = stdx::ct<"Hello"_cts>();
-    static_assert(v2 == "Hello"_ctst);
+    STATIC_REQUIRE(v2 == "Hello"_ctst);
 }

--- a/test/cx_map.cpp
+++ b/test/cx_map.cpp
@@ -101,8 +101,8 @@ TEST_CASE("non-empty iterators", "[cx_map]") {
 
 TEST_CASE("constexpr empty and size", "[cx_map]") {
     constexpr auto m = stdx::cx_map<int, int, 64>{};
-    static_assert(m.size() == 0);
-    static_assert(m.empty());
+    STATIC_REQUIRE(m.size() == 0);
+    STATIC_REQUIRE(m.empty());
 }
 
 TEST_CASE("constexpr populated map", "[cx_map]") {
@@ -113,12 +113,12 @@ TEST_CASE("constexpr populated map", "[cx_map]") {
         return t;
     }();
 
-    static_assert(not m.empty());
-    static_assert(m.contains(10));
-    static_assert(m.get(10) == 50);
-    static_assert(m.contains(11));
-    static_assert(m.get(11) == 100);
-    static_assert(not m.contains(12));
+    STATIC_REQUIRE(not m.empty());
+    STATIC_REQUIRE(m.contains(10));
+    STATIC_REQUIRE(m.get(10) == 50);
+    STATIC_REQUIRE(m.contains(11));
+    STATIC_REQUIRE(m.get(11) == 100);
+    STATIC_REQUIRE(not m.contains(12));
 }
 
 TEST_CASE("constexpr erase", "[cx_map]") {
@@ -131,10 +131,10 @@ TEST_CASE("constexpr erase", "[cx_map]") {
         return t;
     }();
 
-    static_assert(not m.empty());
-    static_assert(m.contains(10));
-    static_assert(m.get(10) == 50);
-    static_assert(not m.contains(11));
+    STATIC_REQUIRE(not m.empty());
+    STATIC_REQUIRE(m.contains(10));
+    STATIC_REQUIRE(m.get(10) == 50);
+    STATIC_REQUIRE(not m.contains(11));
 }
 
 TEST_CASE("constexpr update value", "[cx_map]") {
@@ -145,9 +145,9 @@ TEST_CASE("constexpr update value", "[cx_map]") {
         return t;
     }();
 
-    static_assert(not m.empty());
-    static_assert(m.contains(10));
-    static_assert(m.get(10) == 100);
+    STATIC_REQUIRE(not m.empty());
+    STATIC_REQUIRE(m.contains(10));
+    STATIC_REQUIRE(m.get(10) == 100);
 }
 
 TEST_CASE("constexpr erase first", "[cx_map]") {
@@ -159,8 +159,8 @@ TEST_CASE("constexpr erase first", "[cx_map]") {
         return t;
     }();
 
-    static_assert(not m.empty());
-    static_assert(m.contains(11));
-    static_assert(m.get(11) == 100);
-    static_assert(not m.contains(10));
+    STATIC_REQUIRE(not m.empty());
+    STATIC_REQUIRE(m.contains(11));
+    STATIC_REQUIRE(m.get(11) == 100);
+    STATIC_REQUIRE(not m.contains(10));
 }

--- a/test/cx_multimap.cpp
+++ b/test/cx_multimap.cpp
@@ -26,9 +26,9 @@ TEST_CASE("put and contains", "[cx_multimap]") {
 TEST_CASE("constexpr empty", "[cx_multimap]") {
     constexpr auto t = stdx::cx_multimap<int, int, 64>{};
 
-    static_assert(t.empty());
-    static_assert(not t.contains(10));
-    static_assert(not t.contains(10, 10));
+    STATIC_REQUIRE(t.empty());
+    STATIC_REQUIRE(not t.contains(10));
+    STATIC_REQUIRE(not t.contains(10, 10));
 }
 
 TEST_CASE("put multiple values", "[cx_multimap]") {
@@ -82,17 +82,17 @@ TEST_CASE("constexpr populated map", "[cx_multimap]") {
         return t;
     }();
 
-    static_assert(not m.empty());
-    static_assert(m.size() == 2);
-    static_assert(m.contains(10));
-    static_assert(not m.get(10).empty());
-    static_assert(m.get(10).size() == 3);
-    static_assert(m.contains(10, 100));
-    static_assert(m.contains(10, 101));
-    static_assert(m.contains(10, 110));
-    static_assert(not m.contains(10, 50));
-    static_assert(not m.get(50).empty());
-    static_assert(m.get(50).size() == 1);
-    static_assert(m.contains(50, 1));
-    static_assert(not m.contains(50, 2));
+    STATIC_REQUIRE(not m.empty());
+    STATIC_REQUIRE(m.size() == 2);
+    STATIC_REQUIRE(m.contains(10));
+    STATIC_REQUIRE(not m.get(10).empty());
+    STATIC_REQUIRE(m.get(10).size() == 3);
+    STATIC_REQUIRE(m.contains(10, 100));
+    STATIC_REQUIRE(m.contains(10, 101));
+    STATIC_REQUIRE(m.contains(10, 110));
+    STATIC_REQUIRE(not m.contains(10, 50));
+    STATIC_REQUIRE(not m.get(50).empty());
+    STATIC_REQUIRE(m.get(50).size() == 1);
+    STATIC_REQUIRE(m.contains(50, 1));
+    STATIC_REQUIRE(not m.contains(50, 2));
 }

--- a/test/cx_set.cpp
+++ b/test/cx_set.cpp
@@ -8,13 +8,13 @@ TEST_CASE("empty and size", "[cx_set]") {
     CHECK(s.empty());
 
     constexpr auto cs = stdx::cx_set<int, 64>{};
-    static_assert(cs.size() == 0);
-    static_assert(cs.empty());
+    STATIC_REQUIRE(cs.size() == 0);
+    STATIC_REQUIRE(cs.empty());
 }
 
 TEST_CASE("CTAD", "[cx_set]") {
     stdx::cx_set set{1, 2, 3, 4, 5, 6};
-    static_assert(std::is_same_v<decltype(set), stdx::cx_set<int, 6>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(set), stdx::cx_set<int, 6>>);
 }
 
 TEST_CASE("contains", "[cx_set]") {
@@ -85,9 +85,9 @@ TEST_CASE("constexpr populated set", "[cx_set]") {
         return t;
     }();
 
-    static_assert(not populatedSetTest.empty());
-    static_assert(populatedSetTest.contains(10));
-    static_assert(not populatedSetTest.contains(11));
+    STATIC_REQUIRE(not populatedSetTest.empty());
+    STATIC_REQUIRE(populatedSetTest.contains(10));
+    STATIC_REQUIRE(not populatedSetTest.contains(11));
 }
 
 TEST_CASE("constexpr erase", "[cx_set]") {
@@ -102,13 +102,13 @@ TEST_CASE("constexpr erase", "[cx_set]") {
         return t;
     }();
 
-    static_assert(not testSetRemove.empty());
-    static_assert(testSetRemove.contains(12));
-    static_assert(testSetRemove.contains(40));
-    static_assert(testSetRemove.contains(42));
+    STATIC_REQUIRE(not testSetRemove.empty());
+    STATIC_REQUIRE(testSetRemove.contains(12));
+    STATIC_REQUIRE(testSetRemove.contains(40));
+    STATIC_REQUIRE(testSetRemove.contains(42));
 
-    static_assert(not testSetRemove.contains(10));
-    static_assert(not testSetRemove.contains(11));
-    static_assert(not testSetRemove.contains(32));
-    static_assert(not testSetRemove.contains(56));
+    STATIC_REQUIRE(not testSetRemove.contains(10));
+    STATIC_REQUIRE(not testSetRemove.contains(11));
+    STATIC_REQUIRE(not testSetRemove.contains(32));
+    STATIC_REQUIRE(not testSetRemove.contains(56));
 }

--- a/test/cx_vector.cpp
+++ b/test/cx_vector.cpp
@@ -9,12 +9,12 @@ TEST_CASE("empty vector", "[cx_vector]") {
     stdx::cx_vector<uint32_t, 3> const v{};
     CHECK(0u == v.size());
     CHECK(v.empty());
-    static_assert(3u == v.capacity());
+    STATIC_REQUIRE(3u == v.capacity());
 }
 
 TEST_CASE("CTAD", "[cx_vector]") {
     stdx::cx_vector v{1, 2, 3, 4, 5, 6};
-    static_assert(std::is_same_v<decltype(v), stdx::cx_vector<int, 6>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(v), stdx::cx_vector<int, 6>>);
 }
 
 TEST_CASE("mutable vector", "[cx_vector]") {
@@ -161,7 +161,7 @@ TEST_CASE("inequality", "[cx_vector]") {
 TEST_CASE("zero capacity", "[cx_vector]") {
     stdx::cx_vector<int, 0> const v{};
     CHECK(0u == v.size());
-    static_assert(0u == v.capacity());
+    STATIC_REQUIRE(0u == v.capacity());
     CHECK(v.empty());
     CHECK(v.full());
     CHECK(v.begin() == v.end());

--- a/test/env.cpp
+++ b/test/env.cpp
@@ -19,18 +19,18 @@ namespace {
 } // namespace
 
 TEST_CASE("lookup query with default", "[env]") {
-    static_assert(custom(stdx::env<>{}) == 42);
+    STATIC_REQUIRE(custom(stdx::env<>{}) == 42);
 }
 
 TEST_CASE("make an environment", "[env]") {
     using E = stdx::make_env_t<custom, 17>;
-    static_assert(custom(E{}) == 17);
+    STATIC_REQUIRE(custom(E{}) == 17);
 }
 
 TEST_CASE("extend an environment", "[env]") {
     using E1 = stdx::make_env_t<custom, 17>;
     using E2 = stdx::extend_env_t<E1, custom, 18>;
-    static_assert(custom(E2{}) == 18);
+    STATIC_REQUIRE(custom(E2{}) == 18);
 }
 
 TEST_CASE("append an environment", "[env]") {
@@ -38,18 +38,18 @@ TEST_CASE("append an environment", "[env]") {
     using E2 = stdx::make_env_t<custom, 18>;
     using E3 = stdx::make_env_t<custom, 19>;
     using E = stdx::append_env_t<E1, E2, E3>;
-    static_assert(custom(E{}) == 19);
+    STATIC_REQUIRE(custom(E{}) == 19);
 }
 
 TEST_CASE("environment converts string literals to ct_string", "[env]") {
     using namespace stdx::literals;
     using E = stdx::make_env_t<custom, "hello">;
-    static_assert(custom(E{}) == "hello"_cts);
+    STATIC_REQUIRE(custom(E{}) == "hello"_cts);
 }
 
 TEST_CASE("envlike concept", "[env]") {
-    static_assert(stdx::envlike<stdx::env<>>);
-    static_assert(stdx::envlike<stdx::make_env_t<custom, 17>>);
+    STATIC_REQUIRE(stdx::envlike<stdx::env<>>);
+    STATIC_REQUIRE(stdx::envlike<stdx::make_env_t<custom, 17>>);
 }
 
 namespace {
@@ -61,7 +61,7 @@ template <typename Q> struct match_query {
 TEST_CASE("extending environment doesn't create duplicate keys", "[env]") {
     using E1 = stdx::make_env_t<custom, 17>;
     using E2 = stdx::extend_env_t<E1, custom, 18>;
-    static_assert(
+    STATIC_REQUIRE(
         boost::mp11::mp_count_if_q<E2, match_query<custom_t>>::value == 1);
 }
 
@@ -70,6 +70,6 @@ TEST_CASE("appending environment doesn't create duplicate keys", "[env]") {
     using E2 = stdx::make_env_t<custom, 18>;
     using E3 = stdx::make_env_t<custom, 19>;
     using E = stdx::append_env_t<E1, E2, E3>;
-    static_assert(boost::mp11::mp_count_if_q<E, match_query<custom_t>>::value ==
-                  1);
+    STATIC_REQUIRE(
+        boost::mp11::mp_count_if_q<E, match_query<custom_t>>::value == 1);
 }

--- a/test/function_traits.cpp
+++ b/test/function_traits.cpp
@@ -13,68 +13,68 @@ namespace {
 } // namespace
 
 TEST_CASE("function return type", "[function_traits]") {
-    static_assert(std::is_void_v<typename stdx::function_traits<
-                      decltype(func_no_args)>::return_type>);
-    static_assert(std::is_void_v<stdx::return_t<decltype(func_no_args)>>);
+    STATIC_REQUIRE(std::is_void_v<typename stdx::function_traits<
+                       decltype(func_no_args)>::return_type>);
+    STATIC_REQUIRE(std::is_void_v<stdx::return_t<decltype(func_no_args)>>);
 
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<
             typename stdx::function_traits<decltype(func_one_arg)>::return_type,
             int>);
-    static_assert(std::is_same_v<stdx::return_t<decltype(func_one_arg)>, int>);
+    STATIC_REQUIRE(std::is_same_v<stdx::return_t<decltype(func_one_arg)>, int>);
 }
 
 TEST_CASE("lambda return type", "[function_traits]") {
     [[maybe_unused]] auto const x = []() {};
     [[maybe_unused]] auto const y = []() mutable {};
 
-    static_assert(std::is_void_v<stdx::return_t<decltype(x)>>);
-    static_assert(std::is_void_v<stdx::return_t<decltype(y)>>);
+    STATIC_REQUIRE(std::is_void_v<stdx::return_t<decltype(x)>>);
+    STATIC_REQUIRE(std::is_void_v<stdx::return_t<decltype(y)>>);
 }
 
 TEST_CASE("function args", "[function_traits]") {
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<typename stdx::function_traits<
                            decltype(func_no_args)>::template args<std::tuple>,
                        std::tuple<>>);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<stdx::args_t<decltype(func_no_args), std::tuple>,
                        std::tuple<>>);
 
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<typename stdx::function_traits<
                            decltype(func_one_arg)>::template args<std::tuple>,
                        std::tuple<int>>);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<stdx::args_t<decltype(func_one_arg), std::tuple>,
                        std::tuple<int>>);
 }
 
 TEST_CASE("function decayed args", "[function_traits]") {
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<typename stdx::function_traits<decltype(func_ref_arg)>::
                            template decayed_args<std::tuple>,
                        std::tuple<int>>);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<stdx::decayed_args_t<decltype(func_ref_arg), std::tuple>,
                        std::tuple<int>>);
 }
 
 TEST_CASE("function nth arg", "[function_traits]") {
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<typename stdx::function_traits<
                            decltype(func_one_arg)>::template nth_arg<0>,
                        int>);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<stdx::nth_arg_t<decltype(func_one_arg), 0>, int>);
 }
 
 TEST_CASE("function decayed nth arg", "[function_traits]") {
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<typename stdx::function_traits<
                            decltype(func_ref_arg)>::template decayed_nth_arg<0>,
                        int>);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<stdx::decayed_nth_arg_t<decltype(func_ref_arg), 0>,
                        int>);
 }
@@ -83,16 +83,16 @@ TEST_CASE("lambda args", "[function_traits]") {
     [[maybe_unused]] auto const x = [](int) {};
     [[maybe_unused]] auto const y = [](int) mutable {};
 
-    static_assert(std::is_same_v<typename stdx::function_traits<
-                                     decltype(x)>::template args<std::tuple>,
-                                 std::tuple<int>>);
-    static_assert(
+    STATIC_REQUIRE(std::is_same_v<typename stdx::function_traits<
+                                      decltype(x)>::template args<std::tuple>,
+                                  std::tuple<int>>);
+    STATIC_REQUIRE(
         std::is_same_v<stdx::args_t<decltype(x), std::tuple>, std::tuple<int>>);
 
-    static_assert(std::is_same_v<typename stdx::function_traits<
-                                     decltype(y)>::template args<std::tuple>,
-                                 std::tuple<int>>);
-    static_assert(
+    STATIC_REQUIRE(std::is_same_v<typename stdx::function_traits<
+                                      decltype(y)>::template args<std::tuple>,
+                                  std::tuple<int>>);
+    STATIC_REQUIRE(
         std::is_same_v<stdx::args_t<decltype(y), std::tuple>, std::tuple<int>>);
 }
 
@@ -100,73 +100,74 @@ TEST_CASE("lambda decayed args", "[function_traits]") {
     [[maybe_unused]] auto const x = [](int &) {};
     [[maybe_unused]] auto const y = [](int &) mutable {};
 
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<typename stdx::function_traits<
                            decltype(x)>::template decayed_args<std::tuple>,
                        std::tuple<int>>);
-    static_assert(std::is_same_v<stdx::decayed_args_t<decltype(x), std::tuple>,
-                                 std::tuple<int>>);
+    STATIC_REQUIRE(std::is_same_v<stdx::decayed_args_t<decltype(x), std::tuple>,
+                                  std::tuple<int>>);
 
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<typename stdx::function_traits<
                            decltype(y)>::template decayed_args<std::tuple>,
                        std::tuple<int>>);
-    static_assert(std::is_same_v<stdx::decayed_args_t<decltype(y), std::tuple>,
-                                 std::tuple<int>>);
+    STATIC_REQUIRE(std::is_same_v<stdx::decayed_args_t<decltype(y), std::tuple>,
+                                  std::tuple<int>>);
 }
 
 TEST_CASE("lambda nth arg", "[function_traits]") {
     [[maybe_unused]] auto const x = [](int) {};
 
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<
             typename stdx::function_traits<decltype(x)>::template nth_arg<0>,
             int>);
-    static_assert(std::is_same_v<stdx::nth_arg_t<decltype(x), 0>, int>);
+    STATIC_REQUIRE(std::is_same_v<stdx::nth_arg_t<decltype(x), 0>, int>);
 }
 
 TEST_CASE("lambda decayed nth arg", "[function_traits]") {
     [[maybe_unused]] auto const x = [](int &) {};
 
-    static_assert(std::is_same_v<typename stdx::function_traits<
-                                     decltype(x)>::template decayed_nth_arg<0>,
-                                 int>);
-    static_assert(std::is_same_v<stdx::decayed_nth_arg_t<decltype(x), 0>, int>);
+    STATIC_REQUIRE(std::is_same_v<typename stdx::function_traits<
+                                      decltype(x)>::template decayed_nth_arg<0>,
+                                  int>);
+    STATIC_REQUIRE(
+        std::is_same_v<stdx::decayed_nth_arg_t<decltype(x), 0>, int>);
 }
 
 TEST_CASE("function arity", "[function_traits]") {
-    static_assert(stdx::function_traits<decltype(func_no_args)>::arity::value ==
-                  0u);
-    static_assert(stdx::function_traits<decltype(func_one_arg)>::arity::value ==
-                  1u);
-    static_assert(stdx::arity_t<decltype(func_no_args)>::value == 0u);
-    static_assert(stdx::arity_t<decltype(func_one_arg)>::value == 1u);
+    STATIC_REQUIRE(
+        stdx::function_traits<decltype(func_no_args)>::arity::value == 0u);
+    STATIC_REQUIRE(
+        stdx::function_traits<decltype(func_one_arg)>::arity::value == 1u);
+    STATIC_REQUIRE(stdx::arity_t<decltype(func_no_args)>::value == 0u);
+    STATIC_REQUIRE(stdx::arity_t<decltype(func_one_arg)>::value == 1u);
 
-    static_assert(stdx::arity_v<decltype(func_no_args)> == 0u);
-    static_assert(stdx::arity_v<decltype(func_one_arg)> == 1u);
+    STATIC_REQUIRE(stdx::arity_v<decltype(func_no_args)> == 0u);
+    STATIC_REQUIRE(stdx::arity_v<decltype(func_one_arg)> == 1u);
 }
 
 TEST_CASE("lambda arity", "[function_traits]") {
     [[maybe_unused]] auto const x = []() {};
     [[maybe_unused]] auto const y = [](int) {};
 
-    static_assert(stdx::function_traits<decltype(x)>::arity::value == 0u);
-    static_assert(stdx::function_traits<decltype(y)>::arity::value == 1u);
-    static_assert(stdx::arity_t<decltype(x)>::value == 0u);
-    static_assert(stdx::arity_t<decltype(y)>::value == 1u);
+    STATIC_REQUIRE(stdx::function_traits<decltype(x)>::arity::value == 0u);
+    STATIC_REQUIRE(stdx::function_traits<decltype(y)>::arity::value == 1u);
+    STATIC_REQUIRE(stdx::arity_t<decltype(x)>::value == 0u);
+    STATIC_REQUIRE(stdx::arity_t<decltype(y)>::value == 1u);
 
-    static_assert(stdx::arity_v<decltype(x)> == 0u);
-    static_assert(stdx::arity_v<decltype(y)> == 1u);
+    STATIC_REQUIRE(stdx::arity_v<decltype(x)> == 0u);
+    STATIC_REQUIRE(stdx::arity_v<decltype(y)> == 1u);
 }
 
 TEST_CASE("generic lambda arity", "[function_traits]") {
     [[maybe_unused]] auto const x = [](auto) {};
     [[maybe_unused]] auto const y = [](auto, auto) {};
-    static_assert(stdx::arity_t<decltype(x)>::value == 1u);
-    static_assert(stdx::arity_t<decltype(y)>::value == 2u);
+    STATIC_REQUIRE(stdx::arity_t<decltype(x)>::value == 1u);
+    STATIC_REQUIRE(stdx::arity_t<decltype(y)>::value == 2u);
 
-    static_assert(stdx::arity_v<decltype(x)> == 1u);
-    static_assert(stdx::arity_v<decltype(y)> == 2u);
+    STATIC_REQUIRE(stdx::arity_v<decltype(x)> == 1u);
+    STATIC_REQUIRE(stdx::arity_v<decltype(y)> == 2u);
 }
 
 namespace {

--- a/test/indexed_tuple.cpp
+++ b/test/indexed_tuple.cpp
@@ -18,13 +18,13 @@ template <typename T> using key_for = typename T::key_t;
 } // namespace
 
 TEST_CASE("make_indexed_tuple", "[indexed_tuple]") {
-    static_assert(stdx::make_indexed_tuple<>() == stdx::indexed_tuple{});
-    static_assert(stdx::make_indexed_tuple<>(1, 2, 3) ==
-                  stdx::indexed_tuple{1, 2, 3});
+    STATIC_REQUIRE(stdx::make_indexed_tuple<>() == stdx::indexed_tuple{});
+    STATIC_REQUIRE(stdx::make_indexed_tuple<>(1, 2, 3) ==
+                   stdx::indexed_tuple{1, 2, 3});
 }
 
 TEST_CASE("comparable with regular tuple", "[indexed_tuple]") {
-    static_assert(stdx::indexed_tuple{} == stdx::tuple{});
+    STATIC_REQUIRE(stdx::indexed_tuple{} == stdx::tuple{});
 }
 
 TEST_CASE("indexed_tuple destructuring", "[indexed_tuple]") {
@@ -39,15 +39,15 @@ TEST_CASE("tuple with user index", "[indexed_tuple]") {
     struct Y;
     constexpr auto t = stdx::make_indexed_tuple<key_for>(map_entry<X, int>{42},
                                                          map_entry<Y, int>{17});
-    static_assert(stdx::get<X>(t).value == 42);
-    static_assert(stdx::get<Y>(t).value == 17);
+    STATIC_REQUIRE(stdx::get<X>(t).value == 42);
+    STATIC_REQUIRE(stdx::get<Y>(t).value == 17);
     using T = std::remove_const_t<decltype(t)>;
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<
             T, stdx::indexed_tuple<stdx::detail::index_function_list<key_for>,
                                    map_entry<X, int>, map_entry<Y, int>>>);
-    static_assert(stdx::tuple_size_v<T> == 2);
-    static_assert(T::size() == 2);
+    STATIC_REQUIRE(stdx::tuple_size_v<T> == 2);
+    STATIC_REQUIRE(T::size() == 2);
 }
 
 TEST_CASE("indexed_tuple ADL get", "[indexed_tuple]") {
@@ -55,8 +55,8 @@ TEST_CASE("indexed_tuple ADL get", "[indexed_tuple]") {
     struct Y;
     constexpr auto t = stdx::make_indexed_tuple<key_for>(map_entry<X, int>{42},
                                                          map_entry<Y, int>{17});
-    static_assert(get<X>(t).value == 42);
-    static_assert(get<Y>(t).value == 17);
+    STATIC_REQUIRE(get<X>(t).value == 42);
+    STATIC_REQUIRE(get<Y>(t).value == 17);
 }
 
 namespace {
@@ -79,15 +79,15 @@ TEST_CASE("tuple with multiple user indices", "[indexed_tuple]") {
     struct Y;
     constexpr auto t = stdx::make_indexed_tuple<key1_for, key2_for>(
         multimap_entry<M, X, int>{42}, multimap_entry<N, Y, int>{17});
-    static_assert(stdx::get<M>(t).value == 42);
-    static_assert(stdx::get<X>(t).value == 42);
-    static_assert(stdx::get<N>(t).value == 17);
-    static_assert(stdx::get<Y>(t).value == 17);
+    STATIC_REQUIRE(stdx::get<M>(t).value == 42);
+    STATIC_REQUIRE(stdx::get<X>(t).value == 42);
+    STATIC_REQUIRE(stdx::get<N>(t).value == 17);
+    STATIC_REQUIRE(stdx::get<Y>(t).value == 17);
 }
 
 TEST_CASE("apply indices", "[indexed_tuple]") {
     struct X;
     constexpr auto t = stdx::tuple{map_entry<X, int>{42}};
     constexpr auto u = stdx::apply_indices<key_for>(t);
-    static_assert(stdx::get<X>(u).value == 42);
+    STATIC_REQUIRE(stdx::get<X>(u).value == 42);
 }

--- a/test/intrusive_forward_list.cpp
+++ b/test/intrusive_forward_list.cpp
@@ -22,9 +22,9 @@ struct bad_single_link_node {
 
 #if __cpp_concepts >= 201907L
 TEST_CASE("single_linkable", "[intrusive_forward_list]") {
-    static_assert(not stdx::single_linkable<int>);
-    static_assert(not stdx::single_linkable<bad_single_link_node>);
-    static_assert(stdx::single_linkable<single_link_node>);
+    STATIC_REQUIRE(not stdx::single_linkable<int>);
+    STATIC_REQUIRE(not stdx::single_linkable<bad_single_link_node>);
+    STATIC_REQUIRE(stdx::single_linkable<single_link_node>);
 }
 #endif
 
@@ -249,7 +249,7 @@ struct injected_handler {
 #if __cplusplus >= 202002L
     template <stdx::ct_string Why, typename... Ts>
     static auto panic(Ts &&...) noexcept -> void {
-        static_assert(std::string_view{Why} == "bad list node!");
+        STATIC_REQUIRE(std::string_view{Why} == "bad list node!");
         ++compile_time_calls;
     }
 #else

--- a/test/intrusive_list.cpp
+++ b/test/intrusive_list.cpp
@@ -29,9 +29,9 @@ struct bad_double_link_node {
 
 #if __cpp_concepts >= 201907L
 TEST_CASE("double_linkable", "[intrusive_list]") {
-    static_assert(not stdx::double_linkable<int>);
-    static_assert(not stdx::double_linkable<bad_double_link_node>);
-    static_assert(stdx::double_linkable<double_link_node>);
+    STATIC_REQUIRE(not stdx::double_linkable<int>);
+    STATIC_REQUIRE(not stdx::double_linkable<bad_double_link_node>);
+    STATIC_REQUIRE(stdx::double_linkable<double_link_node>);
 }
 #endif
 
@@ -362,7 +362,7 @@ struct injected_handler {
 #if __cplusplus >= 202002L
     template <stdx::ct_string Why, typename... Ts>
     static auto panic(Ts &&...) noexcept -> void {
-        static_assert(std::string_view{Why} == "bad list node!");
+        STATIC_REQUIRE(std::string_view{Why} == "bad list node!");
         ++compile_time_calls;
     }
 #else

--- a/test/iterator.cpp
+++ b/test/iterator.cpp
@@ -16,54 +16,54 @@
 
 TEST_CASE("compile-time capacity (std::array)", "[iterator]") {
     std::array a{1, 2, 3, 4};
-    static_assert(stdx::ct_capacity(a) == 4u);
+    STATIC_REQUIRE(stdx::ct_capacity(a) == 4u);
 }
 
 #if __cpp_lib_span >= 202002L
 TEST_CASE("compile-time capacity (std::span)", "[iterator]") {
     std::array a{1, 2, 3, 4};
     std::span s{a};
-    static_assert(stdx::ct_capacity(s) == 4u);
+    STATIC_REQUIRE(stdx::ct_capacity(s) == 4u);
 }
 #endif
 
 TEST_CASE("compile-time capacity (stdx::span)", "[iterator]") {
     std::array a{1, 2, 3, 4};
     stdx::span s{a};
-    static_assert(stdx::ct_capacity(s) == 4u);
+    STATIC_REQUIRE(stdx::ct_capacity(s) == 4u);
 }
 
 TEST_CASE("compile-time capacity (stdx::cx_map)", "[iterator]") {
     stdx::cx_map<int, int, 4> m{};
-    static_assert(stdx::ct_capacity(m) == 4u);
+    STATIC_REQUIRE(stdx::ct_capacity(m) == 4u);
 }
 
 TEST_CASE("compile-time capacity (stdx::cx_multimap)", "[iterator]") {
     stdx::cx_multimap<int, int, 4, 5> m{};
-    static_assert(stdx::ct_capacity(m) == 4u);
+    STATIC_REQUIRE(stdx::ct_capacity(m) == 4u);
 }
 
 TEST_CASE("compile-time capacity (stdx::cx_queue)", "[iterator]") {
     stdx::cx_queue<int, 4> q{};
-    static_assert(stdx::ct_capacity(q) == 4u);
+    STATIC_REQUIRE(stdx::ct_capacity(q) == 4u);
 }
 
 TEST_CASE("compile-time capacity (stdx::cx_set)", "[iterator]") {
     stdx::cx_set<int, 4> s{};
-    static_assert(stdx::ct_capacity(s) == 4u);
+    STATIC_REQUIRE(stdx::ct_capacity(s) == 4u);
 }
 
 TEST_CASE("compile-time capacity (stdx::cx_vector)", "[iterator]") {
     stdx::cx_vector<int, 4> v{};
-    static_assert(stdx::ct_capacity(v) == 4u);
+    STATIC_REQUIRE(stdx::ct_capacity(v) == 4u);
 }
 
 TEST_CASE("compile-time capacity variable template", "[iterator]") {
     std::array a{1, 2, 3, 4};
-    static_assert(stdx::ct_capacity_v<decltype(a)> == 4u);
+    STATIC_REQUIRE(stdx::ct_capacity_v<decltype(a)> == 4u);
 }
 
 TEST_CASE("compile-time capacity variable template (const)", "[iterator]") {
     std::array const a{1, 2, 3, 4};
-    static_assert(stdx::ct_capacity_v<decltype(a)> == 4u);
+    STATIC_REQUIRE(stdx::ct_capacity_v<decltype(a)> == 4u);
 }

--- a/test/latched.cpp
+++ b/test/latched.cpp
@@ -10,12 +10,12 @@ TEST_CASE("construction", "[latched]") {
 
 TEST_CASE("exposed value_type", "[latched]") {
     auto c = stdx::latched{[] { return 42; }};
-    static_assert(std::is_same_v<typename decltype(c)::value_type, int>);
+    STATIC_REQUIRE(std::is_same_v<typename decltype(c)::value_type, int>);
 }
 
 TEST_CASE("latched_value_t", "[latched]") {
     auto const c = stdx::latched{[] { return 42; }};
-    static_assert(std::is_same_v<stdx::latched_value_t<decltype(c)>, int>);
+    STATIC_REQUIRE(std::is_same_v<stdx::latched_value_t<decltype(c)>, int>);
 }
 
 TEST_CASE("automatic population", "[latched]") {
@@ -69,12 +69,12 @@ TEST_CASE("non-movable value", "[latched]") {
 TEST_CASE("preserving value categories", "[latched]") {
     {
         auto c = stdx::latched{[] { return 42; }};
-        static_assert(std::is_same_v<int const &, decltype(*c)>);
-        static_assert(std::is_same_v<int const &&, decltype(*std::move(c))>);
+        STATIC_REQUIRE(std::is_same_v<int const &, decltype(*c)>);
+        STATIC_REQUIRE(std::is_same_v<int const &&, decltype(*std::move(c))>);
     }
     {
         auto const c = stdx::latched{[] { return 42; }};
-        static_assert(std::is_same_v<int const &, decltype(*c)>);
-        static_assert(std::is_same_v<int const &&, decltype(*std::move(c))>);
+        STATIC_REQUIRE(std::is_same_v<int const &, decltype(*c)>);
+        STATIC_REQUIRE(std::is_same_v<int const &&, decltype(*std::move(c))>);
     }
 }

--- a/test/memory.cpp
+++ b/test/memory.cpp
@@ -9,7 +9,7 @@
 TEST_CASE("to_address for pointer (constexpr)", "[memory]") {
     constexpr static int a{};
     constexpr static auto p = &a;
-    static_assert(stdx::to_address(p) == p);
+    STATIC_REQUIRE(stdx::to_address(p) == p);
 }
 
 TEST_CASE("to_address for pointer (runtime)", "[memory]") {

--- a/test/numeric.cpp
+++ b/test/numeric.cpp
@@ -46,7 +46,7 @@ TEST_CASE("transform_reduce with output fixed by template argument",
     auto v =
         stdx::transform_reduce<double>(std::cbegin(input), std::cend(input), 0,
                                        std::plus{}, [](auto n) { return n; });
-    static_assert(std::is_same_v<decltype(v), double>);
+    STATIC_REQUIRE(std::is_same_v<decltype(v), double>);
     CHECK(v == 12);
 }
 
@@ -69,26 +69,27 @@ TEST_CASE("saturate_cast cppreference example", "[numeric]") {
 }
 
 TEST_CASE("saturate_cast signed large From, small To", "[numeric]") {
-    static_assert(stdx::saturate_cast<std::int8_t>(std::int32_t{42}) == 42);
-    static_assert(stdx::saturate_cast<std::int8_t>(std::int32_t{1000}) == 127);
-    static_assert(stdx::saturate_cast<std::int8_t>(std::int32_t{-200}) == -128);
+    STATIC_REQUIRE(stdx::saturate_cast<std::int8_t>(std::int32_t{42}) == 42);
+    STATIC_REQUIRE(stdx::saturate_cast<std::int8_t>(std::int32_t{1000}) == 127);
+    STATIC_REQUIRE(stdx::saturate_cast<std::int8_t>(std::int32_t{-200}) ==
+                   -128);
 }
 
 TEST_CASE("saturate_cast signed small From, large To", "[numeric]") {
-    static_assert(stdx::saturate_cast<std::int32_t>(std::int8_t{42}) == 42);
+    STATIC_REQUIRE(stdx::saturate_cast<std::int32_t>(std::int8_t{42}) == 42);
 }
 
 TEST_CASE("saturate_cast unsigned From, signed To", "[numeric]") {
-    static_assert(stdx::saturate_cast<std::int8_t>(std::uint8_t{255u}) == 127);
-    static_assert(stdx::saturate_cast<std::int8_t>(std::uint8_t{42u}) == 42);
-    static_assert(stdx::saturate_cast<std::int8_t>(std::uint8_t{0u}) == 0);
+    STATIC_REQUIRE(stdx::saturate_cast<std::int8_t>(std::uint8_t{255u}) == 127);
+    STATIC_REQUIRE(stdx::saturate_cast<std::int8_t>(std::uint8_t{42u}) == 42);
+    STATIC_REQUIRE(stdx::saturate_cast<std::int8_t>(std::uint8_t{0u}) == 0);
 }
 
 TEST_CASE("saturate_cast signed From, unsigned To", "[numeric]") {
-    static_assert(stdx::saturate_cast<std::uint8_t>(std::int8_t{-1}) == 0);
-    static_assert(stdx::saturate_cast<std::uint8_t>(
-                      std::numeric_limits<std::int8_t>::min()) == 0);
-    static_assert(stdx::saturate_cast<std::uint8_t>(
-                      std::numeric_limits<std::int8_t>::max()) ==
-                  std::numeric_limits<std::int8_t>::max());
+    STATIC_REQUIRE(stdx::saturate_cast<std::uint8_t>(std::int8_t{-1}) == 0);
+    STATIC_REQUIRE(stdx::saturate_cast<std::uint8_t>(
+                       std::numeric_limits<std::int8_t>::min()) == 0);
+    STATIC_REQUIRE(stdx::saturate_cast<std::uint8_t>(
+                       std::numeric_limits<std::int8_t>::max()) ==
+                   std::numeric_limits<std::int8_t>::max());
 }

--- a/test/optional.cpp
+++ b/test/optional.cpp
@@ -36,63 +36,63 @@ template <> struct stdx::tombstone_traits<S> {
 
 TEST_CASE("sizeof(optional<T>) == sizeof(T)", "[optional]") {
     using O1 = stdx::optional<E>;
-    static_assert(sizeof(O1) == sizeof(E));
+    STATIC_REQUIRE(sizeof(O1) == sizeof(E));
     using O2 = stdx::optional<S>;
-    static_assert(sizeof(O2) == sizeof(S));
+    STATIC_REQUIRE(sizeof(O2) == sizeof(S));
 }
 
 TEST_CASE("alignof(optional<T>) == alignof(T)", "[optional]") {
     using O1 = stdx::optional<E>;
-    static_assert(alignof(O1) == alignof(E));
+    STATIC_REQUIRE(alignof(O1) == alignof(E));
     using O2 = stdx::optional<S>;
-    static_assert(alignof(O2) == alignof(S));
+    STATIC_REQUIRE(alignof(O2) == alignof(S));
 }
 
 TEST_CASE("optional exposes value_type", "[optional]") {
     using O = stdx::optional<E>;
-    static_assert(std::is_same_v<typename O::value_type, E>);
+    STATIC_REQUIRE(std::is_same_v<typename O::value_type, E>);
 }
 
 TEST_CASE("default construction", "[optional]") {
     constexpr auto o = stdx::optional<E>{};
-    static_assert(not o);
+    STATIC_REQUIRE(not o);
 }
 
 TEST_CASE("construction from nullopt", "[optional]") {
     constexpr auto o = stdx::optional<E>{std::nullopt};
-    static_assert(not o);
+    STATIC_REQUIRE(not o);
 }
 
 TEST_CASE("construction from value", "[optional]") {
     constexpr auto o = stdx::optional<E>{E::VALUE};
-    static_assert(o);
+    STATIC_REQUIRE(o);
 }
 
 TEST_CASE("trivially copy constructible", "[optional]") {
     using O = stdx::optional<E>;
-    static_assert(std::is_trivially_copy_constructible_v<O>);
+    STATIC_REQUIRE(std::is_trivially_copy_constructible_v<O>);
 }
 
 TEST_CASE("trivially move constructible", "[optional]") {
     using O = stdx::optional<E>;
-    static_assert(std::is_trivially_move_constructible_v<O>);
+    STATIC_REQUIRE(std::is_trivially_move_constructible_v<O>);
 }
 
 TEST_CASE("trivially destructible", "[optional]") {
     using O = stdx::optional<E>;
-    static_assert(std::is_trivially_destructible_v<O>);
+    STATIC_REQUIRE(std::is_trivially_destructible_v<O>);
 }
 
 TEST_CASE("in-place construction", "[optional]") {
     using O = stdx::optional<S>;
     constexpr O o{std::in_place, 42};
-    static_assert(o);
+    STATIC_REQUIRE(o);
 }
 
 TEST_CASE("in-place construction (no args)", "[optional]") {
     using O = stdx::optional<E>;
     constexpr O o{std::in_place};
-    static_assert(o);
+    STATIC_REQUIRE(o);
 }
 
 TEST_CASE("retrieve value", "[optional]") {
@@ -120,18 +120,18 @@ TEST_CASE("assignment from value", "[optional]") {
 
 TEST_CASE("trivially copy assignable", "[optional]") {
     using O = stdx::optional<E>;
-    static_assert(std::is_trivially_copy_assignable_v<O>);
+    STATIC_REQUIRE(std::is_trivially_copy_assignable_v<O>);
 }
 
 TEST_CASE("trivially move assignable", "[optional]") {
     using O = stdx::optional<E>;
-    static_assert(std::is_trivially_move_assignable_v<O>);
+    STATIC_REQUIRE(std::is_trivially_move_assignable_v<O>);
 }
 
 TEST_CASE("has_value and boolean conversion", "[optional]") {
     constexpr auto o = stdx::optional<E>{E::VALUE};
-    static_assert(o.has_value());
-    static_assert(o);
+    STATIC_REQUIRE(o.has_value());
+    STATIC_REQUIRE(o);
 }
 
 TEST_CASE("operator->", "[optional]") {
@@ -142,13 +142,13 @@ TEST_CASE("operator->", "[optional]") {
 TEST_CASE("value() preserves value categories", "[optional]") {
     {
         auto o = stdx::optional<E>{E::VALUE};
-        static_assert(std::is_same_v<E &, decltype(*o)>);
-        static_assert(std::is_same_v<E &&, decltype(*std::move(o))>);
+        STATIC_REQUIRE(std::is_same_v<E &, decltype(*o)>);
+        STATIC_REQUIRE(std::is_same_v<E &&, decltype(*std::move(o))>);
     }
     {
         auto const o = stdx::optional<E>{E::VALUE};
-        static_assert(std::is_same_v<E const &, decltype(*o)>);
-        static_assert(std::is_same_v<E const &&, decltype(*std::move(o))>);
+        STATIC_REQUIRE(std::is_same_v<E const &, decltype(*o)>);
+        STATIC_REQUIRE(std::is_same_v<E const &&, decltype(*std::move(o))>);
     }
 }
 
@@ -376,13 +376,13 @@ TEST_CASE("optional can hold non-movable types)", "[optional]") {
 
 TEST_CASE("CTAD", "[optional]") {
     [[maybe_unused]] auto o = stdx::optional{E::VALUE};
-    static_assert(std::is_same_v<decltype(o), stdx::optional<E>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(o), stdx::optional<E>>);
 }
 
 TEST_CASE("easy tombstone with value", "[optional]") {
     constexpr auto o = stdx::optional<int, stdx::tombstone_value<-1>>{};
-    static_assert(not o);
-    static_assert(*o == -1);
+    STATIC_REQUIRE(not o);
+    STATIC_REQUIRE(*o == -1);
 }
 
 TEST_CASE("optional floating-point value has default sentinel", "[optional]") {

--- a/test/panic.cpp
+++ b/test/panic.cpp
@@ -22,7 +22,7 @@ struct injected_handler {
 #if __cplusplus >= 202002L
     template <stdx::ct_string Why, typename... Ts>
     static auto panic(Ts &&...) noexcept -> void {
-        static_assert(std::string_view{Why} == "uh-oh");
+        STATIC_REQUIRE(std::string_view{Why} == "uh-oh");
         ++compile_time_calls;
     }
 #endif

--- a/test/pbt/tuple.py
+++ b/test/pbt/tuple.py
@@ -1,21 +1,28 @@
 from hypothesis import strategies as st, given, settings, event, assume
 
+
 def unpack(l):
     return ", ".join([str(i) for i in l])
 
+
 small_ints = st.integers(min_value=-100, max_value=100)
+
 
 @st.composite
 def tuples(draw, children):
     values = draw(st.lists(children))
     return f"stdx::make_tuple({unpack(values)})"
 
+
 @st.composite
 def list_trees(draw, leaves=st.integers(), max_leaves=100):
-    l = draw(st.recursive(leaves, lambda children: st.lists(children), max_leaves=max_leaves))
+    l = draw(
+        st.recursive(leaves, lambda children: st.lists(children), max_leaves=max_leaves)
+    )
     if not isinstance(l, list):
         l = [l]
     return l
+
 
 def as_tuple_tree(value):
     if isinstance(value, list):
@@ -24,14 +31,17 @@ def as_tuple_tree(value):
     else:
         return value
 
+
 @st.composite
 def tuple_trees(draw, leaves=st.integers()):
     return draw(st.recursive(leaves, lambda children: tuples(children)))
 
+
 @settings(deadline=50000)
 @given(tuple_trees(small_ints))
 def test_tuple_trees(compile, t):
-    assert compile(f"""
+    assert compile(
+        f"""
         #include <stdx/tuple.hpp>
 
         [[maybe_unused]] constexpr auto t = {t};
@@ -39,13 +49,16 @@ def test_tuple_trees(compile, t):
         int main() {{
             return 0;
         }}
-    """)
+    """
+    )
+
 
 @settings(deadline=50000)
 @given(list_trees(small_ints))
 def test_tuple_size(compile, l):
     t = as_tuple_tree(l)
-    assert compile(f"""
+    assert compile(
+        f"""
         #include <stdx/tuple.hpp>
 
         constexpr auto t = {t};
@@ -55,7 +68,8 @@ def test_tuple_size(compile, l):
         int main() {{
             return 0;
         }}
-    """)
+    """
+    )
 
 
 @settings(deadline=50000)
@@ -67,7 +81,8 @@ def test_get_by_index(compile, l, i):
 
     expected_v = as_tuple_tree(l[i])
 
-    assert compile(f"""
+    assert compile(
+        f"""
         #include <stdx/tuple.hpp>
 
         using namespace stdx::literals;
@@ -84,7 +99,8 @@ def test_get_by_index(compile, l, i):
         int main() {{
             return 0;
         }}
-    """)
+    """
+    )
 
 
 @settings(deadline=50000)
@@ -95,7 +111,8 @@ def test_tuple_cat(compile, ls):
     flattened_ls = [i for subl in ls for i in subl]
     expected = as_tuple_tree(flattened_ls)
 
-    assert compile(f"""
+    assert compile(
+        f"""
         #include <stdx/tuple.hpp>
         #include <stdx/tuple_algorithms.hpp>
 
@@ -104,7 +121,8 @@ def test_tuple_cat(compile, ls):
         int main() {{
             return 0;
         }}
-    """)
+    """
+    )
 
 
 @settings(deadline=50000)
@@ -120,7 +138,8 @@ def test_push(compile, l, elem):
 
     t = as_tuple_tree(l)
 
-    assert compile(f"""
+    assert compile(
+        f"""
         #include <stdx/tuple.hpp>
         #include <stdx/tuple_algorithms.hpp>
 
@@ -138,15 +157,19 @@ def test_push(compile, l, elem):
         int main() {{
             return 0;
         }}
-    """)
+    """
+    )
+
 
 from itertools import product
+
 
 def put_in_list(i):
     if isinstance(i, list):
         return i
     else:
         return [i]
+
 
 @settings(deadline=50000)
 @given(list_trees(small_ints, max_leaves=15))
@@ -155,7 +178,8 @@ def test_cartesian_product(compile, ls):
     ts = [as_tuple_tree(l) for l in ls]
     expected = as_tuple_tree([list(p) for p in product(*ls)])
 
-    assert compile(f"""
+    assert compile(
+        f"""
         #include <stdx/tuple.hpp>
         #include <stdx/tuple_algorithms.hpp>
 
@@ -164,9 +188,12 @@ def test_cartesian_product(compile, ls):
         int main() {{
             return 0;
         }}
-    """)
+    """
+    )
+
 
 from functools import reduce
+
 
 @settings(deadline=50000)
 @given(st.lists(small_ints))
@@ -177,7 +204,8 @@ def test_star_of(compile, l):
 
     t = as_tuple_tree(l)
 
-    assert compile(f"""
+    assert compile(
+        f"""
         #include <stdx/tuple.hpp>
         #include <stdx/tuple_algorithms.hpp>
 
@@ -190,4 +218,5 @@ def test_star_of(compile, l):
         int main() {{
             return 0;
         }}
-    """)
+    """
+    )

--- a/test/ranges.cpp
+++ b/test/ranges.cpp
@@ -5,6 +5,6 @@
 #include <array>
 
 TEST_CASE("range concept", "[ranges]") {
-    static_assert(not stdx::range<int>);
-    static_assert(stdx::range<std::array<int, 4>>);
+    STATIC_REQUIRE(not stdx::range<int>);
+    STATIC_REQUIRE(stdx::range<std::array<int, 4>>);
 }

--- a/test/rollover.cpp
+++ b/test/rollover.cpp
@@ -15,7 +15,7 @@ TEMPLATE_TEST_CASE("default construction", "[rollover]", std::uint8_t,
                    std::uint16_t, std::uint32_t, std::uint64_t) {
     using rollover_t = stdx::rollover_t<TestType>;
     constexpr rollover_t x;
-    static_assert(x == rollover_t{TestType{}});
+    STATIC_REQUIRE(x == rollover_t{TestType{}});
     CHECK(x == rollover_t{TestType{}});
 }
 
@@ -23,7 +23,7 @@ TEMPLATE_TEST_CASE("value construction", "[rollover]", std::uint8_t,
                    std::uint16_t, std::uint32_t, std::uint64_t) {
     using rollover_t = stdx::rollover_t<TestType>;
     constexpr rollover_t x{};
-    static_assert(x == rollover_t{TestType{}});
+    STATIC_REQUIRE(x == rollover_t{TestType{}});
     CHECK(x == rollover_t{TestType{}});
 }
 
@@ -31,7 +31,7 @@ TEMPLATE_TEST_CASE("access to underlying value", "[rollover]", std::uint8_t,
                    std::uint16_t, std::uint32_t, std::uint64_t) {
     using rollover_t = stdx::rollover_t<TestType>;
     constexpr rollover_t x;
-    static_assert(x.as_underlying() == TestType{});
+    STATIC_REQUIRE(x.as_underlying() == TestType{});
     CHECK(x.as_underlying() == TestType{});
 }
 
@@ -39,15 +39,15 @@ TEMPLATE_TEST_CASE("cast to underlying type", "[rollover]", std::uint8_t,
                    std::uint16_t, std::uint32_t, std::uint64_t) {
     using rollover_t = stdx::rollover_t<TestType>;
     constexpr rollover_t x;
-    static_assert(static_cast<typename rollover_t::underlying_t>(x) ==
-                  TestType{});
+    STATIC_REQUIRE(static_cast<typename rollover_t::underlying_t>(x) ==
+                   TestType{});
     CHECK(static_cast<typename rollover_t::underlying_t>(x) == TestType{});
 }
 
 TEMPLATE_TEST_CASE("construction from convertible integral value", "[rollover]",
                    std::uint8_t, std::uint16_t, std::uint32_t, std::uint64_t) {
     constexpr stdx::rollover_t<std::uint32_t> x{std::uint8_t{16}};
-    static_assert(x.as_underlying() == TestType{16});
+    STATIC_REQUIRE(x.as_underlying() == TestType{16});
     CHECK(x.as_underlying() == TestType{16});
 }
 
@@ -55,13 +55,13 @@ TEMPLATE_TEST_CASE("construction from convertible rollover_t", "[rollover]",
                    std::uint8_t, std::uint16_t, std::uint32_t, std::uint64_t) {
     constexpr stdx::rollover_t<std::uint32_t> x{
         stdx::rollover_t<std::uint8_t>{16}};
-    static_assert(x.as_underlying() == TestType{16});
+    STATIC_REQUIRE(x.as_underlying() == TestType{16});
     CHECK(x.as_underlying() == TestType{16});
 }
 
 TEST_CASE("conversion with deduction guide", "[rollover]") {
     constexpr auto x = stdx::rollover_t{16u};
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(x), stdx::rollover_t<unsigned int> const>);
 }
 
@@ -76,14 +76,14 @@ TEMPLATE_TEST_CASE("equality", "[rollover]", std::uint8_t, std::uint16_t,
 TEMPLATE_TEST_CASE("unary plus", "[rollover]", std::uint8_t, std::uint16_t,
                    std::uint32_t, std::uint64_t) {
     using rollover_t = stdx::rollover_t<TestType>;
-    static_assert(+rollover_t{1} == rollover_t{1});
+    STATIC_REQUIRE(+rollover_t{1} == rollover_t{1});
     CHECK(+rollover_t{1} == rollover_t{1});
 }
 
 TEMPLATE_TEST_CASE("unary minus", "[rollover]", std::uint8_t, std::uint16_t,
                    std::uint32_t, std::uint64_t) {
     using rollover_t = stdx::rollover_t<TestType>;
-    static_assert(-rollover_t{1} == rollover_t{-1});
+    STATIC_REQUIRE(-rollover_t{1} == rollover_t{-1});
     CHECK(-rollover_t{1} == rollover_t{-1});
 }
 

--- a/test/span.cpp
+++ b/test/span.cpp
@@ -13,36 +13,36 @@
 TEMPLATE_TEST_CASE("span exposes types", "[span]", std::uint8_t,
                    std::uint8_t const, std::uint8_t *) {
     using S = stdx::span<TestType>;
-    static_assert(std::is_same_v<typename S::element_type, TestType>);
-    static_assert(
+    STATIC_REQUIRE(std::is_same_v<typename S::element_type, TestType>);
+    STATIC_REQUIRE(
         std::is_same_v<typename S::value_type, stdx::remove_cvref_t<TestType>>);
-    static_assert(std::is_same_v<typename S::size_type, std::size_t>);
-    static_assert(std::is_same_v<typename S::difference_type, std::ptrdiff_t>);
-    static_assert(std::is_same_v<typename S::pointer, TestType *>);
-    static_assert(std::is_same_v<typename S::const_pointer, TestType const *>);
-    static_assert(std::is_same_v<typename S::reference, TestType &>);
-    static_assert(
+    STATIC_REQUIRE(std::is_same_v<typename S::size_type, std::size_t>);
+    STATIC_REQUIRE(std::is_same_v<typename S::difference_type, std::ptrdiff_t>);
+    STATIC_REQUIRE(std::is_same_v<typename S::pointer, TestType *>);
+    STATIC_REQUIRE(std::is_same_v<typename S::const_pointer, TestType const *>);
+    STATIC_REQUIRE(std::is_same_v<typename S::reference, TestType &>);
+    STATIC_REQUIRE(
         std::is_same_v<typename S::const_reference, TestType const &>);
-    static_assert(std::is_same_v<std::void_t<typename S::iterator>, void>);
-    static_assert(
+    STATIC_REQUIRE(std::is_same_v<std::void_t<typename S::iterator>, void>);
+    STATIC_REQUIRE(
         std::is_same_v<std::void_t<typename S::const_iterator>, void>);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<std::void_t<typename S::reverse_iterator>, void>);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<std::void_t<typename S::const_reverse_iterator>, void>);
 }
 
 TEST_CASE("span exposes extent", "[span]") {
     using S = stdx::span<int>;
-    static_assert(S::extent == stdx::dynamic_extent);
+    STATIC_REQUIRE(S::extent == stdx::dynamic_extent);
     using S4 = stdx::span<int, 4u>;
-    static_assert(S4::extent == 4u);
+    STATIC_REQUIRE(S4::extent == 4u);
 }
 
 TEST_CASE("span is default constructible", "[span]") {
     constexpr auto s = stdx::span<int>{};
-    static_assert(std::data(s) == nullptr);
-    static_assert(std::size(s) == 0u);
+    STATIC_REQUIRE(std::data(s) == nullptr);
+    STATIC_REQUIRE(std::size(s) == 0u);
 }
 
 TEST_CASE("dynamic span is implicitly constructible from iterator & size "
@@ -52,8 +52,8 @@ TEST_CASE("dynamic span is implicitly constructible from iterator & size "
     constexpr auto s = [&]() -> stdx::span<int const> {
         return {std::data(a), 4};
     }();
-    static_assert(std::data(s) == std::data(a));
-    static_assert(std::size(s) == std::size(a));
+    STATIC_REQUIRE(std::data(s) == std::data(a));
+    STATIC_REQUIRE(std::size(s) == std::size(a));
 }
 
 TEST_CASE("span is explicitly constructible from iterator & size "
@@ -61,7 +61,7 @@ TEST_CASE("span is explicitly constructible from iterator & size "
           "[span]") {
     constexpr static auto a = std::array{1, 2, 3, 4};
     constexpr auto s = stdx::span<int const, 4>{std::data(a), 4};
-    static_assert(std::data(s) == std::data(a));
+    STATIC_REQUIRE(std::data(s) == std::data(a));
 }
 
 TEST_CASE("dynamic span is implicitly constructible from iterator & size (non "
@@ -69,7 +69,7 @@ TEST_CASE("dynamic span is implicitly constructible from iterator & size (non "
           "[span]") {
     auto a = std::array{1, 2, 3, 4};
     auto s = [&]() -> stdx::span<int> { return {std::data(a), 4}; }();
-    static_assert(std::is_same_v<decltype(s), stdx::span<int>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s), stdx::span<int>>);
     CHECK(std::data(s) == std::data(a));
     CHECK(std::size(s) == std::size(a));
 }
@@ -89,9 +89,9 @@ TEST_CASE("dynamic span is implicitly constructible from iterator & sentinel "
     constexpr auto s = [&]() -> stdx::span<int const> {
         return {std::begin(a), std::end(a)};
     }();
-    static_assert(std::is_same_v<decltype(s), stdx::span<int const> const>);
-    static_assert(std::data(s) == std::data(a));
-    static_assert(std::size(s) == std::size(a));
+    STATIC_REQUIRE(std::is_same_v<decltype(s), stdx::span<int const> const>);
+    STATIC_REQUIRE(std::data(s) == std::data(a));
+    STATIC_REQUIRE(std::size(s) == std::size(a));
 }
 
 TEST_CASE("span is explicitly constructible from iterator & sentinel "
@@ -99,7 +99,7 @@ TEST_CASE("span is explicitly constructible from iterator & sentinel "
           "[span]") {
     constexpr static auto a = std::array{1, 2, 3, 4};
     constexpr auto s = stdx::span<int const, 4>{std::begin(a), std::end(a)};
-    static_assert(std::data(s) == std::data(a));
+    STATIC_REQUIRE(std::data(s) == std::data(a));
 }
 
 TEST_CASE(
@@ -110,7 +110,7 @@ TEST_CASE(
     auto s = [&]() -> stdx::span<int> {
         return {std::begin(a), std::end(a)};
     }();
-    static_assert(std::is_same_v<decltype(s), stdx::span<int>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s), stdx::span<int>>);
     CHECK(std::data(s) == std::data(a));
     CHECK(std::size(s) == std::size(a));
 }
@@ -126,33 +126,35 @@ TEST_CASE("span is explicitly constructible from iterator & sentinel (non "
 TEST_CASE("span is constructible from std::array (const data)", "[span]") {
     constexpr static auto a = std::array{1, 2, 3, 4};
     constexpr auto s = stdx::span{a};
-    static_assert(std::is_same_v<decltype(s), stdx::span<int const, 4u> const>);
-    static_assert(std::data(s) == std::data(a));
-    static_assert(std::size(s) == std::size(a));
+    STATIC_REQUIRE(
+        std::is_same_v<decltype(s), stdx::span<int const, 4u> const>);
+    STATIC_REQUIRE(std::data(s) == std::data(a));
+    STATIC_REQUIRE(std::size(s) == std::size(a));
 }
 
 TEST_CASE("span is constructible from std::array (non const data)", "[span]") {
     auto a = std::array{1, 2, 3, 4};
     auto s = stdx::span{a};
-    static_assert(std::is_same_v<decltype(s), stdx::span<int, 4u>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s), stdx::span<int, 4u>>);
     CHECK(std::data(s) == std::data(a));
     CHECK(std::size(s) == std::size(a));
-    static_assert(std::size(s) == 4);
+    STATIC_REQUIRE(std::size(s) == 4);
 }
 
 TEST_CASE("span is constructible from C-style array (const data)", "[span]") {
     constexpr static int a[] = {1, 2, 3, 4};
     constexpr auto s = stdx::span{a};
-    static_assert(std::is_same_v<decltype(s), stdx::span<int const, 4u> const>);
-    static_assert(std::data(s) == std::data(a));
-    static_assert(std::size(s) == std::size(a));
+    STATIC_REQUIRE(
+        std::is_same_v<decltype(s), stdx::span<int const, 4u> const>);
+    STATIC_REQUIRE(std::data(s) == std::data(a));
+    STATIC_REQUIRE(std::size(s) == std::size(a));
 }
 
 TEST_CASE("span is constructible from C-style array (non const data)",
           "[span]") {
     int a[] = {1, 2, 3, 4};
     auto s = stdx::span{a};
-    static_assert(std::is_same_v<decltype(s), stdx::span<int, 4u>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s), stdx::span<int, 4u>>);
     CHECK(std::data(s) == std::data(a));
     CHECK(std::size(s) == std::size(a));
 }
@@ -161,7 +163,7 @@ TEST_CASE("dynamic span is implicitly constructible from range (const data)",
           "[span]") {
     std::vector const v{1, 2, 3, 4};
     auto s = stdx::span{v};
-    static_assert(std::is_same_v<decltype(s), stdx::span<int const>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s), stdx::span<int const>>);
     CHECK(std::data(s) == std::data(v));
     CHECK(std::size(s) == std::size(v));
 }
@@ -178,7 +180,7 @@ TEST_CASE(
     "[span]") {
     std::vector v{1, 2, 3, 4};
     auto s = stdx::span{v};
-    static_assert(std::is_same_v<decltype(s), stdx::span<int>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s), stdx::span<int>>);
     CHECK(std::data(s) == std::data(v));
     CHECK(std::size(s) == std::size(v));
 }
@@ -217,7 +219,7 @@ TEST_CASE("span is a range", "[span]") {
 TEST_CASE("span is a const range", "[span]") {
     std::array a{1, 2, 3, 4};
     auto const s = stdx::span{a};
-    static_assert(std::is_same_v<decltype(s.cbegin()), int const *>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s.cbegin()), int const *>);
     CHECK(*std::cbegin(s) == 1);
     CHECK(std::distance(std::cbegin(s), std::cend(s)) == std::size(a));
 }
@@ -225,7 +227,7 @@ TEST_CASE("span is a const range", "[span]") {
 TEST_CASE("span is a mutable range", "[span]") {
     std::array a{1, 2, 3, 4};
     auto const s = stdx::span{a};
-    static_assert(std::is_same_v<decltype(s.begin()), int *>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s.begin()), int *>);
     *s.begin() = 2;
     CHECK(a[0] == 2);
 }
@@ -253,20 +255,20 @@ TEST_CASE("span is a mutable reverse range", "[span]") {
 
 TEST_CASE("dynamic span reports empty", "[span]") {
     constexpr auto s = stdx::span<int>{};
-    static_assert(s.empty());
+    STATIC_REQUIRE(s.empty());
 }
 
 TEST_CASE("span reports empty", "[span]") {
     constexpr auto s1 = stdx::span<int, 4>{};
-    static_assert(not s1.empty());
+    STATIC_REQUIRE(not s1.empty());
     constexpr auto s2 = stdx::span<int, 0>{};
-    static_assert(s2.empty());
+    STATIC_REQUIRE(s2.empty());
 }
 
 TEST_CASE("span reports size in bytes", "[span]") {
     constexpr static auto a = std::array{1, 2, 3, 4};
     constexpr auto s = stdx::span{a};
-    static_assert(s.size_bytes() == 4 * sizeof(int));
+    STATIC_REQUIRE(s.size_bytes() == 4 * sizeof(int));
 }
 
 TEST_CASE("dynamic span reports size in bytes", "[span]") {
@@ -278,17 +280,17 @@ TEST_CASE("dynamic span reports size in bytes", "[span]") {
 TEST_CASE("front and back", "[span]") {
     constexpr static auto a = std::array{1, 2, 3, 4};
     constexpr auto s = stdx::span{a};
-    static_assert(s.front() == 1);
-    static_assert(s.back() == 4);
+    STATIC_REQUIRE(s.front() == 1);
+    STATIC_REQUIRE(s.back() == 4);
 }
 
 TEST_CASE("indexing", "[span]") {
     constexpr static auto a = std::array{1, 2, 3, 4};
     constexpr auto s = stdx::span{a};
-    static_assert(s[0] == 1);
-    static_assert(s[1] == 2);
-    static_assert(s[2] == 3);
-    static_assert(s[3] == 4);
+    STATIC_REQUIRE(s[0] == 1);
+    STATIC_REQUIRE(s[1] == 2);
+    STATIC_REQUIRE(s[2] == 3);
+    STATIC_REQUIRE(s[3] == 4);
 }
 
 TEST_CASE("prefix of span", "[span]") {
@@ -296,15 +298,16 @@ TEST_CASE("prefix of span", "[span]") {
     constexpr auto s1 = stdx::span{a};
 
     constexpr auto s2 = s1.first<2>();
-    static_assert(std::is_same_v<decltype(s2), stdx::span<int const, 2> const>);
-    static_assert(s2[0] == 1);
-    static_assert(s2[1] == 2);
+    STATIC_REQUIRE(
+        std::is_same_v<decltype(s2), stdx::span<int const, 2> const>);
+    STATIC_REQUIRE(s2[0] == 1);
+    STATIC_REQUIRE(s2[1] == 2);
 
     constexpr auto s3 = s1.first(2);
-    static_assert(std::is_same_v<decltype(s3), stdx::span<int const> const>);
-    static_assert(std::size(s3) == 2);
-    static_assert(s3[0] == 1);
-    static_assert(s3[1] == 2);
+    STATIC_REQUIRE(std::is_same_v<decltype(s3), stdx::span<int const> const>);
+    STATIC_REQUIRE(std::size(s3) == 2);
+    STATIC_REQUIRE(s3[0] == 1);
+    STATIC_REQUIRE(s3[1] == 2);
 }
 
 TEST_CASE("prefix of dynamic span", "[span]") {
@@ -312,12 +315,12 @@ TEST_CASE("prefix of dynamic span", "[span]") {
     auto s1 = stdx::span{v};
 
     auto s2 = s1.first<2>();
-    static_assert(std::is_same_v<decltype(s2), stdx::span<int, 2>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s2), stdx::span<int, 2>>);
     CHECK(s2[0] == 1);
     CHECK(s2[1] == 2);
 
     auto s3 = s1.first(2);
-    static_assert(std::is_same_v<decltype(s3), stdx::span<int>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s3), stdx::span<int>>);
     CHECK(std::size(s3) == 2);
     CHECK(s3[0] == 1);
     CHECK(s3[1] == 2);
@@ -328,15 +331,16 @@ TEST_CASE("suffix of span", "[span]") {
     constexpr auto s1 = stdx::span{a};
 
     constexpr auto s2 = s1.last<2>();
-    static_assert(std::is_same_v<decltype(s2), stdx::span<int const, 2> const>);
-    static_assert(s2[0] == 3);
-    static_assert(s2[1] == 4);
+    STATIC_REQUIRE(
+        std::is_same_v<decltype(s2), stdx::span<int const, 2> const>);
+    STATIC_REQUIRE(s2[0] == 3);
+    STATIC_REQUIRE(s2[1] == 4);
 
     constexpr auto s3 = s1.last(2);
-    static_assert(std::is_same_v<decltype(s3), stdx::span<int const> const>);
-    static_assert(std::size(s3) == 2);
-    static_assert(s3[0] == 3);
-    static_assert(s3[1] == 4);
+    STATIC_REQUIRE(std::is_same_v<decltype(s3), stdx::span<int const> const>);
+    STATIC_REQUIRE(std::size(s3) == 2);
+    STATIC_REQUIRE(s3[0] == 3);
+    STATIC_REQUIRE(s3[1] == 4);
 }
 
 TEST_CASE("suffix of dynamic span", "[span]") {
@@ -344,12 +348,12 @@ TEST_CASE("suffix of dynamic span", "[span]") {
     auto s1 = stdx::span{v};
 
     auto s2 = s1.last<2>();
-    static_assert(std::is_same_v<decltype(s2), stdx::span<int, 2>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s2), stdx::span<int, 2>>);
     CHECK(s2[0] == 3);
     CHECK(s2[1] == 4);
 
     auto s3 = s1.last(2);
-    static_assert(std::is_same_v<decltype(s3), stdx::span<int>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s3), stdx::span<int>>);
     CHECK(std::size(s3) == 2);
     CHECK(s3[0] == 3);
     CHECK(s3[1] == 4);
@@ -360,26 +364,29 @@ TEST_CASE("subspan of span", "[span]") {
     constexpr auto s1 = stdx::span{a};
 
     constexpr auto s2 = s1.subspan<1, 2>();
-    static_assert(std::is_same_v<decltype(s2), stdx::span<int const, 2> const>);
-    static_assert(std::data(s2) == &a[1]);
+    STATIC_REQUIRE(
+        std::is_same_v<decltype(s2), stdx::span<int const, 2> const>);
+    STATIC_REQUIRE(std::data(s2) == &a[1]);
 
     constexpr auto s3 = s1.subspan<1>();
-    static_assert(std::is_same_v<decltype(s3), stdx::span<int const, 3> const>);
-    static_assert(std::data(s3) == &a[1]);
+    STATIC_REQUIRE(
+        std::is_same_v<decltype(s3), stdx::span<int const, 3> const>);
+    STATIC_REQUIRE(std::data(s3) == &a[1]);
 
     constexpr auto s4 = s1.subspan(1, 2);
-    static_assert(std::is_same_v<decltype(s4), stdx::span<int const> const>);
-    static_assert(std::size(s4) == 2);
-    static_assert(std::data(s4) == &a[1]);
+    STATIC_REQUIRE(std::is_same_v<decltype(s4), stdx::span<int const> const>);
+    STATIC_REQUIRE(std::size(s4) == 2);
+    STATIC_REQUIRE(std::data(s4) == &a[1]);
 
     constexpr auto s5 = s1.subspan(1);
-    static_assert(std::is_same_v<decltype(s5), stdx::span<int const> const>);
-    static_assert(std::size(s5) == 3);
-    static_assert(std::data(s5) == &a[1]);
+    STATIC_REQUIRE(std::is_same_v<decltype(s5), stdx::span<int const> const>);
+    STATIC_REQUIRE(std::size(s5) == 3);
+    STATIC_REQUIRE(std::data(s5) == &a[1]);
 
     constexpr auto s6 = s1.subspan<4, 0>();
-    static_assert(std::is_same_v<decltype(s6), stdx::span<int const, 0> const>);
-    static_assert(std::data(s6) == stdx::to_address(std::end(a)));
+    STATIC_REQUIRE(
+        std::is_same_v<decltype(s6), stdx::span<int const, 0> const>);
+    STATIC_REQUIRE(std::data(s6) == stdx::to_address(std::end(a)));
 }
 
 TEST_CASE("subspan of dynamic span", "[span]") {
@@ -387,25 +394,25 @@ TEST_CASE("subspan of dynamic span", "[span]") {
     auto s1 = stdx::span{a};
 
     auto s2 = s1.subspan<1, 2>();
-    static_assert(std::is_same_v<decltype(s2), stdx::span<int, 2>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s2), stdx::span<int, 2>>);
     CHECK(std::data(s2) == &a[1]);
 
     auto s3 = s1.subspan<1>();
-    static_assert(std::is_same_v<decltype(s3), stdx::span<int>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s3), stdx::span<int>>);
     CHECK(std::data(s3) == &a[1]);
 
     auto s4 = s1.subspan(1, 2);
-    static_assert(std::is_same_v<decltype(s4), stdx::span<int>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s4), stdx::span<int>>);
     CHECK(std::size(s4) == 2);
     CHECK(std::data(s4) == &a[1]);
 
     auto s5 = s1.subspan(1);
-    static_assert(std::is_same_v<decltype(s5), stdx::span<int>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s5), stdx::span<int>>);
     CHECK(std::size(s5) == 3);
     CHECK(std::data(s5) == &a[1]);
 
     auto s6 = s1.subspan<4, 0>();
-    static_assert(std::is_same_v<decltype(s6), stdx::span<int, 0>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s6), stdx::span<int, 0>>);
     CHECK(std::data(s6) == stdx::to_address(std::end(a)));
 }
 
@@ -422,8 +429,9 @@ TEST_CASE("as_bytes on span", "[span]") {
     auto s1 = stdx::span{a};
     auto s2 = as_bytes(s1);
 
-    static_assert(std::is_same_v<decltype(s2),
-                                 stdx::span<std::byte const, 4 * sizeof(int)>>);
+    STATIC_REQUIRE(
+        std::is_same_v<decltype(s2),
+                       stdx::span<std::byte const, 4 * sizeof(int)>>);
     CHECK(static_cast<void const *>(std::data(s2)) ==
           static_cast<void const *>(std::data(a)));
 }
@@ -433,7 +441,7 @@ TEST_CASE("as_bytes on dynamic span", "[span]") {
     auto s1 = stdx::span{v};
     auto s2 = as_bytes(s1);
 
-    static_assert(std::is_same_v<decltype(s2), stdx::span<std::byte const>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s2), stdx::span<std::byte const>>);
     CHECK(static_cast<void const *>(std::data(s2)) ==
           static_cast<void const *>(std::data(v)));
     CHECK(std::size(s2) == 4 * sizeof(int));
@@ -444,7 +452,7 @@ TEST_CASE("as_writable_bytes on span", "[span]") {
     auto s1 = stdx::span{a};
     auto s2 = as_writable_bytes(s1);
 
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(s2), stdx::span<std::byte, 4 * sizeof(int)>>);
     CHECK(static_cast<void *>(std::data(s2)) ==
           static_cast<void *>(std::data(a)));
@@ -453,7 +461,7 @@ TEST_CASE("as_writable_bytes on span", "[span]") {
 TEST_CASE("span-over-const is implicitly constructible from span", "[span]") {
     auto a = std::array{1, 2, 3, 4};
     auto s1 = stdx::span{a};
-    static_assert(std::is_same_v<decltype(s1), stdx::span<int, 4>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s1), stdx::span<int, 4>>);
     auto s2 = [&]() -> stdx::span<int const, 4> { return s1; }();
     CHECK(std::data(s2) == std::data(s1));
 }
@@ -462,7 +470,7 @@ TEST_CASE("dynamic span-over-const is implicitly constructible from span",
           "[span]") {
     auto a = std::array{1, 2, 3, 4};
     auto s1 = stdx::span{a};
-    static_assert(std::is_same_v<decltype(s1), stdx::span<int, 4>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s1), stdx::span<int, 4>>);
     auto s2 = [&]() -> stdx::span<int const> { return s1; }();
     CHECK(std::data(s2) == std::data(s1));
     CHECK(std::size(s2) == 4u);
@@ -473,7 +481,7 @@ TEST_CASE(
     "[span]") {
     auto v = std::vector{1, 2, 3, 4};
     auto s1 = stdx::span{v};
-    static_assert(std::is_same_v<decltype(s1), stdx::span<int>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s1), stdx::span<int>>);
     auto s2 = [&]() -> stdx::span<int const> { return s1; }();
     CHECK(std::size(s2) == 4u);
 }
@@ -482,7 +490,7 @@ TEST_CASE("span-over-const is explicitly constructible from dynamic span",
           "[span]") {
     auto v = std::vector{1, 2, 3, 4};
     auto s1 = stdx::span{v};
-    static_assert(std::is_same_v<decltype(s1), stdx::span<int>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(s1), stdx::span<int>>);
     auto s2 = stdx::span<int const, 4>{s1};
     CHECK(std::data(s2) == std::data(s1));
 }

--- a/test/tuple.cpp
+++ b/test/tuple.cpp
@@ -12,44 +12,44 @@
 #include <utility>
 
 TEST_CASE("empty tuple", "[tuple]") {
-    static_assert(std::is_empty_v<stdx::tuple<>>);
+    STATIC_REQUIRE(std::is_empty_v<stdx::tuple<>>);
     constexpr auto t = stdx::tuple{};
     using T = std::remove_const_t<decltype(t)>;
-    static_assert(std::is_same_v<T, stdx::tuple<>>);
-    static_assert(stdx::tuple_size_v<T> == 0);
-    static_assert(T::size() == 0);
+    STATIC_REQUIRE(std::is_same_v<T, stdx::tuple<>>);
+    STATIC_REQUIRE(stdx::tuple_size_v<T> == 0);
+    STATIC_REQUIRE(T::size() == 0);
 }
 
 TEST_CASE("single element tuple", "[tuple]") {
     constexpr auto t = stdx::tuple{1};
     using T = std::remove_const_t<decltype(t)>;
-    static_assert(std::is_same_v<T, stdx::tuple<int>>);
-    static_assert(stdx::tuple_size_v<T> == 1);
-    static_assert(T::size() == 1);
-    static_assert(sizeof(T) == sizeof(int));
+    STATIC_REQUIRE(std::is_same_v<T, stdx::tuple<int>>);
+    STATIC_REQUIRE(stdx::tuple_size_v<T> == 1);
+    STATIC_REQUIRE(T::size() == 1);
+    STATIC_REQUIRE(sizeof(T) == sizeof(int));
 
     auto u = stdx::tuple{1};
     using U = decltype(u);
-    static_assert(std::is_same_v<U, stdx::tuple<int>>);
-    static_assert(stdx::tuple_size_v<U> == 1);
-    static_assert(U::size() == 1);
-    static_assert(sizeof(U) == sizeof(int));
+    STATIC_REQUIRE(std::is_same_v<U, stdx::tuple<int>>);
+    STATIC_REQUIRE(stdx::tuple_size_v<U> == 1);
+    STATIC_REQUIRE(U::size() == 1);
+    STATIC_REQUIRE(sizeof(U) == sizeof(int));
 }
 
 TEST_CASE("multi element tuple", "[tuple]") {
     constexpr auto t = stdx::tuple{1, 2.0f};
     using T = std::remove_const_t<decltype(t)>;
-    static_assert(std::is_same_v<T, stdx::tuple<int, float>>);
-    static_assert(stdx::tuple_size_v<T> == 2);
-    static_assert(T::size() == 2);
+    STATIC_REQUIRE(std::is_same_v<T, stdx::tuple<int, float>>);
+    STATIC_REQUIRE(stdx::tuple_size_v<T> == 2);
+    STATIC_REQUIRE(T::size() == 2);
 }
 
 TEST_CASE("constexpr tuple of references", "[tuple]") {
     constexpr static int x = 1;
     constexpr auto t = stdx::tuple<int const &>{x};
     using T = std::remove_const_t<decltype(t)>;
-    static_assert(stdx::tuple_size_v<T> == 1);
-    static_assert(T::size() == 1);
+    STATIC_REQUIRE(stdx::tuple_size_v<T> == 1);
+    STATIC_REQUIRE(T::size() == 1);
 }
 
 TEST_CASE("free get", "[tuple]") {
@@ -58,16 +58,16 @@ TEST_CASE("free get", "[tuple]") {
     CHECK(stdx::get<0>(t) == 5);
     CHECK(stdx::get<1>(t));
     CHECK(stdx::get<2>(t) == 10);
-    static_assert(stdx::get<0>(t) == 5);
-    static_assert(stdx::get<1>(t));
-    static_assert(stdx::get<2>(t) == 10);
+    STATIC_REQUIRE(stdx::get<0>(t) == 5);
+    STATIC_REQUIRE(stdx::get<1>(t));
+    STATIC_REQUIRE(stdx::get<2>(t) == 10);
 
     CHECK(stdx::get<int>(t) == 5);
     CHECK(stdx::get<bool>(t));
     CHECK(stdx::get<long>(t) == 10);
-    static_assert(stdx::get<int>(t) == 5);
-    static_assert(stdx::get<bool>(t));
-    static_assert(stdx::get<long>(t) == 10);
+    STATIC_REQUIRE(stdx::get<int>(t) == 5);
+    STATIC_REQUIRE(stdx::get<bool>(t));
+    STATIC_REQUIRE(stdx::get<long>(t) == 10);
 }
 
 TEST_CASE("free get (ADL)", "[tuple]") {
@@ -76,30 +76,31 @@ TEST_CASE("free get (ADL)", "[tuple]") {
     CHECK(get<0>(t) == 5);
     CHECK(get<1>(t));
     CHECK(get<2>(t) == 10);
-    static_assert(get<0>(t) == 5);
-    static_assert(get<1>(t));
-    static_assert(get<2>(t) == 10);
+    STATIC_REQUIRE(get<0>(t) == 5);
+    STATIC_REQUIRE(get<1>(t));
+    STATIC_REQUIRE(get<2>(t) == 10);
 
     CHECK(get<int>(t) == 5);
     CHECK(get<bool>(t));
     CHECK(get<long>(t) == 10);
-    static_assert(get<int>(t) == 5);
-    static_assert(get<bool>(t));
-    static_assert(get<long>(t) == 10);
+    STATIC_REQUIRE(get<int>(t) == 5);
+    STATIC_REQUIRE(get<bool>(t));
+    STATIC_REQUIRE(get<long>(t) == 10);
 }
 
 TEST_CASE("free get value categories", "[tuple]") {
     {
         auto const t = stdx::tuple{42};
-        static_assert(std::is_same_v<decltype(get<0>(t)), int const &>);
-        static_assert(std::is_same_v<decltype(get<int>(t)), int const &>);
+        STATIC_REQUIRE(std::is_same_v<decltype(get<0>(t)), int const &>);
+        STATIC_REQUIRE(std::is_same_v<decltype(get<int>(t)), int const &>);
     }
     {
         auto t = stdx::tuple{42};
-        static_assert(std::is_same_v<decltype(get<0>(t)), int &>);
-        static_assert(std::is_same_v<decltype(get<int>(t)), int &>);
-        static_assert(std::is_same_v<decltype(get<0>(std::move(t))), int &&>);
-        static_assert(std::is_same_v<decltype(get<int>(std::move(t))), int &&>);
+        STATIC_REQUIRE(std::is_same_v<decltype(get<0>(t)), int &>);
+        STATIC_REQUIRE(std::is_same_v<decltype(get<int>(t)), int &>);
+        STATIC_REQUIRE(std::is_same_v<decltype(get<0>(std::move(t))), int &&>);
+        STATIC_REQUIRE(
+            std::is_same_v<decltype(get<int>(std::move(t))), int &&>);
     }
 }
 
@@ -107,14 +108,14 @@ TEST_CASE("indexing", "[tuple]") {
     using namespace stdx::literals;
 
     constexpr auto t = stdx::tuple{5, true, 10l};
-    static_assert(t[0_idx] == 5);
-    static_assert(t[1_idx] == true);
-    static_assert(t[2_idx] == 10l);
+    STATIC_REQUIRE(t[0_idx] == 5);
+    STATIC_REQUIRE(t[1_idx] == true);
+    STATIC_REQUIRE(t[2_idx] == 10l);
 
-    static_assert(std::is_same_v<decltype(t[0_idx]), int const &>);
+    STATIC_REQUIRE(std::is_same_v<decltype(t[0_idx]), int const &>);
     auto u = stdx::tuple{1};
-    static_assert(std::is_same_v<decltype(u[0_idx]), int &>);
-    static_assert(std::is_same_v<decltype(stdx::tuple{1}[0_idx]), int &&>);
+    STATIC_REQUIRE(std::is_same_v<decltype(u[0_idx]), int &>);
+    STATIC_REQUIRE(std::is_same_v<decltype(stdx::tuple{1}[0_idx]), int &&>);
 }
 
 TEST_CASE("indexing with small literals", "[tuple]") {
@@ -124,9 +125,9 @@ TEST_CASE("indexing with small literals", "[tuple]") {
     CHECK(get<"index"_0>(t) == 5);
     CHECK(get<"index"_1>(t));
     CHECK(get<"index"_2>(t) == 10);
-    static_assert(t["index"_0] == 5);
-    static_assert(t["index"_1]);
-    static_assert(t["index"_2] == 10l);
+    STATIC_REQUIRE(t["index"_0] == 5);
+    STATIC_REQUIRE(t["index"_1]);
+    STATIC_REQUIRE(t["index"_2] == 10l);
 }
 
 TEST_CASE("tuple of lvalue references", "[tuple]") {
@@ -147,16 +148,16 @@ TEST_CASE("tuple of lambdas", "[tuple]") {
 
 TEST_CASE("tuple size/elements", "[tuple]") {
     using T = stdx::tuple<int, bool>;
-    static_assert(stdx::tuple_size_v<T> == 2);
-    static_assert(std::is_same_v<stdx::tuple_element_t<0, T>, int>);
-    static_assert(std::is_same_v<stdx::tuple_element_t<1, T>, bool>);
+    STATIC_REQUIRE(stdx::tuple_size_v<T> == 2);
+    STATIC_REQUIRE(std::is_same_v<stdx::tuple_element_t<0, T>, int>);
+    STATIC_REQUIRE(std::is_same_v<stdx::tuple_element_t<1, T>, bool>);
 
     using A = stdx::tuple<int &>;
-    static_assert(std::is_same_v<stdx::tuple_element_t<0, A>, int &>);
+    STATIC_REQUIRE(std::is_same_v<stdx::tuple_element_t<0, A>, int &>);
     using B = stdx::tuple<int const &>;
-    static_assert(std::is_same_v<stdx::tuple_element_t<0, B>, int const &>);
+    STATIC_REQUIRE(std::is_same_v<stdx::tuple_element_t<0, B>, int const &>);
     using C = stdx::tuple<int &&>;
-    static_assert(std::is_same_v<stdx::tuple_element_t<0, C>, int &&>);
+    STATIC_REQUIRE(std::is_same_v<stdx::tuple_element_t<0, C>, int &&>);
 }
 
 TEST_CASE("destructuring", "[tuple]") {
@@ -174,64 +175,65 @@ struct B {
 } // namespace
 
 TEST_CASE("default constructability", "[tuple]") {
-    static_assert(std::is_default_constructible_v<stdx::tuple<A>>);
-    static_assert(std::is_nothrow_default_constructible_v<stdx::tuple<A>>);
-    static_assert(not std::is_default_constructible_v<stdx::tuple<B>>);
-    static_assert(not std::is_nothrow_default_constructible_v<stdx::tuple<B>>);
+    STATIC_REQUIRE(std::is_default_constructible_v<stdx::tuple<A>>);
+    STATIC_REQUIRE(std::is_nothrow_default_constructible_v<stdx::tuple<A>>);
+    STATIC_REQUIRE(not std::is_default_constructible_v<stdx::tuple<B>>);
+    STATIC_REQUIRE(not std::is_nothrow_default_constructible_v<stdx::tuple<B>>);
 }
 
 TEMPLATE_TEST_CASE("constructability", "[tuple]",
                    (stdx::detail::element<0, int>), stdx::tuple<>,
                    (stdx::tuple<A, int, bool>)) {
-    static_assert(std::is_default_constructible_v<TestType>);
-    static_assert(std::is_nothrow_default_constructible_v<TestType>);
+    STATIC_REQUIRE(std::is_default_constructible_v<TestType>);
+    STATIC_REQUIRE(std::is_nothrow_default_constructible_v<TestType>);
 }
 
 TEMPLATE_TEST_CASE("copyability", "[tuple]", (stdx::detail::element<0, int>),
                    stdx::tuple<>, (stdx::tuple<A, int, bool>)) {
-    static_assert(std::is_copy_constructible_v<TestType>);
-    static_assert(std::is_copy_assignable_v<TestType>);
-    static_assert(std::is_nothrow_copy_constructible_v<TestType>);
-    static_assert(std::is_nothrow_copy_assignable_v<TestType>);
-    static_assert(std::is_trivially_copy_constructible_v<TestType>);
-    static_assert(std::is_trivially_copy_assignable_v<TestType>);
+    STATIC_REQUIRE(std::is_copy_constructible_v<TestType>);
+    STATIC_REQUIRE(std::is_copy_assignable_v<TestType>);
+    STATIC_REQUIRE(std::is_nothrow_copy_constructible_v<TestType>);
+    STATIC_REQUIRE(std::is_nothrow_copy_assignable_v<TestType>);
+    STATIC_REQUIRE(std::is_trivially_copy_constructible_v<TestType>);
+    STATIC_REQUIRE(std::is_trivially_copy_assignable_v<TestType>);
 }
 
 TEMPLATE_TEST_CASE("moveability", "[tuple]", (stdx::detail::element<0, int>),
                    stdx::tuple<>, (stdx::tuple<A, int, bool>)) {
-    static_assert(std::is_move_constructible_v<TestType>);
-    static_assert(std::is_move_assignable_v<TestType>);
-    static_assert(std::is_nothrow_move_constructible_v<TestType>);
-    static_assert(std::is_nothrow_move_assignable_v<TestType>);
-    static_assert(std::is_trivially_move_constructible_v<TestType>);
-    static_assert(std::is_trivially_move_assignable_v<TestType>);
+    STATIC_REQUIRE(std::is_move_constructible_v<TestType>);
+    STATIC_REQUIRE(std::is_move_assignable_v<TestType>);
+    STATIC_REQUIRE(std::is_nothrow_move_constructible_v<TestType>);
+    STATIC_REQUIRE(std::is_nothrow_move_assignable_v<TestType>);
+    STATIC_REQUIRE(std::is_trivially_move_constructible_v<TestType>);
+    STATIC_REQUIRE(std::is_trivially_move_assignable_v<TestType>);
 }
 
 TEMPLATE_TEST_CASE("destructability", "[tuple]",
                    (stdx::detail::element<0, int>), stdx::tuple<>,
                    (stdx::tuple<A, int, bool>)) {
-    static_assert(std::is_nothrow_destructible_v<TestType>);
-    static_assert(std::is_trivially_destructible_v<TestType>);
+    STATIC_REQUIRE(std::is_nothrow_destructible_v<TestType>);
+    STATIC_REQUIRE(std::is_trivially_destructible_v<TestType>);
 }
 
 TEST_CASE("move-only types", "[tuple]") {
-    static_assert(std::is_default_constructible_v<stdx::tuple<move_only>>);
-    static_assert(
+    STATIC_REQUIRE(std::is_default_constructible_v<stdx::tuple<move_only>>);
+    STATIC_REQUIRE(
         std::is_nothrow_default_constructible_v<stdx::tuple<move_only>>);
 
-    static_assert(not std::is_copy_constructible_v<stdx::tuple<move_only>>);
-    static_assert(not std::is_copy_assignable_v<stdx::tuple<move_only>>);
+    STATIC_REQUIRE(not std::is_copy_constructible_v<stdx::tuple<move_only>>);
+    STATIC_REQUIRE(not std::is_copy_assignable_v<stdx::tuple<move_only>>);
 
-    static_assert(std::is_move_constructible_v<stdx::tuple<move_only>>);
-    static_assert(std::is_move_assignable_v<stdx::tuple<move_only>>);
-    static_assert(std::is_nothrow_move_constructible_v<stdx::tuple<move_only>>);
-    static_assert(std::is_nothrow_move_assignable_v<stdx::tuple<move_only>>);
-    static_assert(
+    STATIC_REQUIRE(std::is_move_constructible_v<stdx::tuple<move_only>>);
+    STATIC_REQUIRE(std::is_move_assignable_v<stdx::tuple<move_only>>);
+    STATIC_REQUIRE(
+        std::is_nothrow_move_constructible_v<stdx::tuple<move_only>>);
+    STATIC_REQUIRE(std::is_nothrow_move_assignable_v<stdx::tuple<move_only>>);
+    STATIC_REQUIRE(
         std::is_trivially_move_constructible_v<stdx::tuple<move_only>>);
-    static_assert(std::is_trivially_move_assignable_v<stdx::tuple<move_only>>);
+    STATIC_REQUIRE(std::is_trivially_move_assignable_v<stdx::tuple<move_only>>);
 
-    static_assert(std::is_nothrow_destructible_v<stdx::tuple<move_only>>);
-    static_assert(std::is_trivially_destructible_v<stdx::tuple<move_only>>);
+    STATIC_REQUIRE(std::is_nothrow_destructible_v<stdx::tuple<move_only>>);
+    STATIC_REQUIRE(std::is_trivially_destructible_v<stdx::tuple<move_only>>);
 }
 
 TEST_CASE("equality comparable", "[tuple]") {
@@ -239,8 +241,8 @@ TEST_CASE("equality comparable", "[tuple]") {
 
     REQUIRE(t == t);
     REQUIRE(t != stdx::tuple{5, 11});
-    static_assert(t == stdx::tuple{5, 10});
-    static_assert(t != stdx::tuple{5, 11});
+    STATIC_REQUIRE(t == stdx::tuple{5, 10});
+    STATIC_REQUIRE(t != stdx::tuple{5, 11});
 }
 
 TEST_CASE("equality comparable (tuple of references)", "[tuple]") {
@@ -263,7 +265,7 @@ TEST_CASE("equality comparable (references and non-references)", "[tuple]") {
 
 TEST_CASE("equality comparable (conversions)", "[tuple]") {
     constexpr auto t = stdx::tuple{1};
-    static_assert(t == stdx::tuple{1.0});
+    STATIC_REQUIRE(t == stdx::tuple{1.0});
 }
 
 namespace {
@@ -280,13 +282,13 @@ struct eq_derived : eq {};
 TEST_CASE("equality comparable (user-defined)", "[tuple]") {
     constexpr auto t = stdx::tuple{eq{1}};
 
-    static_assert(t == stdx::tuple{eq{1}});
-    static_assert(t != stdx::tuple{eq{2}});
+    STATIC_REQUIRE(t == stdx::tuple{eq{1}});
+    STATIC_REQUIRE(t != stdx::tuple{eq{2}});
 }
 
 TEST_CASE("equality comparable (conversions, user-defined)", "[tuple]") {
     constexpr auto t = stdx::tuple{eq{1}};
-    static_assert(t == stdx::tuple{eq_derived{1}});
+    STATIC_REQUIRE(t == stdx::tuple{eq_derived{1}});
 }
 
 TEST_CASE("order comparable", "[tuple]") {
@@ -296,41 +298,41 @@ TEST_CASE("order comparable", "[tuple]") {
     REQUIRE(t < stdx::tuple{5, 11});
     REQUIRE(not(t < t));
     REQUIRE(not(t < stdx::tuple{4, 11}));
-    static_assert(t < stdx::tuple{6, 9});
-    static_assert(t < stdx::tuple{5, 11});
-    static_assert(not(t < t)); // NOLINT(misc-redundant-expression)
-    static_assert(not(t < stdx::tuple{4, 11}));
+    STATIC_REQUIRE(t < stdx::tuple{6, 9});
+    STATIC_REQUIRE(t < stdx::tuple{5, 11});
+    STATIC_REQUIRE(not(t < t)); // NOLINT(misc-redundant-expression)
+    STATIC_REQUIRE(not(t < stdx::tuple{4, 11}));
 
     REQUIRE(t <= t);
     REQUIRE(t <= stdx::tuple{6, 9});
     REQUIRE(t <= stdx::tuple{5, 11});
     REQUIRE(not(t <= stdx::tuple{5, 9}));
     REQUIRE(not(t <= stdx::tuple{4, 11}));
-    static_assert(t <= t); // NOLINT(misc-redundant-expression)
-    static_assert(t <= stdx::tuple{6, 9});
-    static_assert(t <= stdx::tuple{5, 11});
-    static_assert(not(t <= stdx::tuple{5, 9}));
-    static_assert(not(t <= stdx::tuple{4, 11}));
+    STATIC_REQUIRE(t <= t); // NOLINT(misc-redundant-expression)
+    STATIC_REQUIRE(t <= stdx::tuple{6, 9});
+    STATIC_REQUIRE(t <= stdx::tuple{5, 11});
+    STATIC_REQUIRE(not(t <= stdx::tuple{5, 9}));
+    STATIC_REQUIRE(not(t <= stdx::tuple{4, 11}));
 
     REQUIRE(t > stdx::tuple{5, 9});
     REQUIRE(t > stdx::tuple{4, 11});
     REQUIRE(not(t > t));
     REQUIRE(not(t > stdx::tuple{6, 9}));
-    static_assert(t > stdx::tuple{5, 9});
-    static_assert(t > stdx::tuple{4, 11});
-    static_assert(not(t > t)); // NOLINT(misc-redundant-expression)
-    static_assert(not(t > stdx::tuple{6, 9}));
+    STATIC_REQUIRE(t > stdx::tuple{5, 9});
+    STATIC_REQUIRE(t > stdx::tuple{4, 11});
+    STATIC_REQUIRE(not(t > t)); // NOLINT(misc-redundant-expression)
+    STATIC_REQUIRE(not(t > stdx::tuple{6, 9}));
 
     REQUIRE(t >= t);
     REQUIRE(t >= stdx::tuple{5, 9});
     REQUIRE(t >= stdx::tuple{4, 11});
     REQUIRE(not(t >= stdx::tuple{5, 11}));
     REQUIRE(not(t >= stdx::tuple{6, 9}));
-    static_assert(t >= t); // NOLINT(misc-redundant-expression)
-    static_assert(t >= stdx::tuple{5, 9});
-    static_assert(t >= stdx::tuple{4, 11});
-    static_assert(not(t >= stdx::tuple{5, 11}));
-    static_assert(not(t >= stdx::tuple{6, 9}));
+    STATIC_REQUIRE(t >= t); // NOLINT(misc-redundant-expression)
+    STATIC_REQUIRE(t >= stdx::tuple{5, 9});
+    STATIC_REQUIRE(t >= stdx::tuple{4, 11});
+    STATIC_REQUIRE(not(t >= stdx::tuple{5, 11}));
+    STATIC_REQUIRE(not(t >= stdx::tuple{6, 9}));
 }
 
 TEST_CASE("order comparable (references and non-references)", "[tuple]") {
@@ -352,13 +354,13 @@ TEST_CASE("spaceship comparable", "[tuple]") {
     REQUIRE(t <=> stdx::tuple{5, 9} == std::strong_ordering::greater);
     REQUIRE(t <=> stdx::tuple{4, 10} == std::strong_ordering::greater);
     REQUIRE(t <=> stdx::tuple{4, 11} == std::strong_ordering::greater);
-    static_assert(t <=> t == std::strong_ordering::equal);
-    static_assert(t <=> stdx::tuple{6, 9} == std::strong_ordering::less);
-    static_assert(t <=> stdx::tuple{6, 10} == std::strong_ordering::less);
-    static_assert(t <=> stdx::tuple{5, 11} == std::strong_ordering::less);
-    static_assert(t <=> stdx::tuple{5, 9} == std::strong_ordering::greater);
-    static_assert(t <=> stdx::tuple{4, 10} == std::strong_ordering::greater);
-    static_assert(t <=> stdx::tuple{4, 11} == std::strong_ordering::greater);
+    STATIC_REQUIRE(t <=> t == std::strong_ordering::equal);
+    STATIC_REQUIRE(t <=> stdx::tuple{6, 9} == std::strong_ordering::less);
+    STATIC_REQUIRE(t <=> stdx::tuple{6, 10} == std::strong_ordering::less);
+    STATIC_REQUIRE(t <=> stdx::tuple{5, 11} == std::strong_ordering::less);
+    STATIC_REQUIRE(t <=> stdx::tuple{5, 9} == std::strong_ordering::greater);
+    STATIC_REQUIRE(t <=> stdx::tuple{4, 10} == std::strong_ordering::greater);
+    STATIC_REQUIRE(t <=> stdx::tuple{4, 11} == std::strong_ordering::greater);
 }
 
 TEST_CASE("spaceship comparable (references and non-references)", "[tuple]") {
@@ -373,7 +375,7 @@ TEST_CASE("free get is SFINAE-friendly", "[tuple]") {
     constexpr auto t = []<typename... Ts>(stdx::tuple<Ts...> const &tup) {
         return stdx::tuple{get<Ts>(tup)...};
     }(stdx::tuple{});
-    static_assert(t == stdx::tuple{});
+    STATIC_REQUIRE(t == stdx::tuple{});
 }
 
 TEST_CASE("copy/move behavior for tuple", "[tuple]") {
@@ -391,14 +393,14 @@ TEST_CASE("copy/move behavior for tuple", "[tuple]") {
 }
 
 TEST_CASE("make_tuple", "[tuple]") {
-    static_assert(stdx::make_tuple() == stdx::tuple{});
-    static_assert(stdx::make_tuple(1, 2, 3) == stdx::tuple{1, 2, 3});
+    STATIC_REQUIRE(stdx::make_tuple() == stdx::tuple{});
+    STATIC_REQUIRE(stdx::make_tuple(1, 2, 3) == stdx::tuple{1, 2, 3});
 
     constexpr auto t = stdx::make_tuple(stdx::tuple{});
     using T = std::remove_const_t<decltype(t)>;
-    static_assert(std::is_same_v<T, stdx::tuple<stdx::tuple<>>>);
-    static_assert(stdx::tuple_size_v<T> == 1);
-    static_assert(T::size() == 1);
+    STATIC_REQUIRE(std::is_same_v<T, stdx::tuple<stdx::tuple<>>>);
+    STATIC_REQUIRE(stdx::tuple_size_v<T> == 1);
+    STATIC_REQUIRE(T::size() == 1);
 }
 
 namespace detail {
@@ -419,8 +421,8 @@ struct concat<L<Ts...>, L<U, Us...>> {
 TEST_CASE("tuple type-based concat", "[tuple]") {
     using T = stdx::tuple<int>;
     using U = stdx::tuple<float>;
-    static_assert(std::is_same_v<typename detail::concat<T, U>::type,
-                                 stdx::tuple<int, float>>);
+    STATIC_REQUIRE(std::is_same_v<typename detail::concat<T, U>::type,
+                                  stdx::tuple<int, float>>);
 }
 
 TEST_CASE("forward_as_tuple", "[tuple]") {
@@ -428,25 +430,25 @@ TEST_CASE("forward_as_tuple", "[tuple]") {
     auto y = 17;
     auto z = 17;
     auto t = stdx::forward_as_tuple(x, y, std::move(z));
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(t), stdx::tuple<int const &, int &, int &&>>);
     CHECK(t == stdx::tuple{17, 17, 17});
 }
 
 TEST_CASE("one_of", "[tuple]") {
-    static_assert(1 == stdx::one_of{1, 2, 3});
-    static_assert(4 != stdx::one_of{1, 2, 3});
-    static_assert(stdx::one_of{1, 2, 3} == 1);
-    static_assert(stdx::one_of{1, 2, 3} != 4);
+    STATIC_REQUIRE(1 == stdx::one_of{1, 2, 3});
+    STATIC_REQUIRE(4 != stdx::one_of{1, 2, 3});
+    STATIC_REQUIRE(stdx::one_of{1, 2, 3} == 1);
+    STATIC_REQUIRE(stdx::one_of{1, 2, 3} != 4);
 
-    static_assert(stdx::one_of{1, 2, 3} == stdx::one_of{3, 4, 5});
-    static_assert(stdx::one_of{1, 2, 3} != stdx::one_of{4, 5, 6});
+    STATIC_REQUIRE(stdx::one_of{1, 2, 3} == stdx::one_of{3, 4, 5});
+    STATIC_REQUIRE(stdx::one_of{1, 2, 3} != stdx::one_of{4, 5, 6});
 }
 
 TEST_CASE("indexing unambiguously", "[tuple]") {
     using namespace stdx::literals;
 
     constexpr auto t = stdx::tuple{42, stdx::tuple{17}};
-    static_assert(t[0_idx] == 42);
-    static_assert(t[1_idx][0_idx] == 17);
+    STATIC_REQUIRE(t[0_idx] == 42);
+    STATIC_REQUIRE(t[1_idx][0_idx] == 17);
 }

--- a/test/tuple_algorithms.cpp
+++ b/test/tuple_algorithms.cpp
@@ -12,29 +12,29 @@
 #include <utility>
 
 TEST_CASE("unary transform", "[tuple_algorithms]") {
-    static_assert(stdx::transform([](auto) { return 1; }, stdx::tuple{}) ==
-                  stdx::tuple{});
+    STATIC_REQUIRE(stdx::transform([](auto) { return 1; }, stdx::tuple{}) ==
+                   stdx::tuple{});
     constexpr auto t = stdx::tuple{1, 2, 3};
     constexpr auto u = stdx::transform([](auto x) { return x + 1; }, t);
-    static_assert(u == stdx::tuple{2, 3, 4});
+    STATIC_REQUIRE(u == stdx::tuple{2, 3, 4});
 }
 
 TEST_CASE("unary type transform", "[tuple_algorithms]") {
-    static_assert(stdx::transform([](auto) { return 1; }, stdx::tuple{}) ==
-                  stdx::tuple{});
+    STATIC_REQUIRE(stdx::transform([](auto) { return 1; }, stdx::tuple{}) ==
+                   stdx::tuple{});
     constexpr auto t = stdx::tuple{1, 0, 3};
     constexpr auto u =
         stdx::transform([](auto x) -> bool { return x != 0; }, t);
-    static_assert(u == stdx::tuple{true, false, true});
+    STATIC_REQUIRE(u == stdx::tuple{true, false, true});
 }
 
 TEST_CASE("n-ary transform", "[tuple_algorithms]") {
-    static_assert(stdx::transform([](auto, auto) { return 1; }, stdx::tuple{},
-                                  stdx::tuple{}) == stdx::tuple{});
+    STATIC_REQUIRE(stdx::transform([](auto, auto) { return 1; }, stdx::tuple{},
+                                   stdx::tuple{}) == stdx::tuple{});
     constexpr auto t = stdx::tuple{1, 2, 3};
     constexpr auto u =
         stdx::transform([](auto x, auto y) { return x + y; }, t, t);
-    static_assert(u == stdx::tuple{2, 4, 6});
+    STATIC_REQUIRE(u == stdx::tuple{2, 4, 6});
 }
 
 TEST_CASE("rvalue transform", "[tuple_algorithms]") {
@@ -57,8 +57,8 @@ TEST_CASE("transform preserves references", "[tuple_algorithms]") {
 }
 
 TEST_CASE("transform stops at smallest tuple length", "[tuple_algorithms]") {
-    static_assert(stdx::transform(std::plus{}, stdx::tuple{1, 2, 3},
-                                  stdx::tuple{1, 2}) == stdx::tuple{2, 4});
+    STATIC_REQUIRE(stdx::transform(std::plus{}, stdx::tuple{1, 2, 3},
+                                   stdx::tuple{1, 2}) == stdx::tuple{2, 4});
 }
 
 namespace {
@@ -75,14 +75,14 @@ TEST_CASE("transform with index", "[tuple_algorithms]") {
     struct X;
     constexpr auto t = stdx::transform<key_for>(
         [](auto value) { return map_entry<X, int>{value}; }, stdx::tuple{42});
-    static_assert(stdx::get<X>(t).value == 42);
+    STATIC_REQUIRE(stdx::get<X>(t).value == 42);
 }
 
 TEST_CASE("apply", "[tuple_algorithms]") {
-    static_assert(stdx::apply([](auto... xs) { return (0 + ... + xs); },
-                              stdx::tuple{}) == 0);
-    static_assert(stdx::apply([](auto... xs) { return (0 + ... + xs); },
-                              stdx::tuple{1, 2, 3}) == 6);
+    STATIC_REQUIRE(stdx::apply([](auto... xs) { return (0 + ... + xs); },
+                               stdx::tuple{}) == 0);
+    STATIC_REQUIRE(stdx::apply([](auto... xs) { return (0 + ... + xs); },
+                               stdx::tuple{1, 2, 3}) == 6);
 }
 
 TEST_CASE("apply handles a stateful function properly", "[tuple_algorithms]") {
@@ -92,8 +92,8 @@ TEST_CASE("apply handles a stateful function properly", "[tuple_algorithms]") {
 }
 
 TEST_CASE("apply handles move-only types", "[tuple_algorithms]") {
-    static_assert(stdx::apply([](auto x) { return x.value; },
-                              stdx::tuple{move_only{42}}) == 42);
+    STATIC_REQUIRE(stdx::apply([](auto x) { return x.value; },
+                               stdx::tuple{move_only{42}}) == 42);
 }
 
 TEST_CASE("apply handles tuples of references", "[tuple_algorithms]") {
@@ -115,10 +115,10 @@ TEST_CASE("apply preserves argument order", "[tuple_algorithms]") {
 }
 
 TEST_CASE("variadic apply", "[tuple_algorithms]") {
-    static_assert(stdx::apply([](auto... xs) { return (0 + ... + xs); }) == 0);
-    static_assert(stdx::apply([](auto... xs) { return (0 + ... + xs); },
-                              stdx::tuple{1, 2, 3},
-                              stdx::tuple{4, 5, 6}) == 21);
+    STATIC_REQUIRE(stdx::apply([](auto... xs) { return (0 + ... + xs); }) == 0);
+    STATIC_REQUIRE(stdx::apply([](auto... xs) { return (0 + ... + xs); },
+                               stdx::tuple{1, 2, 3},
+                               stdx::tuple{4, 5, 6}) == 21);
 }
 
 TEST_CASE("variadic apply handles a stateful function properly",
@@ -129,9 +129,9 @@ TEST_CASE("variadic apply handles a stateful function properly",
 }
 
 TEST_CASE("variadic apply handles move-only types", "[tuple_algorithms]") {
-    static_assert(stdx::apply([](auto x, auto y) { return x.value + y.value; },
-                              stdx::tuple{move_only{42}},
-                              stdx::tuple{move_only{17}}) == 59);
+    STATIC_REQUIRE(stdx::apply([](auto x, auto y) { return x.value + y.value; },
+                               stdx::tuple{move_only{42}},
+                               stdx::tuple{move_only{17}}) == 59);
 }
 
 TEST_CASE("variadic apply handles tuples of references", "[tuple_algorithms]") {
@@ -161,9 +161,9 @@ TEST_CASE("variadic apply preserves argument order", "[tuple_algorithms]") {
 
 TEST_CASE("join", "[tuple_algorithms]") {
     constexpr auto t = stdx::tuple{1, 2, 3};
-    static_assert(t.join(std::plus{}) == 6);
-    static_assert(stdx::tuple{1, 2, 3}.join(std::plus{}) == 6);
-    static_assert(
+    STATIC_REQUIRE(t.join(std::plus{}) == 6);
+    STATIC_REQUIRE(stdx::tuple{1, 2, 3}.join(std::plus{}) == 6);
+    STATIC_REQUIRE(
         stdx::tuple{move_only{42}}
             .join([](auto x, auto y) { return move_only{x.value + y.value}; })
             .value == 42);
@@ -171,13 +171,13 @@ TEST_CASE("join", "[tuple_algorithms]") {
 
 TEST_CASE("join (single element)", "[tuple_algorithms]") {
     constexpr auto t = stdx::tuple{1};
-    static_assert(t.join(std::plus{}) == 1);
+    STATIC_REQUIRE(t.join(std::plus{}) == 1);
 }
 
 TEST_CASE("join with default for empty tuple", "[tuple_algorithms]") {
-    static_assert(stdx::tuple{}.join(42, std::plus{}) == 42);
-    static_assert(stdx::tuple{1}.join(42, std::plus{}) == 1);
-    static_assert(stdx::tuple{1, 2, 3}.join(42, std::plus{}) == 6);
+    STATIC_REQUIRE(stdx::tuple{}.join(42, std::plus{}) == 42);
+    STATIC_REQUIRE(stdx::tuple{1}.join(42, std::plus{}) == 1);
+    STATIC_REQUIRE(stdx::tuple{1, 2, 3}.join(42, std::plus{}) == 6);
 }
 
 TEST_CASE("for_each", "[tuple_algorithms]") {
@@ -233,30 +233,30 @@ TEST_CASE("unrolled_for_each on arrays", "[tuple_algorithms]") {
 }
 
 TEST_CASE("tuple_cat", "[tuple_algorithms]") {
-    static_assert(stdx::tuple_cat() == stdx::tuple{});
-    static_assert(stdx::tuple_cat(stdx::tuple{}, stdx::tuple{}) ==
-                  stdx::tuple{});
-    static_assert(stdx::tuple_cat(stdx::tuple{1, 2}, stdx::tuple{}) ==
-                  stdx::tuple{1, 2});
-    static_assert(stdx::tuple_cat(stdx::tuple{}, stdx::tuple{1, 2}) ==
-                  stdx::tuple{1, 2});
-    static_assert(stdx::tuple_cat(stdx::tuple{1, 2}, stdx::tuple{3, 4}) ==
-                  stdx::tuple{1, 2, 3, 4});
-    static_assert(stdx::tuple_cat(stdx::tuple{1, 2}, stdx::tuple{3, 4},
-                                  stdx::tuple{5, 6}) ==
-                  stdx::tuple{1, 2, 3, 4, 5, 6});
-    static_assert(
+    STATIC_REQUIRE(stdx::tuple_cat() == stdx::tuple{});
+    STATIC_REQUIRE(stdx::tuple_cat(stdx::tuple{}, stdx::tuple{}) ==
+                   stdx::tuple{});
+    STATIC_REQUIRE(stdx::tuple_cat(stdx::tuple{1, 2}, stdx::tuple{}) ==
+                   stdx::tuple{1, 2});
+    STATIC_REQUIRE(stdx::tuple_cat(stdx::tuple{}, stdx::tuple{1, 2}) ==
+                   stdx::tuple{1, 2});
+    STATIC_REQUIRE(stdx::tuple_cat(stdx::tuple{1, 2}, stdx::tuple{3, 4}) ==
+                   stdx::tuple{1, 2, 3, 4});
+    STATIC_REQUIRE(stdx::tuple_cat(stdx::tuple{1, 2}, stdx::tuple{3, 4},
+                                   stdx::tuple{5, 6}) ==
+                   stdx::tuple{1, 2, 3, 4, 5, 6});
+    STATIC_REQUIRE(
         stdx::tuple_cat(stdx::tuple{1, 2}, stdx::tuple{}, stdx::tuple{3, 4}) ==
         stdx::tuple{1, 2, 3, 4});
 
     auto t = stdx::tuple_cat(stdx::tuple{1}, stdx::tuple{2});
-    static_assert(std::is_same_v<decltype(t), stdx::tuple<int, int>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(t), stdx::tuple<int, int>>);
 }
 
 TEST_CASE("tuple_cat (move only)", "[tuple_algorithms]") {
     auto t =
         stdx::tuple_cat(stdx::tuple{move_only{5}}, stdx::tuple{move_only{10}});
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(t), stdx::tuple<move_only, move_only>>);
     CHECK(t == stdx::tuple{move_only{5}, move_only{10}});
 }
@@ -264,7 +264,7 @@ TEST_CASE("tuple_cat (move only)", "[tuple_algorithms]") {
 TEST_CASE("tuple_cat (references)", "[tuple_algorithms]") {
     auto x = 1;
     auto t = stdx::tuple_cat(stdx::tuple<int &>{x}, stdx::tuple<int &>{x});
-    static_assert(std::is_same_v<decltype(t), stdx::tuple<int &, int &>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(t), stdx::tuple<int &, int &>>);
     CHECK(std::addressof(x) == std::addressof(t[stdx::index<0>]));
     CHECK(std::addressof(x) == std::addressof(t[stdx::index<1>]));
     CHECK(x == 1);
@@ -278,7 +278,7 @@ TEST_CASE("tuple_cat (const references)", "[tuple_algorithms]") {
     auto x = 1;
     auto t = stdx::tuple_cat(stdx::tuple<int const &>{x},
                              stdx::tuple<int const &>{x});
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(t), stdx::tuple<int const &, int const &>>);
     CHECK(std::addressof(x) == std::addressof(t[stdx::index<0>]));
     CHECK(std::addressof(x) == std::addressof(t[stdx::index<1>]));
@@ -293,7 +293,7 @@ TEST_CASE("tuple_cat (rvalue references)", "[tuple_algorithms]") {
     auto y = 1;
     auto t = stdx::tuple_cat(stdx::tuple<int &&>{std::move(x)},
                              stdx::tuple<int &&>{std::move(y)});
-    static_assert(std::is_same_v<decltype(t), stdx::tuple<int &&, int &&>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(t), stdx::tuple<int &&, int &&>>);
     CHECK(std::addressof(x) == std::addressof(t[stdx::index<0>]));
     CHECK(std::addressof(y) == std::addressof(t[stdx::index<1>]));
     CHECK(x == 1);
@@ -307,13 +307,13 @@ TEST_CASE("tuple_cat (rvalue references)", "[tuple_algorithms]") {
 
 TEST_CASE("fold_left", "[tuple_algorithms]") {
     constexpr auto t = stdx::tuple{1, 2, 3};
-    static_assert(t.fold_left(0, std::minus{}) == (((0 - 1) - 2) - 3));
-    static_assert(stdx::tuple{move_only{1}, move_only{2}, move_only{3}}
-                      .fold_left(move_only{0},
-                                 [](move_only &&x, move_only &&y) {
-                                     return move_only{x.value + y.value};
-                                 })
-                      .value == 6);
+    STATIC_REQUIRE(t.fold_left(0, std::minus{}) == (((0 - 1) - 2) - 3));
+    STATIC_REQUIRE(stdx::tuple{move_only{1}, move_only{2}, move_only{3}}
+                       .fold_left(move_only{0},
+                                  [](move_only &&x, move_only &&y) {
+                                      return move_only{x.value + y.value};
+                                  })
+                       .value == 6);
 
     int calls{};
     auto stateful = [&](auto x, auto y) mutable {
@@ -326,11 +326,11 @@ TEST_CASE("fold_left", "[tuple_algorithms]") {
 
 TEST_CASE("fold_left (heterogeneous types in fold)", "[tuple_algorithms]") {
     constexpr auto t = stdx::tuple{1, 2, 3};
-    static_assert(t.fold_left(stdx::tuple{}, [](auto acc, auto n) {
+    STATIC_REQUIRE(t.fold_left(stdx::tuple{}, [](auto acc, auto n) {
         return stdx::tuple_cat(acc, stdx::tuple{n});
     }) == t);
 
-    static_assert(
+    STATIC_REQUIRE(
         stdx::tuple{1, 2, 3}.fold_left(stdx::tuple{}, [](auto acc, auto n) {
             return stdx::tuple_cat(acc, stdx::tuple{n});
         }) == t);
@@ -345,18 +345,18 @@ template <auto X, auto Y> constexpr auto operator+(addend<X>, addend<Y>) {
 
 TEST_CASE("fold_left (heterogeneous types in tuple)", "[tuple_algorithms]") {
     constexpr auto t = stdx::tuple{addend<1>{}, addend<2>{}};
-    static_assert(t.fold_left(addend<0>{}, std::plus{}) == addend<3>{});
+    STATIC_REQUIRE(t.fold_left(addend<0>{}, std::plus{}) == addend<3>{});
 }
 
 TEST_CASE("fold_right", "[tuple_algorithms]") {
     constexpr auto t = stdx::tuple{1, 2, 3};
-    static_assert(t.fold_right(4, std::minus{}) == (1 - (2 - (3 - 4))));
-    static_assert(stdx::tuple{move_only{1}, move_only{2}, move_only{3}}
-                      .fold_right(move_only{0},
-                                  [](move_only &&x, move_only &&y) {
-                                      return move_only{x.value + y.value};
-                                  })
-                      .value == 6);
+    STATIC_REQUIRE(t.fold_right(4, std::minus{}) == (1 - (2 - (3 - 4))));
+    STATIC_REQUIRE(stdx::tuple{move_only{1}, move_only{2}, move_only{3}}
+                       .fold_right(move_only{0},
+                                   [](move_only &&x, move_only &&y) {
+                                       return move_only{x.value + y.value};
+                                   })
+                       .value == 6);
 
     int calls{};
     auto stateful = [&](auto x, auto y) mutable {
@@ -369,11 +369,11 @@ TEST_CASE("fold_right", "[tuple_algorithms]") {
 
 TEST_CASE("fold_right (heterogeneous types in fold)", "[tuple_algorithms]") {
     constexpr auto t = stdx::tuple{1, 2, 3};
-    static_assert(t.fold_right(stdx::tuple{}, [](auto n, auto acc) {
+    STATIC_REQUIRE(t.fold_right(stdx::tuple{}, [](auto n, auto acc) {
         return stdx::tuple_cat(stdx::tuple{n}, acc);
     }) == t);
 
-    static_assert(
+    STATIC_REQUIRE(
         stdx::tuple{1, 2, 3}.fold_right(stdx::tuple{}, [](auto n, auto acc) {
             return stdx::tuple_cat(stdx::tuple{n}, acc);
         }) == t);
@@ -381,7 +381,7 @@ TEST_CASE("fold_right (heterogeneous types in fold)", "[tuple_algorithms]") {
 
 TEST_CASE("fold_right (heterogeneous types in tuple)", "[tuple_algorithms]") {
     constexpr auto t = stdx::tuple{addend<1>{}, addend<2>{}};
-    static_assert(t.fold_right(addend<0>{}, std::plus{}) == addend<3>{});
+    STATIC_REQUIRE(t.fold_right(addend<0>{}, std::plus{}) == addend<3>{});
 }
 
 template <typename T> struct is_even {
@@ -393,8 +393,8 @@ TEST_CASE("filter", "[tuple_algorithms]") {
         std::integral_constant<int, 1>{}, std::integral_constant<int, 2>{},
         std::integral_constant<int, 3>{}, std::integral_constant<int, 4>{}};
     constexpr auto u = stdx::filter<is_even>(t);
-    static_assert(u == stdx::tuple{std::integral_constant<int, 2>{},
-                                   std::integral_constant<int, 4>{}});
+    STATIC_REQUIRE(u == stdx::tuple{std::integral_constant<int, 2>{},
+                                    std::integral_constant<int, 4>{}});
 }
 
 TEST_CASE("copy/move behavior for tuple_cat", "[tuple_algorithms]") {
@@ -428,40 +428,41 @@ TEST_CASE("copy/move behavior for filter", "[tuple_algorithms]") {
 
 TEST_CASE("all_of", "[tuple_algorithms]") {
     constexpr auto t = stdx::tuple{1, 2, 3};
-    static_assert(stdx::all_of([](auto n) { return n > 0; }, t));
-    static_assert(
+    STATIC_REQUIRE(stdx::all_of([](auto n) { return n > 0; }, t));
+    STATIC_REQUIRE(
         stdx::all_of([](auto x, auto y) { return (x + y) % 2 == 0; }, t, t));
 
-    static_assert(stdx::all_of([](auto x, auto y) { return (x + y) % 2 == 0; },
-                               stdx::tuple{1, 3, 5}, stdx::tuple{1, 3}));
+    STATIC_REQUIRE(stdx::all_of([](auto x, auto y) { return (x + y) % 2 == 0; },
+                                stdx::tuple{1, 3, 5}, stdx::tuple{1, 3}));
 }
 
 TEST_CASE("any_of", "[tuple_algorithms]") {
     constexpr auto t = stdx::tuple{1, 2, 3};
-    static_assert(stdx::any_of([](auto n) { return n % 2 == 0; }, t));
-    static_assert(
+    STATIC_REQUIRE(stdx::any_of([](auto n) { return n % 2 == 0; }, t));
+    STATIC_REQUIRE(
         stdx::any_of([](auto x, auto y) { return (x + y) % 2 == 0; }, t, t));
 
-    static_assert(stdx::any_of([](auto x, auto y) { return (x + y) % 2 == 0; },
-                               stdx::tuple{1, 3, 5}, stdx::tuple{1, 3}));
+    STATIC_REQUIRE(stdx::any_of([](auto x, auto y) { return (x + y) % 2 == 0; },
+                                stdx::tuple{1, 3, 5}, stdx::tuple{1, 3}));
 }
 
 TEST_CASE("none_of", "[tuple_algorithms]") {
     constexpr auto t = stdx::tuple{1, 3, 5};
-    static_assert(stdx::none_of([](auto n) { return n % 2 == 0; }, t));
-    static_assert(
+    STATIC_REQUIRE(stdx::none_of([](auto n) { return n % 2 == 0; }, t));
+    STATIC_REQUIRE(
         stdx::none_of([](auto x, auto y) { return (x + y) % 2 != 0; }, t, t));
 
-    static_assert(stdx::none_of([](auto x, auto y) { return (x + y) % 2 != 0; },
-                                stdx::tuple{1, 3, 5}, stdx::tuple{1, 3}));
+    STATIC_REQUIRE(
+        stdx::none_of([](auto x, auto y) { return (x + y) % 2 != 0; },
+                      stdx::tuple{1, 3, 5}, stdx::tuple{1, 3}));
 }
 
 TEST_CASE("contains_type", "[tuple_algorithms]") {
     using T = stdx::tuple<int, bool, int &>;
-    static_assert(stdx::contains_type<T, int>);
-    static_assert(stdx::contains_type<T, bool>);
-    static_assert(stdx::contains_type<T, int &>);
-    static_assert(not stdx::contains_type<T, float>);
+    STATIC_REQUIRE(stdx::contains_type<T, int>);
+    STATIC_REQUIRE(stdx::contains_type<T, bool>);
+    STATIC_REQUIRE(stdx::contains_type<T, int &>);
+    STATIC_REQUIRE(not stdx::contains_type<T, float>);
 }
 
 TEST_CASE("contains_type (indexed)", "[tuple_algorithms]") {
@@ -470,23 +471,23 @@ TEST_CASE("contains_type (indexed)", "[tuple_algorithms]") {
     using T = stdx::indexed_tuple<stdx::detail::index_function_list<key_for>,
                                   map_entry<X, int>, map_entry<Y, int>>;
 
-    static_assert(stdx::contains_type<T, map_entry<X, int>>);
-    static_assert(stdx::contains_type<T, X>);
-    static_assert(not stdx::contains_type<T, float>);
+    STATIC_REQUIRE(stdx::contains_type<T, map_entry<X, int>>);
+    STATIC_REQUIRE(stdx::contains_type<T, X>);
+    STATIC_REQUIRE(not stdx::contains_type<T, float>);
 }
 
 TEST_CASE("sort (empty tuple)", "[tuple_algorithms]") {
     constexpr auto t = stdx::tuple{};
     [[maybe_unused]] constexpr auto sorted = stdx::sort(t);
-    static_assert(std::is_same_v<decltype(sorted), stdx::tuple<> const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(sorted), stdx::tuple<> const>);
 }
 
 TEST_CASE("sort", "[tuple_algorithms]") {
     constexpr auto t = stdx::tuple{1, 1.0, true};
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(t), stdx::tuple<int, double, bool> const>);
     constexpr auto sorted = stdx::sort(t);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(sorted), stdx::tuple<bool, double, int> const>);
     CHECK(sorted == stdx::tuple{true, 1.0, 1});
 }
@@ -495,18 +496,18 @@ TEST_CASE("sort preserves references", "[tuple_algorithms]") {
     int x{1};
     double d{2.0};
     auto t = stdx::forward_as_tuple(x, d);
-    static_assert(std::is_same_v<decltype(t), stdx::tuple<int &, double &>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(t), stdx::tuple<int &, double &>>);
     auto sorted = stdx::sort(t);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(sorted), stdx::tuple<double &, int &>>);
     CHECK(sorted == stdx::tuple{2.0, 1});
 }
 
 TEST_CASE("sort with move only types", "[tuple_algorithms]") {
     auto t = stdx::tuple{move_only{1}, 1.0};
-    static_assert(std::is_same_v<decltype(t), stdx::tuple<move_only, double>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(t), stdx::tuple<move_only, double>>);
     auto sorted = stdx::sort(std::move(t));
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(sorted), stdx::tuple<double, move_only>>);
     CHECK(sorted == stdx::tuple{1, move_only{1}});
 }
@@ -514,33 +515,33 @@ TEST_CASE("sort with move only types", "[tuple_algorithms]") {
 TEST_CASE("chunk (empty tuple)", "[tuple_algorithms]") {
     constexpr auto t = stdx::tuple{};
     [[maybe_unused]] constexpr auto chunked = stdx::chunk(t);
-    static_assert(std::is_same_v<decltype(chunked), stdx::tuple<> const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(chunked), stdx::tuple<> const>);
 }
 
 TEST_CASE("chunk (1-element tuple)", "[tuple_algorithms]") {
     constexpr auto t = stdx::tuple{1};
     constexpr auto chunked = stdx::chunk(t);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(chunked), stdx::tuple<stdx::tuple<int>> const>);
     CHECK(chunked == stdx::make_tuple(stdx::tuple{1}));
 }
 
 TEST_CASE("count chunks", "[tuple_algorithms]") {
-    static_assert(stdx::detail::count_chunks<stdx::tuple<int, int>>() == 1);
-    static_assert(stdx::detail::count_chunks<stdx::tuple<int, float>>() == 2);
-    static_assert(stdx::detail::count_chunks<stdx::tuple<int, int, float>>() ==
-                  2);
-    static_assert(
+    STATIC_REQUIRE(stdx::detail::count_chunks<stdx::tuple<int, int>>() == 1);
+    STATIC_REQUIRE(stdx::detail::count_chunks<stdx::tuple<int, float>>() == 2);
+    STATIC_REQUIRE(stdx::detail::count_chunks<stdx::tuple<int, int, float>>() ==
+                   2);
+    STATIC_REQUIRE(
         stdx::detail::count_chunks<stdx::tuple<int, float, float>>() == 2);
 }
 
 TEST_CASE("create chunks", "[tuple_algorithms]") {
-    static_assert(stdx::detail::create_chunks<stdx::tuple<int, int>>() ==
-                  std::array{stdx::detail::chunk{0, 2}});
-    static_assert(
+    STATIC_REQUIRE(stdx::detail::create_chunks<stdx::tuple<int, int>>() ==
+                   std::array{stdx::detail::chunk{0, 2}});
+    STATIC_REQUIRE(
         stdx::detail::create_chunks<stdx::tuple<int, int, float>>() ==
         std::array{stdx::detail::chunk{0, 2}, stdx::detail::chunk{2, 1}});
-    static_assert(
+    STATIC_REQUIRE(
         stdx::detail::create_chunks<
             stdx::tuple<int, int, float, int, int, float>>() ==
         std::array{stdx::detail::chunk{0, 2}, stdx::detail::chunk{2, 1},
@@ -550,7 +551,7 @@ TEST_CASE("create chunks", "[tuple_algorithms]") {
 TEST_CASE("chunk (general case)", "[tuple_algorithms]") {
     constexpr auto t = stdx::tuple{1, 2, 3, 1.0, 2.0, true};
     constexpr auto chunked = stdx::chunk(t);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<
             decltype(chunked),
             stdx::tuple<stdx::tuple<int, int, int>, stdx::tuple<double, double>,
@@ -564,51 +565,52 @@ TEST_CASE("chunk preserves references", "[tuple_algorithms]") {
     int y{2};
     auto t = stdx::tuple<int &, int &>{x, y};
     auto chunked = stdx::chunk(t);
-    static_assert(std::is_same_v<decltype(chunked),
-                                 stdx::tuple<stdx::tuple<int &, int &>>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(chunked),
+                                  stdx::tuple<stdx::tuple<int &, int &>>>);
     CHECK(get<0>(chunked) == stdx::tuple{1, 2});
 }
 
 TEST_CASE("chunk with move only types", "[tuple_algorithms]") {
     auto t = stdx::tuple{move_only{1}};
     auto chunked = stdx::chunk(std::move(t));
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(chunked), stdx::tuple<stdx::tuple<move_only>>>);
     CHECK(get<0>(chunked) == stdx::tuple{move_only{1}});
 }
 
 TEST_CASE("cartesian product (no tuples)", "[tuple_algorithms]") {
     constexpr auto c = stdx::cartesian_product_copy();
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(c), stdx::tuple<stdx::tuple<>> const>);
 }
 
 TEST_CASE("cartesian product (one tuple)", "[tuple_algorithms]") {
     using namespace stdx::literals;
     constexpr auto c = stdx::cartesian_product_copy(stdx::tuple{1, 2, 3});
-    static_assert(std::is_same_v<decltype(c),
-                                 stdx::tuple<stdx::tuple<int>, stdx::tuple<int>,
-                                             stdx::tuple<int>> const>);
-    static_assert(c[0_idx][0_idx] == 1);
-    static_assert(c[1_idx][0_idx] == 2);
-    static_assert(c[2_idx][0_idx] == 3);
+    STATIC_REQUIRE(
+        std::is_same_v<decltype(c),
+                       stdx::tuple<stdx::tuple<int>, stdx::tuple<int>,
+                                   stdx::tuple<int>> const>);
+    STATIC_REQUIRE(c[0_idx][0_idx] == 1);
+    STATIC_REQUIRE(c[1_idx][0_idx] == 2);
+    STATIC_REQUIRE(c[2_idx][0_idx] == 3);
 }
 
 TEST_CASE("cartesian product (two tuples)", "[tuple_algorithms]") {
     using namespace stdx::literals;
     constexpr auto c =
         stdx::cartesian_product_copy(stdx::tuple{1}, stdx::tuple{2});
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(c), stdx::tuple<stdx::tuple<int, int>> const>);
-    static_assert(c[0_idx][0_idx] == 1);
-    static_assert(c[0_idx][1_idx] == 2);
+    STATIC_REQUIRE(c[0_idx][0_idx] == 1);
+    STATIC_REQUIRE(c[0_idx][1_idx] == 2);
 }
 
 TEST_CASE("cartesian product (general case)", "[tuple_algorithms]") {
     using namespace stdx::literals;
     constexpr auto c = stdx::cartesian_product_copy(
         stdx::tuple{1, 2}, stdx::tuple{'a', 'b'}, stdx::tuple{1.1f, 2.2f});
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<
             decltype(c),
             stdx::tuple<
@@ -617,14 +619,14 @@ TEST_CASE("cartesian product (general case)", "[tuple_algorithms]") {
                 stdx::tuple<int, char, float>, stdx::tuple<int, char, float>,
                 stdx::tuple<int, char, float>,
                 stdx::tuple<int, char, float>> const>);
-    static_assert(c[0_idx] == stdx::tuple{1, 'a', 1.1f});
-    static_assert(c[1_idx] == stdx::tuple{1, 'a', 2.2f});
-    static_assert(c[2_idx] == stdx::tuple{1, 'b', 1.1f});
-    static_assert(c[3_idx] == stdx::tuple{1, 'b', 2.2f});
-    static_assert(c[4_idx] == stdx::tuple{2, 'a', 1.1f});
-    static_assert(c[5_idx] == stdx::tuple{2, 'a', 2.2f});
-    static_assert(c[6_idx] == stdx::tuple{2, 'b', 1.1f});
-    static_assert(c[7_idx] == stdx::tuple{2, 'b', 2.2f});
+    STATIC_REQUIRE(c[0_idx] == stdx::tuple{1, 'a', 1.1f});
+    STATIC_REQUIRE(c[1_idx] == stdx::tuple{1, 'a', 2.2f});
+    STATIC_REQUIRE(c[2_idx] == stdx::tuple{1, 'b', 1.1f});
+    STATIC_REQUIRE(c[3_idx] == stdx::tuple{1, 'b', 2.2f});
+    STATIC_REQUIRE(c[4_idx] == stdx::tuple{2, 'a', 1.1f});
+    STATIC_REQUIRE(c[5_idx] == stdx::tuple{2, 'a', 2.2f});
+    STATIC_REQUIRE(c[6_idx] == stdx::tuple{2, 'b', 1.1f});
+    STATIC_REQUIRE(c[7_idx] == stdx::tuple{2, 'b', 2.2f});
 }
 
 TEST_CASE("cartesian product of references", "[tuple_algorithms]") {
@@ -633,20 +635,20 @@ TEST_CASE("cartesian product of references", "[tuple_algorithms]") {
     constexpr static auto t2 = stdx::tuple{2};
 
     constexpr auto c = stdx::cartesian_product(t1, t2);
-    static_assert(std::is_same_v<
-                  decltype(c),
-                  stdx::tuple<stdx::tuple<int const &, int const &>> const>);
-    static_assert(c[0_idx][0_idx] == 1);
-    static_assert(c[0_idx][1_idx] == 2);
+    STATIC_REQUIRE(std::is_same_v<
+                   decltype(c),
+                   stdx::tuple<stdx::tuple<int const &, int const &>> const>);
+    STATIC_REQUIRE(c[0_idx][0_idx] == 1);
+    STATIC_REQUIRE(c[0_idx][1_idx] == 2);
 }
 
 TEST_CASE("unique", "[tuple_algorithms]") {
     constexpr auto t = stdx::tuple{1, 1.0, 2.0, true, false};
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(t),
                        stdx::tuple<int, double, double, bool, bool> const>);
     constexpr auto u = stdx::unique(t);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(u), stdx::tuple<int, double, bool> const>);
     CHECK(u == stdx::tuple{1, 1.0, true});
 }
@@ -655,27 +657,27 @@ TEST_CASE("unique preserves references", "[tuple_algorithms]") {
     int x{1};
     int y{2};
     auto t = stdx::forward_as_tuple(x, y);
-    static_assert(std::is_same_v<decltype(t), stdx::tuple<int &, int &>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(t), stdx::tuple<int &, int &>>);
     CHECK(t == stdx::tuple{1, 2});
     auto u = stdx::unique(t);
-    static_assert(std::is_same_v<decltype(u), stdx::tuple<int &>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(u), stdx::tuple<int &>>);
     CHECK(u == stdx::tuple{1});
     CHECK(std::addressof(x) == std::addressof(u[stdx::index<0>]));
 }
 
 TEST_CASE("unique with move only types", "[tuple_algorithms]") {
     auto t = stdx::tuple{move_only{1}, move_only{2}};
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(t), stdx::tuple<move_only, move_only>>);
     auto u = stdx::unique(std::move(t));
-    static_assert(std::is_same_v<decltype(u), stdx::tuple<move_only>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(u), stdx::tuple<move_only>>);
     CHECK(u == stdx::tuple{move_only{1}});
 }
 
 TEST_CASE("to_sorted_set", "[tuple_algorithms]") {
     constexpr auto t = stdx::tuple{1, 1.0, true, 2.0, false};
     constexpr auto u = stdx::to_sorted_set(t);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(u), stdx::tuple<bool, double, int> const>);
     CHECK(u == stdx::tuple{true, 1.0, 1});
 }
@@ -683,7 +685,7 @@ TEST_CASE("to_sorted_set", "[tuple_algorithms]") {
 TEST_CASE("to_sorted_set with move only types", "[tuple_algorithms]") {
     auto t = stdx::tuple{1, move_only{1}, true, move_only{2}, false};
     auto u = stdx::to_sorted_set(std::move(t));
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(u), stdx::tuple<bool, int, move_only>>);
     CHECK(u == stdx::tuple{true, 1, move_only{1}});
 }
@@ -694,12 +696,12 @@ TEST_CASE("to_sorted_set preserves references", "[tuple_algorithms]") {
     double a{3.0};
     double b{4.0};
     auto t = stdx::forward_as_tuple(x, y, a, b);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(t),
                        stdx::tuple<int &, int &, double &, double &>>);
     CHECK(t == stdx::tuple{1, 2, 3.0, 4.0});
     auto u = stdx::to_sorted_set(t);
-    static_assert(std::is_same_v<decltype(u), stdx::tuple<double &, int &>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(u), stdx::tuple<double &, int &>>);
     CHECK(u == stdx::tuple{3.0, 1});
     CHECK(std::addressof(a) == std::addressof(u[stdx::index<0>]));
     CHECK(std::addressof(x) == std::addressof(u[stdx::index<1>]));
@@ -708,7 +710,7 @@ TEST_CASE("to_sorted_set preserves references", "[tuple_algorithms]") {
 TEST_CASE("to_unsorted_set", "[tuple_algorithms]") {
     constexpr auto t = stdx::tuple{1, 1.0, true, 2.0, false};
     constexpr auto u = stdx::to_unsorted_set(t);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(u), stdx::tuple<int, double, bool> const>);
     CHECK(u == stdx::tuple{1, 1.0, true});
 }
@@ -719,12 +721,12 @@ TEST_CASE("to_unsorted_set preserves references", "[tuple_algorithms]") {
     double a{3.0};
     double b{4.0};
     auto t = stdx::forward_as_tuple(x, y, a, b);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(t),
                        stdx::tuple<int &, int &, double &, double &>>);
     CHECK(t == stdx::tuple{1, 2, 3.0, 4.0});
     auto u = stdx::to_unsorted_set(t);
-    static_assert(std::is_same_v<decltype(u), stdx::tuple<int &, double &>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(u), stdx::tuple<int &, double &>>);
     CHECK(u == stdx::tuple{1, 3.0});
     CHECK(std::addressof(x) == std::addressof(u[stdx::index<0>]));
     CHECK(std::addressof(a) == std::addressof(u[stdx::index<1>]));
@@ -733,7 +735,7 @@ TEST_CASE("to_unsorted_set preserves references", "[tuple_algorithms]") {
 TEST_CASE("to_unsorted_set with move only types", "[tuple_algorithms]") {
     auto t = stdx::tuple{1, move_only{1}, true, move_only{2}, false};
     auto u = stdx::to_unsorted_set(std::move(t));
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(u), stdx::tuple<int, move_only, bool>>);
     CHECK(u == stdx::tuple{1, move_only{1}, true});
 }
@@ -759,24 +761,24 @@ TEST_CASE("unrolled enumerate on arrays", "[tuple_algorithms]") {
 TEST_CASE("gather (empty tuple)", "[tuple_algorithms]") {
     constexpr auto t = stdx::tuple{};
     [[maybe_unused]] constexpr auto gathered = stdx::gather(t);
-    static_assert(std::is_same_v<decltype(gathered), stdx::tuple<> const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(gathered), stdx::tuple<> const>);
 }
 
 TEST_CASE("gather (1-element tuple)", "[tuple_algorithms]") {
     constexpr auto t = stdx::tuple{1};
     constexpr auto gathered = stdx::gather(t);
-    static_assert(std::is_same_v<decltype(gathered),
-                                 stdx::tuple<stdx::tuple<int>> const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(gathered),
+                                  stdx::tuple<stdx::tuple<int>> const>);
     CHECK(gathered == stdx::make_tuple(stdx::tuple{1}));
 }
 
 TEST_CASE("gather (general case)", "[tuple_algorithms]") {
     constexpr auto t = stdx::tuple{1, 1.0, 2, 1.0, 3, true};
     constexpr auto gathered = stdx::gather(t);
-    static_assert(std::is_same_v<
-                  decltype(gathered),
-                  stdx::tuple<stdx::tuple<bool>, stdx::tuple<double, double>,
-                              stdx::tuple<int, int, int>> const>);
+    STATIC_REQUIRE(std::is_same_v<
+                   decltype(gathered),
+                   stdx::tuple<stdx::tuple<bool>, stdx::tuple<double, double>,
+                               stdx::tuple<int, int, int>> const>);
     // NB: the subtuples are not necessarily ordered the same way as originally
     CHECK(stdx::get<0>(gathered) == stdx::tuple{true});
     CHECK(stdx::get<1>(gathered).fold_left(0.0, std::plus{}) == 2.0);
@@ -788,16 +790,16 @@ TEST_CASE("gather preserves references", "[tuple_algorithms]") {
     int y{2};
     auto t = stdx::tuple<int &, int &>{x, y};
     auto gathered = stdx::gather(t);
-    static_assert(std::is_same_v<decltype(gathered),
-                                 stdx::tuple<stdx::tuple<int &, int &>>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(gathered),
+                                  stdx::tuple<stdx::tuple<int &, int &>>>);
     CHECK(get<0>(gathered) == stdx::tuple{1, 2});
 }
 
 TEST_CASE("gather with move only types", "[tuple_algorithms]") {
     auto t = stdx::tuple{move_only{1}};
     auto gathered = stdx::gather(std::move(t));
-    static_assert(std::is_same_v<decltype(gathered),
-                                 stdx::tuple<stdx::tuple<move_only>>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(gathered),
+                                  stdx::tuple<stdx::tuple<move_only>>>);
     CHECK(get<0>(gathered) == stdx::tuple{move_only{1}});
 }
 
@@ -818,7 +820,7 @@ TEST_CASE("gather_by with projection", "[tuple_algorithms]") {
     constexpr auto t = stdx::tuple{named_int<C>{3}, named_int<B>{11},
                                    named_int<A>{0}, named_int<B>{12}};
     constexpr auto gathered = stdx::gather_by<name_of_t>(t);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(gathered),
                        stdx::tuple<stdx::tuple<named_int<A>>,
                                    stdx::tuple<named_int<B>, named_int<B>>,
@@ -830,14 +832,14 @@ TEST_CASE("gather_by with projection", "[tuple_algorithms]") {
 }
 
 TEST_CASE("tuple_cons", "[tuple_algorithms]") {
-    static_assert(stdx::tuple_cons(1, stdx::tuple{}) == stdx::tuple{1});
+    STATIC_REQUIRE(stdx::tuple_cons(1, stdx::tuple{}) == stdx::tuple{1});
     auto t = stdx::tuple_cons(1, stdx::tuple{});
-    static_assert(std::is_same_v<decltype(t), stdx::tuple<int>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(t), stdx::tuple<int>>);
 }
 
 TEST_CASE("tuple_cons (move only)", "[tuple_algorithms]") {
     auto t = stdx::tuple_cons(move_only{5}, stdx::tuple{move_only{10}});
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(t), stdx::tuple<move_only, move_only>>);
     CHECK(t == stdx::tuple{move_only{5}, move_only{10}});
 }
@@ -845,20 +847,20 @@ TEST_CASE("tuple_cons (move only)", "[tuple_algorithms]") {
 TEST_CASE("tuple_cons (references)", "[tuple_algorithms]") {
     auto x = 1;
     auto t = stdx::tuple_cons(1, stdx::tuple<int &>{x});
-    static_assert(std::is_same_v<decltype(t), stdx::tuple<int, int &>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(t), stdx::tuple<int, int &>>);
     CHECK(t == stdx::tuple{1, 1});
     CHECK(std::addressof(x) == std::addressof(t[stdx::index<1>]));
 }
 
 TEST_CASE("tuple_snoc", "[tuple_algorithms]") {
-    static_assert(stdx::tuple_snoc(stdx::tuple{}, 1) == stdx::tuple{1});
+    STATIC_REQUIRE(stdx::tuple_snoc(stdx::tuple{}, 1) == stdx::tuple{1});
     auto t = stdx::tuple_snoc(stdx::tuple{}, 1);
-    static_assert(std::is_same_v<decltype(t), stdx::tuple<int>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(t), stdx::tuple<int>>);
 }
 
 TEST_CASE("tuple_snoc (move only)", "[tuple_algorithms]") {
     auto t = stdx::tuple_snoc(stdx::tuple{move_only{10}}, move_only{5});
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(t), stdx::tuple<move_only, move_only>>);
     CHECK(t == stdx::tuple{move_only{10}, move_only{5}});
 }
@@ -866,15 +868,15 @@ TEST_CASE("tuple_snoc (move only)", "[tuple_algorithms]") {
 TEST_CASE("tuple_snoc (references)", "[tuple_algorithms]") {
     auto x = 1;
     auto t = stdx::tuple_snoc(stdx::tuple<int &>{x}, 1);
-    static_assert(std::is_same_v<decltype(t), stdx::tuple<int &, int>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(t), stdx::tuple<int &, int>>);
     CHECK(t == stdx::tuple{1, 1});
     CHECK(std::addressof(x) == std::addressof(t[stdx::index<0>]));
 }
 
 TEST_CASE("tuple_push_front", "[tuple_algorithms]") {
-    static_assert(stdx::tuple_push_front(1, stdx::tuple{}) == stdx::tuple{1});
+    STATIC_REQUIRE(stdx::tuple_push_front(1, stdx::tuple{}) == stdx::tuple{1});
 }
 
 TEST_CASE("tuple_push_back", "[tuple_algorithms]") {
-    static_assert(stdx::tuple_push_back(stdx::tuple{}, 1) == stdx::tuple{1});
+    STATIC_REQUIRE(stdx::tuple_push_back(stdx::tuple{}, 1) == stdx::tuple{1});
 }

--- a/test/type_map.cpp
+++ b/test/type_map.cpp
@@ -12,48 +12,48 @@ struct Z;
 
 TEST_CASE("look up type in map", "[type map]") {
     using M = stdx::type_map<stdx::type_pair<A, X>, stdx::type_pair<B, Y>>;
-    static_assert(std::is_same_v<stdx::type_lookup_t<M, A>, X>);
-    static_assert(std::is_same_v<stdx::type_lookup_t<M, B>, Y>);
+    STATIC_REQUIRE(std::is_same_v<stdx::type_lookup_t<M, A>, X>);
+    STATIC_REQUIRE(std::is_same_v<stdx::type_lookup_t<M, B>, Y>);
 }
 
 TEST_CASE("look up type not in map", "[type map]") {
     using M = stdx::type_map<stdx::type_pair<A, X>, stdx::type_pair<B, Y>>;
-    static_assert(std::is_same_v<stdx::type_lookup_t<M, Z>, void>);
-    static_assert(std::is_same_v<stdx::type_lookup_t<M, Z, int>, int>);
+    STATIC_REQUIRE(std::is_same_v<stdx::type_lookup_t<M, Z>, void>);
+    STATIC_REQUIRE(std::is_same_v<stdx::type_lookup_t<M, Z, int>, int>);
 }
 
 TEST_CASE("look up type in map (by value)", "[type map]") {
     using M = stdx::type_map<stdx::vt_pair<0, X>, stdx::vt_pair<1, Y>>;
-    static_assert(std::is_same_v<stdx::value_lookup_t<M, 0>, X>);
-    static_assert(std::is_same_v<stdx::value_lookup_t<M, 1>, Y>);
+    STATIC_REQUIRE(std::is_same_v<stdx::value_lookup_t<M, 0>, X>);
+    STATIC_REQUIRE(std::is_same_v<stdx::value_lookup_t<M, 1>, Y>);
 }
 
 TEST_CASE("look up type not in map (by value)", "[type map]") {
     using M = stdx::type_map<stdx::vt_pair<0, X>, stdx::vt_pair<1, Y>>;
-    static_assert(std::is_same_v<stdx::value_lookup_t<M, 2>, void>);
-    static_assert(std::is_same_v<stdx::value_lookup_t<M, 2, int>, int>);
+    STATIC_REQUIRE(std::is_same_v<stdx::value_lookup_t<M, 2>, void>);
+    STATIC_REQUIRE(std::is_same_v<stdx::value_lookup_t<M, 2, int>, int>);
 }
 
 TEST_CASE("look up value in map (by type)", "[type map]") {
     using M = stdx::type_map<stdx::tv_pair<A, 0>, stdx::tv_pair<B, 1>>;
-    static_assert(stdx::type_lookup_v<M, A> == 0);
-    static_assert(stdx::type_lookup_v<M, B> == 1);
+    STATIC_REQUIRE(stdx::type_lookup_v<M, A> == 0);
+    STATIC_REQUIRE(stdx::type_lookup_v<M, B> == 1);
 }
 
 TEST_CASE("look up value not in map (by type)", "[type map]") {
     using M = stdx::type_map<stdx::tv_pair<A, 0>, stdx::tv_pair<B, 1>>;
-    static_assert(stdx::type_lookup_v<M, Z> == 0);
-    static_assert(stdx::type_lookup_v<M, Z, 2> == 2);
+    STATIC_REQUIRE(stdx::type_lookup_v<M, Z> == 0);
+    STATIC_REQUIRE(stdx::type_lookup_v<M, Z, 2> == 2);
 }
 
 TEST_CASE("look up value in map (by value)", "[type map]") {
     using M = stdx::type_map<stdx::vv_pair<0, 10>, stdx::vv_pair<1, 11>>;
-    static_assert(stdx::value_lookup_v<M, 0> == 10);
-    static_assert(stdx::value_lookup_v<M, 1> == 11);
+    STATIC_REQUIRE(stdx::value_lookup_v<M, 0> == 10);
+    STATIC_REQUIRE(stdx::value_lookup_v<M, 1> == 11);
 }
 
 TEST_CASE("look up value not in map (by value)", "[type map]") {
     using M = stdx::type_map<stdx::vv_pair<0, 10>, stdx::vv_pair<1, 11>>;
-    static_assert(stdx::value_lookup_v<M, 2> == 0);
-    static_assert(stdx::value_lookup_v<M, 2, 3> == 3);
+    STATIC_REQUIRE(stdx::value_lookup_v<M, 2> == 0);
+    STATIC_REQUIRE(stdx::value_lookup_v<M, 2, 3> == 3);
 }

--- a/test/type_traits.cpp
+++ b/test/type_traits.cpp
@@ -14,28 +14,28 @@ template <typename T> struct derived_t : unary_t<T> {};
 } // namespace
 
 TEST_CASE("detect specializations", "[type_traits]") {
-    static_assert(stdx::is_specialization_of_v<unary_t<int>, unary_t>);
-    static_assert(stdx::is_type_specialization_of_v<unary_t<int>, unary_t>);
-    static_assert(stdx::is_specialization_of<unary_t<int>, unary_t>());
+    STATIC_REQUIRE(stdx::is_specialization_of_v<unary_t<int>, unary_t>);
+    STATIC_REQUIRE(stdx::is_type_specialization_of_v<unary_t<int>, unary_t>);
+    STATIC_REQUIRE(stdx::is_specialization_of<unary_t<int>, unary_t>());
 
-    static_assert(not stdx::is_specialization_of_v<int, unary_t>);
-    static_assert(not stdx::is_type_specialization_of_v<int, unary_t>);
-    static_assert(not stdx::is_specialization_of<int, unary_t>());
+    STATIC_REQUIRE(not stdx::is_specialization_of_v<int, unary_t>);
+    STATIC_REQUIRE(not stdx::is_type_specialization_of_v<int, unary_t>);
+    STATIC_REQUIRE(not stdx::is_specialization_of<int, unary_t>());
 
-    static_assert(stdx::is_specialization_of_v<variadic_t<>, variadic_t>);
-    static_assert(stdx::is_type_specialization_of_v<variadic_t<>, variadic_t>);
-    static_assert(stdx::is_specialization_of<variadic_t<>, variadic_t>());
+    STATIC_REQUIRE(stdx::is_specialization_of_v<variadic_t<>, variadic_t>);
+    STATIC_REQUIRE(stdx::is_type_specialization_of_v<variadic_t<>, variadic_t>);
+    STATIC_REQUIRE(stdx::is_specialization_of<variadic_t<>, variadic_t>());
 
-    static_assert(not stdx::is_specialization_of_v<int, variadic_t>);
-    static_assert(not stdx::is_type_specialization_of_v<int, variadic_t>);
-    static_assert(not stdx::is_specialization_of<int, variadic_t>());
+    STATIC_REQUIRE(not stdx::is_specialization_of_v<int, variadic_t>);
+    STATIC_REQUIRE(not stdx::is_type_specialization_of_v<int, variadic_t>);
+    STATIC_REQUIRE(not stdx::is_specialization_of<int, variadic_t>());
 }
 
 TEST_CASE("derived types are not specializations", "[type_traits]") {
-    static_assert(not stdx::is_specialization_of_v<derived_t<int>, unary_t>);
-    static_assert(
+    STATIC_REQUIRE(not stdx::is_specialization_of_v<derived_t<int>, unary_t>);
+    STATIC_REQUIRE(
         not stdx::is_type_specialization_of_v<derived_t<int>, unary_t>);
-    static_assert(not stdx::is_specialization_of<derived_t<int>, unary_t>());
+    STATIC_REQUIRE(not stdx::is_specialization_of<derived_t<int>, unary_t>());
 }
 
 namespace {
@@ -45,29 +45,29 @@ template <auto V> struct value_derived_t : value_unary_t<V> {};
 } // namespace
 
 TEST_CASE("detect specializations (value templates)", "[type_traits]") {
-    static_assert(
+    STATIC_REQUIRE(
         stdx::is_value_specialization_of_v<value_unary_t<0>, value_unary_t>);
-    static_assert(
+    STATIC_REQUIRE(
         stdx::is_specialization_of<value_unary_t<0>, value_unary_t>());
 
-    static_assert(not stdx::is_value_specialization_of_v<int, value_unary_t>);
-    static_assert(not stdx::is_specialization_of<int, value_unary_t>());
+    STATIC_REQUIRE(not stdx::is_value_specialization_of_v<int, value_unary_t>);
+    STATIC_REQUIRE(not stdx::is_specialization_of<int, value_unary_t>());
 
-    static_assert(stdx::is_value_specialization_of_v<value_variadic_t<>,
-                                                     value_variadic_t>);
-    static_assert(
+    STATIC_REQUIRE(stdx::is_value_specialization_of_v<value_variadic_t<>,
+                                                      value_variadic_t>);
+    STATIC_REQUIRE(
         stdx::is_specialization_of<value_variadic_t<>, value_variadic_t>());
 
-    static_assert(
+    STATIC_REQUIRE(
         not stdx::is_value_specialization_of_v<int, value_variadic_t>);
-    static_assert(not stdx::is_specialization_of<int, value_variadic_t>());
+    STATIC_REQUIRE(not stdx::is_specialization_of<int, value_variadic_t>());
 }
 
 TEST_CASE("derived types are not specializations (value templates)",
           "[type_traits]") {
-    static_assert(not stdx::is_value_specialization_of_v<value_derived_t<0>,
-                                                         value_unary_t>);
-    static_assert(
+    STATIC_REQUIRE(not stdx::is_value_specialization_of_v<value_derived_t<0>,
+                                                          value_unary_t>);
+    STATIC_REQUIRE(
         not stdx::is_specialization_of<value_derived_t<0>, value_unary_t>());
 }
 
@@ -77,25 +77,25 @@ enum struct E2 {};
 } // namespace
 
 TEST_CASE("is_scoped_enum", "[type_traits]") {
-    static_assert(not stdx::is_scoped_enum_v<int>);
-    static_assert(not stdx::is_scoped_enum_v<E1>);
-    static_assert(stdx::is_scoped_enum_v<E2>);
+    STATIC_REQUIRE(not stdx::is_scoped_enum_v<int>);
+    STATIC_REQUIRE(not stdx::is_scoped_enum_v<E1>);
+    STATIC_REQUIRE(stdx::is_scoped_enum_v<E2>);
 
-    static_assert(not stdx::is_scoped_enum<int>::value);
-    static_assert(not stdx::is_scoped_enum<E1>::value);
-    static_assert(stdx::is_scoped_enum<E2>::value);
+    STATIC_REQUIRE(not stdx::is_scoped_enum<int>::value);
+    STATIC_REQUIRE(not stdx::is_scoped_enum<E1>::value);
+    STATIC_REQUIRE(stdx::is_scoped_enum<E2>::value);
 }
 
 TEST_CASE("type_identity", "[type_traits]") {
-    static_assert(std::is_same_v<stdx::type_identity_t<void>, void>);
+    STATIC_REQUIRE(std::is_same_v<stdx::type_identity_t<void>, void>);
 }
 
 TEST_CASE("type_or_t", "[type_traits]") {
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<stdx::type_or_t<std::is_void, void, int>, void>);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<stdx::type_or_t<std::is_void, int, float>, float>);
-    static_assert(std::is_same_v<stdx::type_or_t<std::is_void, int>, void>);
+    STATIC_REQUIRE(std::is_same_v<stdx::type_or_t<std::is_void, int>, void>);
 }
 
 namespace {
@@ -169,16 +169,16 @@ TEST_CASE("apply_sequence with index sequence", "[type_traits]") {
 }
 
 TEST_CASE("is_same_unqualified", "[type_traits]") {
-    static_assert(stdx::is_same_unqualified_v<int, int>);
-    static_assert(not stdx::is_same_unqualified_v<int, void>);
-    static_assert(stdx::is_same_unqualified_v<int, int &>);
-    static_assert(stdx::is_same_unqualified_v<int, int const &>);
-    static_assert(stdx::is_same_unqualified_v<int, int &&>);
-    static_assert(stdx::is_same_unqualified_v<int, int const &&>);
-    static_assert(stdx::is_same_unqualified_v<int &, int>);
-    static_assert(stdx::is_same_unqualified_v<int const &, int>);
-    static_assert(stdx::is_same_unqualified_v<int &&, int>);
-    static_assert(stdx::is_same_unqualified_v<int const &&, int>);
+    STATIC_REQUIRE(stdx::is_same_unqualified_v<int, int>);
+    STATIC_REQUIRE(not stdx::is_same_unqualified_v<int, void>);
+    STATIC_REQUIRE(stdx::is_same_unqualified_v<int, int &>);
+    STATIC_REQUIRE(stdx::is_same_unqualified_v<int, int const &>);
+    STATIC_REQUIRE(stdx::is_same_unqualified_v<int, int &&>);
+    STATIC_REQUIRE(stdx::is_same_unqualified_v<int, int const &&>);
+    STATIC_REQUIRE(stdx::is_same_unqualified_v<int &, int>);
+    STATIC_REQUIRE(stdx::is_same_unqualified_v<int const &, int>);
+    STATIC_REQUIRE(stdx::is_same_unqualified_v<int &&, int>);
+    STATIC_REQUIRE(stdx::is_same_unqualified_v<int const &&, int>);
 }
 
 // for a taxonomy of structural types below, see
@@ -215,21 +215,21 @@ using union_t = union {
 } // namespace structural
 
 TEST_CASE("structural types", "[type_traits]") {
-    static_assert(stdx::is_structural_v<int &>);
-    static_assert(stdx::is_structural_v<int>);
-    static_assert(stdx::is_structural_v<int *>);
-    static_assert(stdx::is_structural_v<structural::pmd_t>);
-    static_assert(stdx::is_structural_v<structural::pmf_t>);
-    static_assert(stdx::is_structural_v<structural::enum_t>);
-    static_assert(stdx::is_structural_v<std::nullptr_t>);
+    STATIC_REQUIRE(stdx::is_structural_v<int &>);
+    STATIC_REQUIRE(stdx::is_structural_v<int>);
+    STATIC_REQUIRE(stdx::is_structural_v<int *>);
+    STATIC_REQUIRE(stdx::is_structural_v<structural::pmd_t>);
+    STATIC_REQUIRE(stdx::is_structural_v<structural::pmf_t>);
+    STATIC_REQUIRE(stdx::is_structural_v<structural::enum_t>);
+    STATIC_REQUIRE(stdx::is_structural_v<std::nullptr_t>);
 
 #if __cpp_nontype_template_args >= 201911L
-    static_assert(stdx::is_structural_v<structural::base_t>);
-    static_assert(stdx::is_structural_v<structural::derived_t>);
-    static_assert(stdx::is_structural_v<structural::class_t>);
-    static_assert(stdx::is_structural_v<structural::lambda_t>);
-    static_assert(stdx::is_structural_v<structural::union_t>);
-    static_assert(stdx::is_structural_v<float>);
+    STATIC_REQUIRE(stdx::is_structural_v<structural::base_t>);
+    STATIC_REQUIRE(stdx::is_structural_v<structural::derived_t>);
+    STATIC_REQUIRE(stdx::is_structural_v<structural::class_t>);
+    STATIC_REQUIRE(stdx::is_structural_v<structural::lambda_t>);
+    STATIC_REQUIRE(stdx::is_structural_v<structural::union_t>);
+    STATIC_REQUIRE(stdx::is_structural_v<float>);
 #endif
 }
 
@@ -240,7 +240,7 @@ struct S {
 } // namespace non_structural
 
 TEST_CASE("non-structural types", "[type_traits]") {
-    static_assert(not stdx::is_structural_v<non_structural::S>);
+    STATIC_REQUIRE(not stdx::is_structural_v<non_structural::S>);
 }
 
 #if __cplusplus >= 202002L
@@ -253,19 +253,19 @@ TEST_CASE("type shrinkage", "[type_traits]") {
     using B = long_type_name<A, A, A, A, A, A, A, A>;
     using C = long_type_name<B, B, B, B, B, B, B, B>;
     using X = stdx::shrink_t<C>;
-    static_assert(stdx::type_as_string<X>().size() <
-                  stdx::type_as_string<C>().size());
-    static_assert(std::same_as<stdx::expand_t<X>, C>);
+    STATIC_REQUIRE(stdx::type_as_string<X>().size() <
+                   stdx::type_as_string<C>().size());
+    STATIC_REQUIRE(std::same_as<stdx::expand_t<X>, C>);
 }
 #endif
 
 TEST_CASE("nth type in pack", "[type_traits]") {
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<stdx::nth_t<2, bool, char, float, int>, float>);
 }
 
 #if __cplusplus >= 202002L
 TEST_CASE("nth value in pack", "[type_traits]") {
-    static_assert(stdx::nth_v<2, 0, true, 'b', 3> == 'b');
+    STATIC_REQUIRE(stdx::nth_v<2, 0, true, 'b', 3> == 'b');
 }
 #endif

--- a/test/udls.cpp
+++ b/test/udls.cpp
@@ -4,88 +4,88 @@
 
 TEST_CASE("compile-time named bools", "[utility]") {
     using namespace stdx::literals;
-    static_assert("variable"_b);
-    static_assert(not(not "variable"_b));
+    STATIC_REQUIRE("variable"_b);
+    STATIC_REQUIRE(not(not "variable"_b));
 
-    static_assert("variable"_true);
-    static_assert(not "variable"_false);
+    STATIC_REQUIRE("variable"_true);
+    STATIC_REQUIRE(not "variable"_false);
 }
 
 TEST_CASE("decimal units", "[units]") {
     using namespace stdx::literals;
-    static_assert(1_k == 1'000ull);
-    static_assert(1_M == 1'000'000ull);
-    static_assert(1_G == 1'000'000'000ull);
+    STATIC_REQUIRE(1_k == 1'000ull);
+    STATIC_REQUIRE(1_M == 1'000'000ull);
+    STATIC_REQUIRE(1_G == 1'000'000'000ull);
 }
 
 TEST_CASE("binary units", "[units]") {
     using namespace stdx::literals;
-    static_assert(1_ki == 1'024ull);
-    static_assert(1_Mi == 1'024ull * 1'024ull);
-    static_assert(1_Gi == 1'024ull * 1'024ull * 1'024ull);
+    STATIC_REQUIRE(1_ki == 1'024ull);
+    STATIC_REQUIRE(1_Mi == 1'024ull * 1'024ull);
+    STATIC_REQUIRE(1_Gi == 1'024ull * 1'024ull * 1'024ull);
 }
 
 TEST_CASE("compile-time named small indices", "[units]") {
     using namespace stdx::literals;
-    static_assert(std::is_same_v<decltype("index"_0),
-                                 std::integral_constant<size_t, 0u>>);
-    static_assert("index"_0 == 0u);
-    static_assert("index"_1 == 1u);
-    static_assert("index"_2 == 2u);
-    static_assert("index"_3 == 3u);
-    static_assert("index"_4 == 4u);
-    static_assert("index"_5 == 5u);
-    static_assert("index"_6 == 6u);
-    static_assert("index"_7 == 7u);
-    static_assert("index"_8 == 8u);
-    static_assert("index"_9 == 9u);
+    STATIC_REQUIRE(std::is_same_v<decltype("index"_0),
+                                  std::integral_constant<size_t, 0u>>);
+    STATIC_REQUIRE("index"_0 == 0u);
+    STATIC_REQUIRE("index"_1 == 1u);
+    STATIC_REQUIRE("index"_2 == 2u);
+    STATIC_REQUIRE("index"_3 == 3u);
+    STATIC_REQUIRE("index"_4 == 4u);
+    STATIC_REQUIRE("index"_5 == 5u);
+    STATIC_REQUIRE("index"_6 == 6u);
+    STATIC_REQUIRE("index"_7 == 7u);
+    STATIC_REQUIRE("index"_8 == 8u);
+    STATIC_REQUIRE("index"_9 == 9u);
 }
 
 TEST_CASE("compile-time constant", "[units]") {
-    static_assert(std::is_same_v<decltype(stdx::_c<0>),
-                                 std::integral_constant<int, 0> const>);
-    static_assert(
+    STATIC_REQUIRE(std::is_same_v<decltype(stdx::_c<0>),
+                                  std::integral_constant<int, 0> const>);
+    STATIC_REQUIRE(
         std::is_same_v<decltype(stdx::_c<0u>),
                        std::integral_constant<unsigned int, 0> const>);
 }
 
 TEST_CASE("compile-time literal (decimal)", "[units]") {
     using namespace stdx::literals;
-    static_assert(std::is_same_v<decltype(0_c),
-                                 std::integral_constant<std::uint32_t, 0>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(0_c),
+                                  std::integral_constant<std::uint32_t, 0>>);
 }
 
 TEST_CASE("compile-time literal supports digit separators", "[units]") {
     using namespace stdx::literals;
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(123'456_c),
                        std::integral_constant<std::uint32_t, 123'456>>);
 }
 
 TEST_CASE("compile-time literal (octal)", "[units]") {
     using namespace stdx::literals;
-    static_assert(std::is_same_v<decltype(010_c),
-                                 std::integral_constant<std::uint32_t, 8>>);
-    static_assert(std::is_same_v<decltype(0'10_c),
-                                 std::integral_constant<std::uint32_t, 8>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(010_c),
+                                  std::integral_constant<std::uint32_t, 8>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(0'10_c),
+                                  std::integral_constant<std::uint32_t, 8>>);
 }
 
 TEST_CASE("compile-time literal (binary)", "[units]") {
     using namespace stdx::literals;
-    static_assert(std::is_same_v<decltype(0b11_c),
-                                 std::integral_constant<std::uint32_t, 3>>);
-    static_assert(std::is_same_v<decltype(0b1'1_c),
-                                 std::integral_constant<std::uint32_t, 3>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(0b11_c),
+                                  std::integral_constant<std::uint32_t, 3>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(0b1'1_c),
+                                  std::integral_constant<std::uint32_t, 3>>);
 }
 
 TEST_CASE("compile-time literal (hex)", "[units]") {
     using namespace stdx::literals;
-    static_assert(std::is_same_v<decltype(0xaa_c),
-                                 std::integral_constant<std::uint32_t, 170>>);
-    static_assert(std::is_same_v<decltype(0xAA_c),
-                                 std::integral_constant<std::uint32_t, 170>>);
-    static_assert(std::is_same_v<decltype(0xA'a_c),
-                                 std::integral_constant<std::uint32_t, 170>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(0xaa_c),
+                                  std::integral_constant<std::uint32_t, 170>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(0xAA_c),
+                                  std::integral_constant<std::uint32_t, 170>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(0xA'a_c),
+                                  std::integral_constant<std::uint32_t, 170>>);
 }
 
 namespace {
@@ -95,10 +95,10 @@ enum struct ScopedEnum : char { Value5 = 5 };
 
 TEST_CASE("compile-time enum constant", "[units]") {
     using namespace stdx;
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(_c<Value3>),
                        std::integral_constant<UnscopedEnum, Value3> const>);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<
             decltype(_c<ScopedEnum::Value5>),
             std::integral_constant<ScopedEnum, ScopedEnum::Value5> const>);

--- a/test/utility.cpp
+++ b/test/utility.cpp
@@ -9,158 +9,158 @@
 #include <type_traits>
 
 TEST_CASE("forward_like", "[utility]") {
-    static_assert(std::is_same_v<stdx::forward_like_t<int, float>, float &&>);
-    static_assert(
+    STATIC_REQUIRE(std::is_same_v<stdx::forward_like_t<int, float>, float &&>);
+    STATIC_REQUIRE(
         std::is_same_v<stdx::forward_like_t<int const, float>, float const &&>);
 
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<stdx::forward_like_t<int &&, float>, float &&>);
-    static_assert(std::is_same_v<stdx::forward_like_t<int const &&, float>,
-                                 float const &&>);
+    STATIC_REQUIRE(std::is_same_v<stdx::forward_like_t<int const &&, float>,
+                                  float const &&>);
 
-    static_assert(std::is_same_v<stdx::forward_like_t<int &, float>, float &>);
-    static_assert(std::is_same_v<stdx::forward_like_t<int const &, float>,
-                                 float const &>);
+    STATIC_REQUIRE(std::is_same_v<stdx::forward_like_t<int &, float>, float &>);
+    STATIC_REQUIRE(std::is_same_v<stdx::forward_like_t<int const &, float>,
+                                  float const &>);
 }
 
 TEST_CASE("as_unsigned (changed)", "[utility]") {
-    static_assert(std::is_same_v<decltype(stdx::as_unsigned(std::int8_t{})),
-                                 std::uint8_t>);
-    static_assert(std::is_same_v<decltype(stdx::as_unsigned(std::int16_t{})),
-                                 std::uint16_t>);
-    static_assert(std::is_same_v<decltype(stdx::as_unsigned(std::int32_t{})),
-                                 std::uint32_t>);
-    static_assert(std::is_same_v<decltype(stdx::as_unsigned(std::int64_t{})),
-                                 std::uint64_t>);
+    STATIC_REQUIRE(std::is_same_v<decltype(stdx::as_unsigned(std::int8_t{})),
+                                  std::uint8_t>);
+    STATIC_REQUIRE(std::is_same_v<decltype(stdx::as_unsigned(std::int16_t{})),
+                                  std::uint16_t>);
+    STATIC_REQUIRE(std::is_same_v<decltype(stdx::as_unsigned(std::int32_t{})),
+                                  std::uint32_t>);
+    STATIC_REQUIRE(std::is_same_v<decltype(stdx::as_unsigned(std::int64_t{})),
+                                  std::uint64_t>);
 }
 
 TEMPLATE_TEST_CASE("as_unsigned (unchanged)", "[utility]", std::uint8_t,
                    std::uint16_t, std::uint32_t, std::uint64_t) {
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(stdx::as_unsigned(TestType{})), TestType>);
 }
 
 TEST_CASE("as_signed (changed)", "[utility]") {
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(stdx::as_signed(std::uint8_t{})), std::int8_t>);
-    static_assert(std::is_same_v<decltype(stdx::as_signed(std::uint16_t{})),
-                                 std::int16_t>);
-    static_assert(std::is_same_v<decltype(stdx::as_signed(std::uint32_t{})),
-                                 std::int32_t>);
-    static_assert(std::is_same_v<decltype(stdx::as_signed(std::uint64_t{})),
-                                 std::int64_t>);
+    STATIC_REQUIRE(std::is_same_v<decltype(stdx::as_signed(std::uint16_t{})),
+                                  std::int16_t>);
+    STATIC_REQUIRE(std::is_same_v<decltype(stdx::as_signed(std::uint32_t{})),
+                                  std::int32_t>);
+    STATIC_REQUIRE(std::is_same_v<decltype(stdx::as_signed(std::uint64_t{})),
+                                  std::int64_t>);
 }
 
 TEMPLATE_TEST_CASE("as_signed (unchanged)", "[utility]", std::int8_t,
                    std::int16_t, std::int32_t, std::int64_t) {
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(stdx::as_signed(TestType{})), TestType>);
 }
 
 TEMPLATE_TEST_CASE("sized<T> in (uint8_t zero/one/two case)", "[utility]",
                    std::uint16_t, std::uint32_t, std::uint64_t) {
-    static_assert(stdx::sized<std::uint8_t>{0}.in<TestType>() == 0);
-    static_assert(stdx::sized<std::uint8_t>{1}.in<TestType>() == 1);
-    static_assert(stdx::sized<std::uint8_t>{2}.in<TestType>() == 1);
+    STATIC_REQUIRE(stdx::sized<std::uint8_t>{0}.in<TestType>() == 0);
+    STATIC_REQUIRE(stdx::sized<std::uint8_t>{1}.in<TestType>() == 1);
+    STATIC_REQUIRE(stdx::sized<std::uint8_t>{2}.in<TestType>() == 1);
 }
 
 TEMPLATE_TEST_CASE("sized<T> in (uint16_t zero/one/two case)", "[utility]",
                    std::uint32_t, std::uint64_t) {
-    static_assert(stdx::sized<std::uint16_t>{0}.in<TestType>() == 0);
-    static_assert(stdx::sized<std::uint16_t>{1}.in<TestType>() == 1);
-    static_assert(stdx::sized<std::uint16_t>{2}.in<TestType>() == 1);
+    STATIC_REQUIRE(stdx::sized<std::uint16_t>{0}.in<TestType>() == 0);
+    STATIC_REQUIRE(stdx::sized<std::uint16_t>{1}.in<TestType>() == 1);
+    STATIC_REQUIRE(stdx::sized<std::uint16_t>{2}.in<TestType>() == 1);
 }
 
 TEMPLATE_TEST_CASE("sized<T> in (uint32_t zero/one/two case)", "[utility]",
                    std::uint64_t) {
-    static_assert(stdx::sized<std::uint32_t>{0}.in<TestType>() == 0);
-    static_assert(stdx::sized<std::uint32_t>{1}.in<TestType>() == 1);
-    static_assert(stdx::sized<std::uint32_t>{2}.in<TestType>() == 1);
+    STATIC_REQUIRE(stdx::sized<std::uint32_t>{0}.in<TestType>() == 0);
+    STATIC_REQUIRE(stdx::sized<std::uint32_t>{1}.in<TestType>() == 1);
+    STATIC_REQUIRE(stdx::sized<std::uint32_t>{2}.in<TestType>() == 1);
 }
 
 TEMPLATE_TEST_CASE("sized<T> in (same type)", "[utility]", std::uint8_t,
                    std::uint16_t, std::uint32_t, std::uint64_t) {
-    static_assert(stdx::sized<TestType>{3}.template in<TestType>() == 3);
+    STATIC_REQUIRE(stdx::sized<TestType>{3}.template in<TestType>() == 3);
 }
 
 TEMPLATE_TEST_CASE("sized<T> in (exact case)", "[utility]", std::uint16_t,
                    std::uint32_t, std::uint64_t) {
-    static_assert(
+    STATIC_REQUIRE(
         stdx::sized<std::uint8_t>{3 * sizeof(TestType)}.in<TestType>() == 3);
 }
 
 TEMPLATE_TEST_CASE("sized<T> in defaults to bytes", "[utility]", std::uint16_t,
                    std::uint32_t, std::uint64_t) {
-    static_assert(stdx::sized<TestType>{3}.in() == 3 * sizeof(TestType));
+    STATIC_REQUIRE(stdx::sized<TestType>{3}.in() == 3 * sizeof(TestType));
 }
 
 TEMPLATE_TEST_CASE("sized<T> in (downsize)", "[utility]", std::uint8_t,
                    std::uint16_t, std::uint32_t) {
-    static_assert(stdx::sized<std::uint64_t>{3}.in<TestType>() ==
-                  3 * sizeof(std::uint64_t) / sizeof(TestType));
+    STATIC_REQUIRE(stdx::sized<std::uint64_t>{3}.in<TestType>() ==
+                   3 * sizeof(std::uint64_t) / sizeof(TestType));
 }
 
 TEST_CASE("sized<T> in (upsize uint8_t)", "[utility]") {
-    static_assert(stdx::sized<std::uint8_t>{3}.in<std::uint16_t>() == 2);
-    static_assert(stdx::sized<std::uint8_t>{17}.in<std::uint16_t>() == 9);
+    STATIC_REQUIRE(stdx::sized<std::uint8_t>{3}.in<std::uint16_t>() == 2);
+    STATIC_REQUIRE(stdx::sized<std::uint8_t>{17}.in<std::uint16_t>() == 9);
 
-    static_assert(stdx::sized<std::uint8_t>{5}.in<std::uint32_t>() == 2);
-    static_assert(stdx::sized<std::uint8_t>{17}.in<std::uint32_t>() == 5);
+    STATIC_REQUIRE(stdx::sized<std::uint8_t>{5}.in<std::uint32_t>() == 2);
+    STATIC_REQUIRE(stdx::sized<std::uint8_t>{17}.in<std::uint32_t>() == 5);
 
-    static_assert(stdx::sized<std::uint8_t>{9}.in<std::uint64_t>() == 2);
-    static_assert(stdx::sized<std::uint8_t>{17}.in<std::uint64_t>() == 3);
+    STATIC_REQUIRE(stdx::sized<std::uint8_t>{9}.in<std::uint64_t>() == 2);
+    STATIC_REQUIRE(stdx::sized<std::uint8_t>{17}.in<std::uint64_t>() == 3);
 }
 
 TEST_CASE("sized<T> in (upsize uint16_t)", "[utility]") {
-    static_assert(stdx::sized<std::uint16_t>{3}.in<std::uint32_t>() == 2);
-    static_assert(stdx::sized<std::uint16_t>{17}.in<std::uint32_t>() == 9);
+    STATIC_REQUIRE(stdx::sized<std::uint16_t>{3}.in<std::uint32_t>() == 2);
+    STATIC_REQUIRE(stdx::sized<std::uint16_t>{17}.in<std::uint32_t>() == 9);
 
-    static_assert(stdx::sized<std::uint16_t>{5}.in<std::uint64_t>() == 2);
-    static_assert(stdx::sized<std::uint16_t>{17}.in<std::uint64_t>() == 5);
+    STATIC_REQUIRE(stdx::sized<std::uint16_t>{5}.in<std::uint64_t>() == 2);
+    STATIC_REQUIRE(stdx::sized<std::uint16_t>{17}.in<std::uint64_t>() == 5);
 }
 
 TEST_CASE("sized<T> in (upsize uint32_t)", "[utility]") {
-    static_assert(stdx::sized<std::uint32_t>{3}.in<std::uint64_t>() == 2);
-    static_assert(stdx::sized<std::uint32_t>{17}.in<std::uint64_t>() == 9);
+    STATIC_REQUIRE(stdx::sized<std::uint32_t>{3}.in<std::uint64_t>() == 2);
+    STATIC_REQUIRE(stdx::sized<std::uint32_t>{17}.in<std::uint64_t>() == 9);
 }
 
 TEST_CASE("sized<T> aliases", "[utility]") {
-    static_assert(stdx::sized8{1}.in<std::uint64_t>() == 1);
-    static_assert(stdx::sized16{1}.in<std::uint64_t>() == 1);
-    static_assert(stdx::sized32{1}.in<std::uint64_t>() == 1);
-    static_assert(stdx::sized64{1}.in<std::uint64_t>() == 1);
+    STATIC_REQUIRE(stdx::sized8{1}.in<std::uint64_t>() == 1);
+    STATIC_REQUIRE(stdx::sized16{1}.in<std::uint64_t>() == 1);
+    STATIC_REQUIRE(stdx::sized32{1}.in<std::uint64_t>() == 1);
+    STATIC_REQUIRE(stdx::sized64{1}.in<std::uint64_t>() == 1);
 }
 
 TEST_CASE("sized<T> in (downsize not divisible)", "[utility]") {
     using T = std::array<char, 3>;
-    static_assert(sizeof(T) == 3);
-    static_assert(stdx::sized<std::uint32_t>{2}.in<T>() == 3);
+    STATIC_REQUIRE(sizeof(T) == 3);
+    STATIC_REQUIRE(stdx::sized<std::uint32_t>{2}.in<T>() == 3);
 }
 
 TEST_CASE("sized<T> in (upsize not divisible)", "[utility]") {
     using T = std::array<char, 3>;
-    static_assert(sizeof(T) == 3);
-    static_assert(stdx::sized<T>{3}.in<std::uint32_t>() == 3);
+    STATIC_REQUIRE(sizeof(T) == 3);
+    STATIC_REQUIRE(stdx::sized<T>{3}.in<std::uint32_t>() == 3);
 }
 
 TEST_CASE("CX_VALUE structural value", "[utility]") {
     auto x = CX_VALUE(42);
-    static_assert(x() == 42);
+    STATIC_REQUIRE(x() == 42);
     auto y = CX_VALUE(17, 42);
-    static_assert(y() == 42);
+    STATIC_REQUIRE(y() == 42);
 }
 
 TEST_CASE("CX_VALUE non-structural value", "[utility]") {
     auto x = CX_VALUE(std::string_view{"Hello"});
-    static_assert(x() == std::string_view{"Hello"});
+    STATIC_REQUIRE(x() == std::string_view{"Hello"});
 }
 
 TEST_CASE("CX_VALUE type", "[utility]") {
     auto x = CX_VALUE(int);
-    static_assert(std::is_same_v<decltype(x()), stdx::type_identity<int>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(x()), stdx::type_identity<int>>);
     auto y = CX_VALUE(std::pair<int, int>);
-    static_assert(std::is_same_v<decltype(y()),
-                                 stdx::type_identity<std::pair<int, int>>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(y()),
+                                  stdx::type_identity<std::pair<int, int>>>);
 }
 
 namespace {
@@ -175,12 +175,12 @@ template <typename T> constexpr auto cx_value_test_type() {
 
 TEST_CASE("CX_VALUE on NTTP", "[utility]") {
     auto x = cx_value_test_nttp<42>();
-    static_assert(x() == 42);
+    STATIC_REQUIRE(x() == 42);
 }
 
 TEST_CASE("CX_VALUE on type template argument", "[utility]") {
     auto x = cx_value_test_type<int>();
-    static_assert(std::is_same_v<decltype(x()), stdx::type_identity<int>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(x()), stdx::type_identity<int>>);
 }
 
 namespace {
@@ -188,19 +188,19 @@ struct alignas(16) over_aligned {};
 } // namespace
 
 TEST_CASE("is_aligned_with (integral)", "[utility]") {
-    static_assert(stdx::is_aligned_with<std::uint8_t>(0b1111));
+    STATIC_REQUIRE(stdx::is_aligned_with<std::uint8_t>(0b1111));
 
-    static_assert(stdx::is_aligned_with<std::uint16_t>(0b1110));
-    static_assert(not stdx::is_aligned_with<std::uint16_t>(0b1111));
+    STATIC_REQUIRE(stdx::is_aligned_with<std::uint16_t>(0b1110));
+    STATIC_REQUIRE(not stdx::is_aligned_with<std::uint16_t>(0b1111));
 
-    static_assert(stdx::is_aligned_with<std::uint32_t>(0b1100));
-    static_assert(not stdx::is_aligned_with<std::uint32_t>(0b1110));
+    STATIC_REQUIRE(stdx::is_aligned_with<std::uint32_t>(0b1100));
+    STATIC_REQUIRE(not stdx::is_aligned_with<std::uint32_t>(0b1110));
 
-    static_assert(stdx::is_aligned_with<std::uint64_t>(0b1000));
-    static_assert(not stdx::is_aligned_with<std::uint64_t>(0b1100));
+    STATIC_REQUIRE(stdx::is_aligned_with<std::uint64_t>(0b1000));
+    STATIC_REQUIRE(not stdx::is_aligned_with<std::uint64_t>(0b1100));
 
-    static_assert(stdx::is_aligned_with<over_aligned>(0b1'0000));
-    static_assert(not stdx::is_aligned_with<over_aligned>(0b1000));
+    STATIC_REQUIRE(stdx::is_aligned_with<over_aligned>(0b1'0000));
+    STATIC_REQUIRE(not stdx::is_aligned_with<over_aligned>(0b1000));
 }
 
 TEST_CASE("is_aligned_with (pointer)", "[utility]") {
@@ -221,22 +221,22 @@ TEST_CASE("is_aligned_with (pointer)", "[utility]") {
 
 TEST_CASE("ct (integral)", "[utility]") {
     constexpr auto vs = stdx::ct<42>();
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(vs), std::integral_constant<int, 42> const>);
     constexpr auto vu = stdx::ct<42u>();
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(vu),
                        std::integral_constant<unsigned int, 42> const>);
 }
 
 TEST_CASE("ct (bool)", "[utility]") {
     constexpr auto v = stdx::ct<true>();
-    static_assert(std::is_same_v<decltype(v), std::bool_constant<true> const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(v), std::bool_constant<true> const>);
 }
 
 TEST_CASE("ct (char)", "[utility]") {
     constexpr auto v = stdx::ct<'A'>();
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(v), std::integral_constant<char, 'A'> const>);
 }
 
@@ -246,13 +246,13 @@ enum struct E { A, B, C };
 
 TEST_CASE("ct (enum)", "[utility]") {
     constexpr auto v = stdx::ct<E::A>();
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(v), std::integral_constant<E, E::A> const>);
 }
 
 TEST_CASE("ct (type)", "[utility]") {
     constexpr auto v = stdx::ct<int>();
-    static_assert(std::is_same_v<decltype(v), stdx::type_identity<int> const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(v), stdx::type_identity<int> const>);
 }
 
 #endif

--- a/test/with_result_of.cpp
+++ b/test/with_result_of.cpp
@@ -6,23 +6,23 @@
 
 TEST_CASE("explicit conversion", "[with_result_of]") {
     constexpr auto f = stdx::with_result_of{[]() { return 42; }};
-    static_assert(std::is_empty_v<std::decay_t<decltype(f)>>);
+    STATIC_REQUIRE(std::is_empty_v<std::decay_t<decltype(f)>>);
     constexpr auto result = static_cast<int>(f);
-    static_assert(result == 42);
+    STATIC_REQUIRE(result == 42);
 }
 
 TEST_CASE("implicit conversion (lvalue)", "[with_result_of]") {
     constexpr auto f = stdx::with_result_of{[]() { return 42; }};
-    static_assert(std::is_empty_v<std::decay_t<decltype(f)>>);
+    STATIC_REQUIRE(std::is_empty_v<std::decay_t<decltype(f)>>);
     constexpr auto result = [](int n) { return n; }(f);
-    static_assert(result == 42);
+    STATIC_REQUIRE(result == 42);
 }
 
 TEST_CASE("implicit conversion (rvalue)", "[with_result_of]") {
     constexpr auto result = [](int n) {
         return n;
     }(stdx::with_result_of{[]() { return 42; }});
-    static_assert(result == 42);
+    STATIC_REQUIRE(result == 42);
 }
 
 TEST_CASE("capturing lambda", "[with_result_of]") {


### PR DESCRIPTION
Problem:
- Using `static_assert` does not report the check in Catch2.
- Not all python passes the check-black-format target.

Solution:
- Use `STATIC_REQUIRE` so that the check is reported.
- Format files with black.
