### PR TITLE
:art: Make concatenating `ct_string` and `cts_t` easier

### DIFF
--- a/include/stdx/ct_string.hpp
+++ b/include/stdx/ct_string.hpp
@@ -157,6 +157,16 @@ constexpr auto operator+(cts_t<X>, cts_t<Y>) {
     return cts_t<X + Y>{};
 }
 
+template <std::size_t N, ct_string S>
+[[nodiscard]] constexpr auto operator+(ct_string<N> const &lhs, cts_t<S> rhs) {
+    return lhs + +rhs;
+}
+
+template <ct_string S, std::size_t N>
+[[nodiscard]] constexpr auto operator+(cts_t<S> lhs, ct_string<N> const &rhs) {
+    return +lhs + rhs;
+}
+
 namespace detail {
 template <std::size_t N> struct ct_helper<ct_string<N>>;
 } // namespace detail

--- a/test/ct_string.cpp
+++ b/test/ct_string.cpp
@@ -159,3 +159,9 @@ TEST_CASE("cts_t can implicitly convert to ct_string", "[ct_string]") {
     using namespace stdx::ct_string_literals;
     STATIC_REQUIRE(conversion_success<"Hello"_ctst>);
 }
+
+TEST_CASE("operator+ works to concat cts_t and ct_string", "[ct_string]") {
+    using namespace stdx::ct_string_literals;
+    STATIC_REQUIRE("Hello"_ctst + " world"_cts == "Hello world"_cts);
+    STATIC_REQUIRE("Hello"_cts + " world"_ctst == "Hello world"_cts);
+}


### PR DESCRIPTION
Problem:
- `ct_string` and `cts_t` are platonically the same, so it makes sense to be able to concatenate them.

Solution:
- Enable binary `operator+` working with `ct_string` and `cts_t` operands.