### PR TITLE
:art: Add implicit conversion from `cts_t` to `ct_string`

### DIFF
--- a/include/stdx/ct_format.hpp
+++ b/include/stdx/ct_format.hpp
@@ -35,7 +35,7 @@ template <typename Str, typename Args> struct format_result {
     friend constexpr auto operator+(format_result const &fr)
         requires(decltype(ct_string_convertible())::value)
     {
-        return ct_string{fr.str.value};
+        return +fr.str;
     }
 
     friend constexpr auto operator+(format_result const &) {

--- a/include/stdx/ct_string.hpp
+++ b/include/stdx/ct_string.hpp
@@ -22,7 +22,7 @@ namespace detail {
 template <typename T>
 concept format_convertible = requires(T t) {
     { T::ct_string_convertible() } -> std::same_as<std::true_type>;
-    { ct_string{t.str.value} };
+    { ct_string{+t} };
 };
 } // namespace detail
 
@@ -39,7 +39,7 @@ template <std::size_t N> struct ct_string {
 
     template <detail::format_convertible T>
     // NOLINTNEXTLINE(google-explicit-constructor)
-    CONSTEVAL explicit(false) ct_string(T t) : ct_string(t.str.value) {}
+    CONSTEVAL explicit(false) ct_string(T t) : ct_string(+t) {}
 
     CONSTEVAL explicit(true) ct_string(char const *str, std::size_t sz) {
         for (auto i = std::size_t{}; i < sz; ++i) {
@@ -78,7 +78,7 @@ template <std::size_t N> struct ct_string {
 };
 
 template <detail::format_convertible T>
-ct_string(T) -> ct_string<decltype(std::declval<T>().str.value)::capacity()>;
+ct_string(T) -> ct_string<decltype(+std::declval<T>())::capacity()>;
 
 template <std::size_t N, std::size_t M>
 [[nodiscard]] constexpr auto operator==(ct_string<N> const &lhs,
@@ -142,6 +142,9 @@ template <std::size_t N, std::size_t M>
 template <ct_string S> struct cts_t {
     using value_type = decltype(S);
     constexpr static auto value = S;
+
+    CONSTEVAL static auto ct_string_convertible() -> std::true_type;
+    friend constexpr auto operator+(cts_t const &) { return value; }
 };
 
 template <ct_string X, ct_string Y>

--- a/test/ct_string.cpp
+++ b/test/ct_string.cpp
@@ -150,3 +150,12 @@ TEST_CASE("ct (ct_string)", "[ct_string]") {
     constexpr auto v2 = stdx::ct<"Hello"_cts>();
     STATIC_REQUIRE(v2 == "Hello"_ctst);
 }
+
+namespace {
+template <stdx::ct_string> constexpr auto conversion_success = true;
+} // namespace
+
+TEST_CASE("cts_t can implicitly convert to ct_string", "[ct_string]") {
+    using namespace stdx::ct_string_literals;
+    STATIC_REQUIRE(conversion_success<"Hello"_ctst>);
+}


### PR DESCRIPTION
Problem:
- Maintaining the constexpr natured of a `ct_string` means passing around `cts_t` values a lot, but template parameters are often specified as `ct_strings`. It's annoying to have to write `str.value` rather than just `str` everywhere.

Solution:
- Allow a `cts_t` to implicitly convert to the corresponding `ct_string`.