### PR TITLE
:bug: Fix `make_tuple` with function pointers

### DIFF
--- a/include/stdx/tuple.hpp
+++ b/include/stdx/tuple.hpp
@@ -444,7 +444,7 @@ template <typename T, tuplelike Tuple>
 }
 
 template <typename... Ts> [[nodiscard]] constexpr auto make_tuple(Ts &&...ts) {
-    return tuple<std::remove_cvref_t<Ts>...>{std::forward<Ts>(ts)...};
+    return tuple<std::decay_t<Ts>...>{std::forward<Ts>(ts)...};
 }
 
 template <template <typename> typename... Fs>

--- a/test/tuple.cpp
+++ b/test/tuple.cpp
@@ -141,7 +141,7 @@ TEST_CASE("tuple of lvalue references", "[tuple]") {
 
 TEST_CASE("tuple of lambdas", "[tuple]") {
     auto x = 1;
-    auto t = stdx::make_tuple([&] { x += 2; }, [&] { x += 3; });
+    auto t = stdx::tuple{[&] { x += 2; }, [&] { x += 3; }};
     get<0>(t)();
     CHECK(x == 3);
 }
@@ -392,9 +392,15 @@ TEST_CASE("copy/move behavior for tuple", "[tuple]") {
     CHECK(counter::copies == 0);
 }
 
+auto func_no_args() -> void;
+auto func_one_arg(int) -> void;
+
 TEST_CASE("make_tuple", "[tuple]") {
     STATIC_REQUIRE(stdx::make_tuple() == stdx::tuple{});
     STATIC_REQUIRE(stdx::make_tuple(1, 2, 3) == stdx::tuple{1, 2, 3});
+    STATIC_REQUIRE(
+        std::is_same_v<decltype(stdx::make_tuple(func_no_args, func_one_arg)),
+                       stdx::tuple<void (*)(), void (*)(int)>>);
 
     constexpr auto t = stdx::make_tuple(stdx::tuple{});
     using T = std::remove_const_t<decltype(t)>;


### PR DESCRIPTION
Problem:
- Passing a function reference to `make_tuple` does not decay and produce a tuple of a function pointer.

Solution:
- Use `decay` instead of `remove_cvref`.