### PR TITLE
:sparkles: Add easy way to select optional implementation

### DIFF
--- a/include/stdx/optional.hpp
+++ b/include/stdx/optional.hpp
@@ -15,9 +15,12 @@
 namespace stdx {
 inline namespace v1 {
 template <typename T, typename = void> struct tombstone_traits {
-    static_assert(
-        stdx::always_false_v<T>,
-        "To use stdx::optional you must specialize stdx::tombstone_traits");
+    using unspecialized = int;
+    constexpr auto operator()() const {
+        static_assert(
+            stdx::always_false_v<T>,
+            "To use stdx::optional you must specialize stdx::tombstone_traits");
+    }
 };
 
 template <typename T>
@@ -47,6 +50,7 @@ template <typename T, typename TS = tombstone_traits<T>> class optional {
                       not stdx::is_specialization_of_v<TS, tombstone_traits>,
                   "Don't define tombstone traits for plain integral types");
     constexpr static inline auto traits = TS{};
+    using check_specialization_t [[maybe_unused]] = decltype(traits());
     T val{traits()};
 
   public:

--- a/test/optional.cpp
+++ b/test/optional.cpp
@@ -427,3 +427,19 @@ TEST_CASE("tombstone with non-structural value", "[optional]") {
     CHECK(*o == std::string_view{});
 }
 #endif
+
+#if __cplusplus >= 202002L
+namespace {
+template <typename T>
+using my_optional = stdx::conditional_t<requires {
+    typename stdx::tombstone_traits<T>::unspecialized;
+}, std::optional<T>, stdx::optional<T>>;
+} // namespace
+
+TEST_CASE("select optional implementation based on whether tombstone traits "
+          "are present",
+          "[optional]") {
+    static_assert(std::is_same_v<my_optional<S>, stdx::optional<S>>);
+    static_assert(std::is_same_v<my_optional<int>, std::optional<int>>);
+}
+#endif


### PR DESCRIPTION
Problem:
- Sometimes it's desirable to select `stdx::optional` or `std::optional` based on whether tombstone_traits is specialized or not.

Solution:
- Add a `specialized` typedef to the primary template for tombstone_traits to allow easy identification.