### PR TITLE
:bug: Make `as_[un]signed` `constexpr`

### DIFF
--- a/include/stdx/utility.hpp
+++ b/include/stdx/utility.hpp
@@ -97,14 +97,14 @@ template <typename T, typename U>
 using forward_like_t = decltype(forward_like<T>(std::declval<U>()));
 
 template <typename T, std::enable_if_t<std::is_integral_v<T>, int> = 0>
-[[nodiscard]] auto as_unsigned(T t) {
+[[nodiscard]] constexpr auto as_unsigned(T t) {
     static_assert(not std::is_same_v<T, bool>,
                   "as_unsigned is not applicable to bool");
     return static_cast<std::make_unsigned_t<T>>(t);
 }
 
 template <typename T, std::enable_if_t<std::is_integral_v<T>, int> = 0>
-[[nodiscard]] auto as_signed(T t) {
+[[nodiscard]] constexpr auto as_signed(T t) {
     static_assert(not std::is_same_v<T, bool>,
                   "as_signed is not applicable to bool");
     return static_cast<std::make_signed_t<T>>(t);

--- a/test/utility.cpp
+++ b/test/utility.cpp
@@ -32,12 +32,14 @@ TEST_CASE("as_unsigned (changed)", "[utility]") {
                                   std::uint32_t>);
     STATIC_REQUIRE(std::is_same_v<decltype(stdx::as_unsigned(std::int64_t{})),
                                   std::uint64_t>);
+    STATIC_REQUIRE(stdx::as_unsigned(std::int8_t{17}) == 17);
 }
 
 TEMPLATE_TEST_CASE("as_unsigned (unchanged)", "[utility]", std::uint8_t,
                    std::uint16_t, std::uint32_t, std::uint64_t) {
     STATIC_REQUIRE(
         std::is_same_v<decltype(stdx::as_unsigned(TestType{})), TestType>);
+    STATIC_REQUIRE(stdx::as_unsigned(TestType{17}) == 17);
 }
 
 TEST_CASE("as_signed (changed)", "[utility]") {
@@ -49,12 +51,14 @@ TEST_CASE("as_signed (changed)", "[utility]") {
                                   std::int32_t>);
     STATIC_REQUIRE(std::is_same_v<decltype(stdx::as_signed(std::uint64_t{})),
                                   std::int64_t>);
+    STATIC_REQUIRE(stdx::as_signed(std::uint8_t{17}) == 17);
 }
 
 TEMPLATE_TEST_CASE("as_signed (unchanged)", "[utility]", std::int8_t,
                    std::int16_t, std::int32_t, std::int64_t) {
     STATIC_REQUIRE(
         std::is_same_v<decltype(stdx::as_signed(TestType{})), TestType>);
+    STATIC_REQUIRE(stdx::as_signed(TestType{17}) == 17);
 }
 
 TEMPLATE_TEST_CASE("sized<T> in (uint8_t zero/one/two case)", "[utility]",


### PR DESCRIPTION
Problem:
- For some reason `constexpr` was omitted from `as_signed` and `as_unsigned` functions.

Solution:
- Make them `constexpr`.