### PR TITLE
:sparkles: Add `CT_WRAP`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,8 +62,8 @@ target_sources(
               include/stdx/detail/list_common.hpp
               include/stdx/env.hpp
               include/stdx/for_each_n_args.hpp
-              include/stdx/functional.hpp
               include/stdx/function_traits.hpp
+              include/stdx/functional.hpp
               include/stdx/intrusive_forward_list.hpp
               include/stdx/intrusive_list.hpp
               include/stdx/iterator.hpp
@@ -72,14 +72,15 @@ target_sources(
               include/stdx/numeric.hpp
               include/stdx/optional.hpp
               include/stdx/panic.hpp
+              include/stdx/pp_map.hpp
               include/stdx/priority.hpp
               include/stdx/ranges.hpp
               include/stdx/rollover.hpp
               include/stdx/span.hpp
               include/stdx/static_assert.hpp
+              include/stdx/tuple.hpp
               include/stdx/tuple_algorithms.hpp
               include/stdx/tuple_destructure.hpp
-              include/stdx/tuple.hpp
               include/stdx/type_traits.hpp
               include/stdx/udls.hpp
               include/stdx/utility.hpp)

--- a/include/stdx/ct_format.hpp
+++ b/include/stdx/ct_format.hpp
@@ -6,6 +6,7 @@
 #include <stdx/concepts.hpp>
 #include <stdx/ct_conversions.hpp>
 #include <stdx/ct_string.hpp>
+#include <stdx/pp_map.hpp>
 #include <stdx/tuple.hpp>
 #include <stdx/tuple_algorithms.hpp>
 #include <stdx/type_traits.hpp>
@@ -258,5 +259,12 @@ constexpr auto num_fmt_specifiers =
     detail::count_specifiers(std::string_view{Fmt});
 } // namespace v1
 } // namespace stdx
+
+// NOLINTBEGIN(cppcoreguidelines-macro-usage)
+
+#define STDX_CT_FORMAT(S, ...)                                                 \
+    stdx::ct_format<S>(STDX_MAP(CX_WRAP __VA_OPT__(, ) __VA_ARGS__))
+
+// NOLINTEND(cppcoreguidelines-macro-usage)
 
 #endif

--- a/include/stdx/ct_format.hpp
+++ b/include/stdx/ct_format.hpp
@@ -8,6 +8,7 @@
 #include <stdx/ct_string.hpp>
 #include <stdx/tuple.hpp>
 #include <stdx/tuple_algorithms.hpp>
+#include <stdx/type_traits.hpp>
 #include <stdx/utility.hpp>
 
 #include <fmt/compile.h>
@@ -107,8 +108,8 @@ template <std::size_t N> CONSTEVAL auto split_specifiers(std::string_view fmt) {
 }
 
 template <typename T>
