### PR TITLE
:bug: Fix dynamic span construct from array

### DIFF
--- a/include/stdx/span.hpp
+++ b/include/stdx/span.hpp
@@ -98,7 +98,7 @@ class span : public detail::span_base<T, Extent> {
     template <typename U, std::size_t N>
     // NOLINTNEXTLINE(google-explicit-constructor)
     constexpr span(std::array<U, N> &arr LIFETIMEBOUND) noexcept
-        : ptr{std::data(arr)} {
+        : base_t{std::data(arr), N}, ptr{std::data(arr)} {
         static_assert(Extent == dynamic_extent or Extent <= N,
                       "Span extends beyond available storage");
     }
@@ -106,7 +106,7 @@ class span : public detail::span_base<T, Extent> {
     template <typename U, std::size_t N>
     // NOLINTNEXTLINE(google-explicit-constructor)
     constexpr span(std::array<U, N> const &arr LIFETIMEBOUND) noexcept
-        : ptr{std::data(arr)} {
+        : base_t{std::data(arr), N}, ptr{std::data(arr)} {
         static_assert(Extent == dynamic_extent or Extent <= N,
                       "Span extends beyond available storage");
     }
@@ -116,7 +116,8 @@ class span : public detail::span_base<T, Extent> {
 
     template <std::size_t N>
     // NOLINTNEXTLINE(google-explicit-constructor)
-    constexpr span(arr_t<N> arr LIFETIMEBOUND) noexcept : ptr{std::data(arr)} {
+    constexpr span(arr_t<N> arr LIFETIMEBOUND) noexcept
+        : base_t{std::data(arr), N}, ptr{std::data(arr)} {
         static_assert(Extent == dynamic_extent or Extent <= N,
                       "Span extends beyond available storage");
     }

--- a/test/span.cpp
+++ b/test/span.cpp
@@ -141,6 +141,22 @@ TEST_CASE("span is constructible from std::array (non const data)", "[span]") {
     STATIC_REQUIRE(std::size(s) == 4);
 }
 
+TEST_CASE("dynamic span is constructible from std::array (const data)",
+          "[span]") {
+    constexpr static auto a = std::array{1, 2, 3, 4};
+    auto s = [](stdx::span<int const> x) { return x; }(a);
+    CHECK(std::data(s) == std::data(a));
+    CHECK(std::size(s) == std::size(a));
+}
+
+TEST_CASE("dynamic span is constructible from std::array (non const data)",
+          "[span]") {
+    auto a = std::array{1, 2, 3, 4};
+    auto s = [](stdx::span<int> x) { return x; }(a);
+    CHECK(std::data(s) == std::data(a));
+    CHECK(std::size(s) == std::size(a));
+}
+
 TEST_CASE("span is constructible from C-style array (const data)", "[span]") {
     constexpr static int a[] = {1, 2, 3, 4};
     constexpr auto s = stdx::span{a};
@@ -155,6 +171,22 @@ TEST_CASE("span is constructible from C-style array (non const data)",
     int a[] = {1, 2, 3, 4};
     auto s = stdx::span{a};
     STATIC_REQUIRE(std::is_same_v<decltype(s), stdx::span<int, 4u>>);
+    CHECK(std::data(s) == std::data(a));
+    CHECK(std::size(s) == std::size(a));
+}
+
+TEST_CASE("dynamic span is constructible from C-style array (const data)",
+          "[span]") {
+    constexpr static int a[] = {1, 2, 3, 4};
+    auto s = [](stdx::span<int const> x) { return x; }(a);
+    CHECK(std::data(s) == std::data(a));
+    CHECK(std::size(s) == std::size(a));
+}
+
+TEST_CASE("dynamic span is constructible from C-style array (non const data)",
+          "[span]") {
+    int a[] = {1, 2, 3, 4};
+    auto s = [](stdx::span<int> x) { return x; }(a);
     CHECK(std::data(s) == std::data(a));
     CHECK(std::size(s) == std::size(a));
 }


### PR DESCRIPTION
Problem:
- When a dynamic span is constructed from an array, the size is not populated.

Solution:
- Initialize the base (size) properly.