### PR TITLE
:bug: Fix issue with size conversion

### DIFF
--- a/include/stdx/utility.hpp
+++ b/include/stdx/utility.hpp
@@ -116,7 +116,7 @@ template <typename T, typename U>
     if constexpr (sizeof(T) == sizeof(U)) {
         return sz;
     } else if constexpr (sizeof(T) > sizeof(U)) {
-        return (sz * sizeof(T) / sizeof(U)) + (sizeof(T) % sizeof(U) & 1u);
+        return (sz * sizeof(T) / sizeof(U)) + (sizeof(T) % sizeof(U) > 0);
     } else {
         return (sz * sizeof(T) + sizeof(U) - 1) / sizeof(U);
     }

--- a/test/utility.cpp
+++ b/test/utility.cpp
@@ -147,6 +147,18 @@ TEST_CASE("sized<T> in (upsize not divisible)", "[utility]") {
     STATIC_REQUIRE(stdx::sized<T>{3}.in<std::uint32_t>() == 3);
 }
 
+TEST_CASE("sized<T> in (downsize, mod > 1)", "[utility]") {
+    using T = std::array<char, 6>;
+    using U = std::array<char, 4>;
+    STATIC_REQUIRE(stdx::sized<T>{1}.in<U>() == 2);
+}
+
+TEST_CASE("sized<T> in (upsize, mod > 1)", "[utility]") {
+    using T = std::array<char, 6>;
+    using U = std::array<char, 4>;
+    STATIC_REQUIRE(stdx::sized<U>{2}.in<T>() == 2);
+}
+
 TEST_CASE("CX_VALUE structural value", "[utility]") {
     auto x = CX_VALUE(42);
     STATIC_REQUIRE(x() == 42);


### PR DESCRIPTION
Problem:
- When the sizes of two objects differ by an even number of bytes, `sized` is incorrect.

Solution:
- Fix it by checking `> 1` rather than `& 1`.