-concept cx_value = requires { typename T::cx_value_t; } or
-                   requires(T t) { ct_string_from_type(t); };
+concept fmt_cx_value =
+    is_cx_value_v<T> or requires(T t) { ct_string_from_type(t); };
 
 template <typename T, T V>
 CONSTEVAL auto arg_value(std::integral_constant<T, V>) {
@@ -125,7 +126,7 @@ template <typename T> CONSTEVAL auto arg_value(type_identity<T>) {
 
 template <ct_string S> CONSTEVAL auto arg_value(cts_t<S>) { return S; }
 
-CONSTEVAL auto arg_value(cx_value auto a) {
+CONSTEVAL auto arg_value(fmt_cx_value auto a) {
     if constexpr (requires { ct_string_from_type(a); }) {
         return ct_string_from_type(a);
     } else if constexpr (std::is_enum_v<decltype(a())>) {

--- a/include/stdx/ct_string.hpp
+++ b/include/stdx/ct_string.hpp
@@ -173,6 +173,8 @@ template <std::size_t N> struct ct_helper<ct_string<N>>;
 
 template <ct_string Value> CONSTEVAL auto ct() { return cts_t<Value>{}; }
 
+template <ct_string Value> constexpr auto is_ct_v<cts_t<Value>> = true;
+
 inline namespace literals {
 inline namespace ct_string_literals {
 template <ct_string S> CONSTEVAL_UDL auto operator""_cts() { return S; }

--- a/include/stdx/pp_map.hpp
+++ b/include/stdx/pp_map.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+// NOLINTBEGIN(cppcoreguidelines-macro-usage)
+
+#define STDX_EVAL0(...) __VA_ARGS__
+#define STDX_EVAL1(...) STDX_EVAL0(STDX_EVAL0(STDX_EVAL0(__VA_ARGS__)))
+#define STDX_EVAL2(...) STDX_EVAL1(STDX_EVAL1(STDX_EVAL1(__VA_ARGS__)))
+#define STDX_EVAL3(...) STDX_EVAL2(STDX_EVAL2(STDX_EVAL2(__VA_ARGS__)))
+#define STDX_EVAL4(...) STDX_EVAL3(STDX_EVAL3(STDX_EVAL3(__VA_ARGS__)))
+#define STDX_EVAL5(...) STDX_EVAL4(STDX_EVAL4(STDX_EVAL4(__VA_ARGS__)))
+#define STDX_EVAL(...) STDX_EVAL5(__VA_ARGS__)
+
+#define STDX_MAP_END(...)
+#define STDX_MAP_OUT
+
+#define STDX_EMPTY()
+#define STDX_DEFER(id) id STDX_EMPTY()
+
+#define STDX_MAP_GET_END2() 0, STDX_MAP_END
+#define STDX_MAP_GET_END1(...) STDX_MAP_GET_END2
+#define STDX_MAP_GET_END(...) STDX_MAP_GET_END1
+#define STDX_MAP_NEXT0(test, next, ...) next STDX_MAP_OUT
+#define STDX_MAP_NEXT1(test, next) STDX_DEFER(STDX_MAP_NEXT0)(test, next, 0)
+#define STDX_MAP_NEXT(test, next) STDX_MAP_NEXT1(STDX_MAP_GET_END test, next)
+#define STDX_MAP_INC(X) STDX_MAP_INC_##X
+
+#define STDX_MAP_A(f, x, peek, ...)                                            \
+    , f(x) STDX_DEFER(STDX_MAP_NEXT(peek, STDX_MAP_B))(f, peek, __VA_ARGS__)
+#define STDX_MAP_B(f, x, peek, ...)                                            \
+    , f(x) STDX_DEFER(STDX_MAP_NEXT(peek, STDX_MAP_A))(f, peek, __VA_ARGS__)
+
+#define STDX_DROP0(X, ...) __VA_ARGS__
+#define STDX_DROP1(...) STDX_DROP0(__VA_ARGS__)
+
+#define STDX_MAP(f, ...)                                                       \
+    __VA_OPT__(STDX_DROP1(                                                     \
+        0 STDX_EVAL(STDX_MAP_A(f, __VA_ARGS__, ()()(), ()()(), ()()(), 0))))
+
+// NOLINTEND(cppcoreguidelines-macro-usage)

--- a/include/stdx/static_assert.hpp
+++ b/include/stdx/static_assert.hpp
@@ -26,7 +26,7 @@ template <bool B> constexpr auto ct_check = ct_check_t<B>{};
 namespace detail {
 template <ct_string Fmt, auto... Args> constexpr auto static_format() {
     constexpr auto make_ct = []<auto V>() {
-        if constexpr (cx_value<decltype(V)>) {
+        if constexpr (fmt_cx_value<decltype(V)>) {
             return V;
         } else {
             return CX_VALUE(V);

--- a/include/stdx/utility.hpp
+++ b/include/stdx/utility.hpp
@@ -148,7 +148,7 @@ struct from_any {
 struct type_val {
     template <typename T, typename U,
               typename = std::enable_if_t<same_as_unqualified<type_val, U>>>
-    friend constexpr auto operator+(T t, U &&) -> T {
+    friend constexpr auto operator+(T t, U const &) -> T {
         return t;
     }
     friend constexpr auto operator+(type_val const &f) -> type_val { return f; }
@@ -238,20 +238,21 @@ template <typename T> constexpr auto is_ct_v<T const> = is_ct_v<T>;
         STDX_PRAGMA(diagnostic push)                                           \
         STDX_PRAGMA(diagnostic ignored "-Wold-style-cast")                     \
         STDX_PRAGMA(diagnostic ignored "-Wunused-value")                       \
-        if constexpr (decltype(stdx::cxv_detail::is_type<                      \
-                               stdx::cxv_detail::from_any(                     \
+        if constexpr (decltype(::stdx::cxv_detail::is_type<                    \
+                               ::stdx::cxv_detail::from_any(                   \
                                    __VA_ARGS__)>())::value) {                  \
-            return stdx::overload{stdx::cxv_detail::cx_base{}, [&] {           \
-                                      return stdx::type_identity<              \
-                                          decltype(stdx::cxv_detail::type_of<  \
-                                                   stdx::cxv_detail::from_any( \
-                                                       __VA_ARGS__)>())>{};    \
-                                  }};                                          \
+            return ::stdx::overload{                                           \
+                ::stdx::cxv_detail::cx_base{}, [&] {                           \
+                    return ::stdx::type_identity<                              \
+                        decltype(::stdx::cxv_detail::type_of<                  \
+                                 ::stdx::cxv_detail::from_any(                 \
+                                     __VA_ARGS__)>())>{};                      \
+                }};                                                            \
         } else {                                                               \
-            return stdx::overload{stdx::cxv_detail::cx_base{}, [&] {           \
-                                      return (__VA_ARGS__) +                   \
-                                             stdx::cxv_detail::type_val{};     \
-                                  }};                                          \
+            return ::stdx::overload{::stdx::cxv_detail::cx_base{}, [&] {       \
+                                        return (__VA_ARGS__) +                 \
+                                               ::stdx::cxv_detail::type_val{}; \
+                                    }};                                        \
         }                                                                      \
         STDX_PRAGMA(diagnostic pop)                                            \
     }()
@@ -272,26 +273,49 @@ template <typename T> constexpr auto is_ct_v<T const> = is_ct_v<T>;
         }                                                                      \
     }([&] { return X; })
 
+#ifdef __clang__
+#define CX_DETECT(X) std::is_empty_v<decltype(CX_VALUE(X))>
+#else
+namespace stdx {
+inline namespace v1 {
+template <auto> constexpr auto cx_detect0() {}
+constexpr auto cx_detect1(auto) { return 0; }
+} // namespace v1
+} // namespace stdx
+#define CX_DETECT(X)                                                           \
+    requires {                                                                 \
+        ::stdx::cx_detect0<::stdx::cx_detect1(                                 \
+            (X) + ::stdx::cxv_detail::type_val{})>;                            \
+    }
+#endif
+
 #define CX_WRAP(X)                                                             \
-    [&]<typename F>(F) {                                                       \
+    [&]<typename F>(F f) {                                                     \
         STDX_PRAGMA(diagnostic push)                                           \
         STDX_PRAGMA(diagnostic ignored "-Wold-style-cast")                     \
         if constexpr (::stdx::is_cx_value_v<std::invoke_result_t<F>>) {        \
-            return (X) + ::stdx::cxv_detail::type_val{};                       \
-        } else if constexpr (requires {                                        \
-                                 ::stdx::detail::cx_detect0<                   \
-                                     ::stdx::detail::cx_detect1(               \
-                                         CX_VALUE(X)())>;                      \
-                             }) {                                              \
-            return CX_VALUE(X);                                                \
+            return f();                                                        \
+        } else if constexpr (CX_DETECT(X)) {                                   \
+            if constexpr (decltype(::stdx::cxv_detail::is_type<                \
+                                   ::stdx::cxv_detail::from_any(               \
+                                       X)>())::value) {                        \
+                return ::stdx::overload{                                       \
+                    ::stdx::cxv_detail::cx_base{}, [&] {                       \
+                        return ::stdx::type_identity<                          \
+                            decltype(::stdx::cxv_detail::type_of<              \
+                                     ::stdx::cxv_detail::from_any(X)>())>{};   \
+                    }};                                                        \
+            } else {                                                           \
+                return ::stdx::overload{::stdx::cxv_detail::cx_base{}, f};     \
+            }                                                                  \
         } else {                                                               \
-            return (X) + ::stdx::cxv_detail::type_val{};                       \
+            return f();                                                        \
         }                                                                      \
         STDX_PRAGMA(diagnostic pop)                                            \
     }([&] {                                                                    \
         STDX_PRAGMA(diagnostic push)                                           \
         STDX_PRAGMA(diagnostic ignored "-Wold-style-cast")                     \
-        return (X) + stdx::cxv_detail::type_val{};                             \
+        return (X) + ::stdx::cxv_detail::type_val{};                           \
         STDX_PRAGMA(diagnostic pop)                                            \
     })
 

--- a/include/stdx/utility.hpp
+++ b/include/stdx/utility.hpp
@@ -148,14 +148,18 @@ struct from_any {
 struct type_val {
     template <typename T, typename U,
               typename = std::enable_if_t<same_as_unqualified<type_val, U>>>
-    friend constexpr auto operator+(T &&t, U &&) -> T {
+    friend constexpr auto operator+(T t, U &&) -> T {
         return t;
     }
     friend constexpr auto operator+(type_val const &f) -> type_val { return f; }
     // NOLINTNEXTLINE(google-explicit-constructor)
     template <typename T> constexpr operator T() const {
-        extern auto cxv_type_val_get_t(T *) -> T;
-        return cxv_type_val_get_t(nullptr);
+        if constexpr (std::is_default_constructible_v<T>) {
+            return T{};
+        } else {
+            extern auto cxv_type_val_get_t(T *) -> T;
+            return cxv_type_val_get_t(nullptr);
+        }
     }
 };
 
@@ -202,6 +206,9 @@ template <typename T> struct ct_helper {
     T value;
 };
 template <typename T> ct_helper(T) -> ct_helper<T>;
+
+template <auto> CONSTEVAL auto cx_detect0() {}
+CONSTEVAL auto cx_detect1(auto) { return 0; }
 } // namespace detail
 
 template <detail::ct_helper Value> CONSTEVAL auto ct() {
@@ -227,21 +234,21 @@ template <typename T> constexpr auto is_ct_v<T const> = is_ct_v<T>;
 
 #ifndef CX_VALUE
 #define CX_VALUE(...)                                                          \
-    []() constexpr {                                                           \
+    [&]() constexpr {                                                          \
         STDX_PRAGMA(diagnostic push)                                           \
         STDX_PRAGMA(diagnostic ignored "-Wold-style-cast")                     \
         STDX_PRAGMA(diagnostic ignored "-Wunused-value")                       \
         if constexpr (decltype(stdx::cxv_detail::is_type<                      \
                                stdx::cxv_detail::from_any(                     \
                                    __VA_ARGS__)>())::value) {                  \
-            return stdx::overload{stdx::cxv_detail::cx_base{}, [] {            \
+            return stdx::overload{stdx::cxv_detail::cx_base{}, [&] {           \
                                       return stdx::type_identity<              \
                                           decltype(stdx::cxv_detail::type_of<  \
                                                    stdx::cxv_detail::from_any( \
                                                        __VA_ARGS__)>())>{};    \
                                   }};                                          \
         } else {                                                               \
-            return stdx::overload{stdx::cxv_detail::cx_base{}, [] {            \
+            return stdx::overload{stdx::cxv_detail::cx_base{}, [&] {           \
                                       return (__VA_ARGS__) +                   \
                                              stdx::cxv_detail::type_val{};     \
                                   }};                                          \
@@ -264,6 +271,29 @@ template <typename T> constexpr auto is_ct_v<T const> = is_ct_v<T>;
             return f();                                                        \
         }                                                                      \
     }([&] { return X; })
+
+#define CX_WRAP(X)                                                             \
+    [&]<typename F>(F) {                                                       \
+        STDX_PRAGMA(diagnostic push)                                           \
+        STDX_PRAGMA(diagnostic ignored "-Wold-style-cast")                     \
+        if constexpr (::stdx::is_cx_value_v<std::invoke_result_t<F>>) {        \
+            return (X) + ::stdx::cxv_detail::type_val{};                       \
+        } else if constexpr (requires {                                        \
+                                 ::stdx::detail::cx_detect0<                   \
+                                     ::stdx::detail::cx_detect1(               \
+                                         CX_VALUE(X)())>;                      \
+                             }) {                                              \
+            return CX_VALUE(X);                                                \
+        } else {                                                               \
+            return (X) + ::stdx::cxv_detail::type_val{};                       \
+        }                                                                      \
+        STDX_PRAGMA(diagnostic pop)                                            \
+    }([&] {                                                                    \
+        STDX_PRAGMA(diagnostic push)                                           \
+        STDX_PRAGMA(diagnostic ignored "-Wold-style-cast")                     \
+        return (X) + stdx::cxv_detail::type_val{};                             \
+        STDX_PRAGMA(diagnostic pop)                                            \
+    })
 
 #endif
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -54,6 +54,7 @@ add_tests(
     optional
     overload
     panic
+    pp_map
     priority
     ranges
     remove_cvref

--- a/test/ct_format.cpp
+++ b/test/ct_format.cpp
@@ -242,6 +242,52 @@ constexpr auto ct_format_as(S const &s) {
 } // namespace user
 
 TEST_CASE("user-defined formatting", "[ct_format]") {
-    auto r = stdx::ct_format<"Hello {}">(user::S{42});
-    CHECK(r == stdx::format_result{"Hello S: {}"_ctst, stdx::make_tuple(42)});
+    auto r = stdx::ct_format<"Hello {}">(user::S{17});
+    CHECK(r == stdx::format_result{"Hello S: {}"_ctst, stdx::make_tuple(17)});
+}
+
+TEST_CASE("FORMAT with no arguments", "[ct_format]") {
+    STATIC_REQUIRE(STDX_CT_FORMAT("Hello") == "Hello"_fmt_res);
+}
+
+TEST_CASE("FORMAT a compile-time string argument", "[ct_format]") {
+    STATIC_REQUIRE(STDX_CT_FORMAT("Hello {}", "world") ==
+                   "Hello world"_fmt_res);
+}
+
+TEST_CASE("FORMAT a compile-time int argument", "[ct_format]") {
+    STATIC_REQUIRE(STDX_CT_FORMAT("Hello {}", 17) == "Hello 17"_fmt_res);
+}
+
+TEST_CASE("FORMAT a type argument", "[ct_format]") {
+    STATIC_REQUIRE(STDX_CT_FORMAT("Hello {}", int) == "Hello int"_fmt_res);
+}
+
+TEST_CASE("FORMAT a constexpr string argument", "[ct_format]") {
+    constexpr static auto S = "world"_cts;
+    STATIC_REQUIRE(STDX_CT_FORMAT("Hello {}", S) == "Hello world"_fmt_res);
+}
+
+TEST_CASE("FORMAT a constexpr int argument", "[ct_format]") {
+    constexpr static auto I = 17;
+    STATIC_REQUIRE(STDX_CT_FORMAT("Hello {}", I) == "Hello 17"_fmt_res);
+}
+
+#ifdef __clang__
+TEST_CASE("FORMAT a constexpr nonstatic string_view argument", "[ct_format]") {
+    constexpr auto S = std::string_view{"world"};
+    constexpr auto expected =
+        stdx::format_result{"Hello {}"_ctst, stdx::make_tuple(S)};
+    STATIC_REQUIRE(STDX_CT_FORMAT("Hello {}", S) == expected);
+}
+#endif
+
+TEST_CASE("FORMAT a constexpr string_view argument", "[ct_format]") {
+    constexpr static auto S = std::string_view{"world"};
+    STATIC_REQUIRE(STDX_CT_FORMAT("Hello {}", S) == "Hello world"_fmt_res);
+}
+
+TEST_CASE("FORMAT an integral_constant argument", "[ct_format]") {
+    constexpr static auto I = std::integral_constant<int, 17>{};
+    STATIC_REQUIRE(STDX_CT_FORMAT("Hello {}", I) == "Hello 17"_fmt_res);
 }

--- a/test/ct_string.cpp
+++ b/test/ct_string.cpp
@@ -165,3 +165,30 @@ TEST_CASE("operator+ works to concat cts_t and ct_string", "[ct_string]") {
     STATIC_REQUIRE("Hello"_ctst + " world"_cts == "Hello world"_cts);
     STATIC_REQUIRE("Hello"_cts + " world"_ctst == "Hello world"_cts);
 }
+
+TEST_CASE("is_ct (ct_string)", "[ct_string]") {
+    using namespace stdx::ct_string_literals;
+    constexpr auto v1 = stdx::ct<"Hello">();
+    STATIC_REQUIRE(stdx::is_ct_v<decltype(v1)>);
+}
+
+TEST_CASE("CT_WRAP", "[ct_string]") {
+    using namespace stdx::ct_string_literals;
+    auto x1 = "hello"_cts;
+    STATIC_REQUIRE(std::is_same_v<decltype(CT_WRAP(x1)), stdx::ct_string<6>>);
+    CHECK(CT_WRAP(x1) == "hello"_cts);
+
+    auto x2 = "hello"_ctst;
+    STATIC_REQUIRE(std::is_same_v<decltype(CT_WRAP(x2)), stdx::cts_t<"hello">>);
+    STATIC_REQUIRE(CT_WRAP(x2) == "hello"_ctst);
+
+    constexpr static auto x3 = "hello"_cts;
+    STATIC_REQUIRE(std::is_same_v<decltype(CT_WRAP(x3)), stdx::cts_t<"hello">>);
+    STATIC_REQUIRE(CT_WRAP(x3) == "hello"_ctst);
+
+    []<stdx::ct_string X>() {
+        STATIC_REQUIRE(
+            std::is_same_v<decltype(CT_WRAP(X)), stdx::cts_t<"hello">>);
+        STATIC_REQUIRE(CT_WRAP(X) == "hello"_ctst);
+    }.template operator()<"hello">();
+}

--- a/test/pp_map.cpp
+++ b/test/pp_map.cpp
@@ -1,0 +1,31 @@
+#include <stdx/compiler.hpp>
+#include <stdx/pp_map.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+namespace {
+auto count_args = [](auto const &...args) { return sizeof...(args); };
+} // namespace
+
+TEST_CASE("pp_map zero arguments", "[pp_map]") {
+#ifdef __clang__
+    STDX_PRAGMA(diagnostic push)
+    STDX_PRAGMA(diagnostic ignored "-Wgnu-zero-variadic-macro-arguments")
+#endif
+    static_assert(count_args(STDX_MAP(int)) == 0);
+#ifdef __clang__
+    STDX_PRAGMA(diagnostic pop)
+#endif
+}
+
+TEST_CASE("pp_map one argument", "[pp_map]") {
+    static_assert(count_args(STDX_MAP(double, 1)) == 1.0);
+}
+
+TEST_CASE("pp_map n arguments", "[pp_map]") {
+    static_assert(count_args(STDX_MAP(double, 1, 2, 3)) == 3);
+}
+
+TEST_CASE("pp_map parenthesized arguments", "[pp_map]") {
+    static_assert(count_args(STDX_MAP(double, ((void)1, 2), 3)) == 2);
+}

--- a/test/utility.cpp
+++ b/test/utility.cpp
@@ -305,4 +305,63 @@ TEST_CASE("CT_WRAP", "[utility]") {
     }.template operator()<17>();
 }
 
+TEST_CASE("CX_WRAP integer runtime arg", "[utility]") {
+    auto x = 17;
+    STATIC_REQUIRE(std::is_same_v<decltype(CX_WRAP(x)), int>);
+    CHECK(CX_WRAP(x) == 17);
+}
+
+TEST_CASE("CX_WRAP string_view runtime arg", "[utility]") {
+    auto x = std::string_view{"hello"};
+    STATIC_REQUIRE(std::is_same_v<decltype(CX_WRAP(x)), std::string_view>);
+    CHECK(CX_WRAP(x) == std::string_view{"hello"});
+}
+
+TEST_CASE("CX_WRAP const integral type", "[utility]") {
+    auto const x = 17;
+    STATIC_REQUIRE(stdx::is_cx_value_v<decltype(CX_WRAP(x))>);
+    STATIC_REQUIRE(CX_WRAP(x)() == 17);
+}
+
+TEST_CASE("CX_WRAP constexpr integral type", "[utility]") {
+    constexpr auto x = 17;
+    STATIC_REQUIRE(stdx::is_cx_value_v<decltype(CX_WRAP(x))>);
+    STATIC_REQUIRE(CX_WRAP(x)() == 17);
+}
+
+TEST_CASE("CX_WRAP constexpr non-structural type", "[utility]") {
+    constexpr static auto x = std::string_view{"hello"};
+    STATIC_REQUIRE(stdx::is_cx_value_v<decltype(CX_WRAP(x))>);
+    STATIC_REQUIRE(CX_WRAP(x)() == std::string_view{"hello"});
+}
+
+TEST_CASE("CX_WRAP integer literal", "[utility]") {
+    STATIC_REQUIRE(stdx::is_cx_value_v<decltype(CX_WRAP(17))>);
+    STATIC_REQUIRE(CX_WRAP(17)() == 17);
+}
+
+TEST_CASE("CX_WRAP string literal", "[utility]") {
+    STATIC_REQUIRE(stdx::is_cx_value_v<decltype(CX_WRAP("hello"))>);
+    STATIC_REQUIRE(CX_WRAP("hello")() == std::string_view{"hello"});
+}
+
+TEST_CASE("CX_WRAP existing CX_VALUE", "[utility]") {
+    auto x = CX_VALUE(17);
+    STATIC_REQUIRE(stdx::is_cx_value_v<decltype(CX_WRAP(x))>);
+    STATIC_REQUIRE(CX_WRAP(x)() == 17);
+}
+
+TEST_CASE("CX_WRAP template argument", "[utility]") {
+    []<int x> {
+        STATIC_REQUIRE(stdx::is_cx_value_v<decltype(CX_WRAP(x))>);
+        STATIC_REQUIRE(CX_WRAP(x)() == 17);
+    }.template operator()<17>();
+}
+
+TEST_CASE("CX_WRAP type argument", "[utility]") {
+    STATIC_REQUIRE(stdx::is_cx_value_v<decltype(CX_WRAP(int))>);
+    STATIC_REQUIRE(
+        std::is_same_v<decltype(CX_WRAP(int)()), stdx::type_identity<int>>);
+}
+
 #endif

--- a/test/utility.cpp
+++ b/test/utility.cpp
@@ -271,4 +271,38 @@ TEST_CASE("ct (type)", "[utility]") {
     STATIC_REQUIRE(std::is_same_v<decltype(v), stdx::type_identity<int> const>);
 }
 
+TEST_CASE("is_ct", "[utility]") {
+    constexpr auto x1 = stdx::ct<42>();
+    STATIC_REQUIRE(stdx::is_ct_v<decltype(x1)>);
+    constexpr auto x2 = stdx::ct<int>();
+    STATIC_REQUIRE(stdx::is_ct_v<decltype(x2)>);
+}
+
+TEST_CASE("CT_WRAP", "[utility]") {
+    auto x1 = 17;
+    STATIC_REQUIRE(std::is_same_v<decltype(CT_WRAP(x1)), int>);
+    CHECK(CT_WRAP(x1) == 17);
+
+    auto x2 = stdx::ct<17>();
+    STATIC_REQUIRE(
+        std::is_same_v<decltype(CT_WRAP(x2)), std::integral_constant<int, 17>>);
+    STATIC_REQUIRE(CT_WRAP(x2).value == 17);
+
+    auto const x3 = 17;
+    STATIC_REQUIRE(
+        std::is_same_v<decltype(CT_WRAP(x3)), std::integral_constant<int, 17>>);
+    STATIC_REQUIRE(CT_WRAP(x3).value == 17);
+
+    constexpr static auto x4 = 17;
+    STATIC_REQUIRE(
+        std::is_same_v<decltype(CT_WRAP(x4)), std::integral_constant<int, 17>>);
+    STATIC_REQUIRE(CT_WRAP(x4).value == 17);
+
+    []<auto X>() {
+        STATIC_REQUIRE(std::is_same_v<decltype(CT_WRAP(X)),
+                                      std::integral_constant<int, 17>>);
+        STATIC_REQUIRE(CT_WRAP(X).value == 17);
+    }.template operator()<17>();
+}
+
 #endif


### PR DESCRIPTION
Problem:
- It is useful to have a macro that wraps a potentially-`constexpr`-usable value in `stdx::ct` when possible, to preserve its `constexpr` properties.

Solution:
- Add `CT_WRAP` that does this.

Notes:
- See https://github.com/intel/compile-time-init-build/pull/743 for some parts of this in CIB; this part probably belongs in stdx.