### PR TITLE
:children_crossing: Improve help message for `format_result` conversion

### DIFF
--- a/include/stdx/ct_format.hpp
+++ b/include/stdx/ct_format.hpp
@@ -41,7 +41,7 @@ template <typename Str, typename Args> struct format_result {
     }
 
     friend constexpr auto operator+(format_result const &) {
-        static_assert(decltype(ct_string_convertible())::value,
+        static_assert(always_false_v<format_result>,
                       "Unary operator+ can only be used on a format_result "
                       "without any runtime arguments");
     }


### PR DESCRIPTION
Problem:
- When converting a `format_result` to a `ct_string`, if it has runtime format arguments, the message does not make the contents of the `format_result` clear.

Solution:
- Use a better assertion.

Note:
- We cannot use a formatted `STATIC_ASSERT` here of course, because `ct_format` provides the mechanism for `STATIC_ASSERT`.