### PR TITLE
:bug: Fix `STATIC_ASSERT` capture spec

### DIFF
--- a/include/stdx/static_assert.hpp
+++ b/include/stdx/static_assert.hpp
@@ -29,7 +29,7 @@ template <bool B> constexpr auto ct_check = ct_check_t<B>{};
 
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define STATIC_ASSERT(cond, ...)                                               \
-    []<bool B>() -> bool {                                                     \
+    [&]<bool B>() -> bool {                                                    \
         STDX_PRAGMA(diagnostic push)                                           \
         STDX_PRAGMA(diagnostic ignored "-Wunknown-warning-option")             \
         STDX_PRAGMA(diagnostic ignored "-Wc++26-extensions")                   \
@@ -43,7 +43,7 @@ template <bool B> constexpr auto ct_check = ct_check_t<B>{};
 
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define STATIC_ASSERT(cond, ...)                                               \
-    []<bool B>() -> bool {                                                     \
+    [&]<bool B>() -> bool {                                                    \
         constexpr auto S = STDX_CT_FORMAT(__VA_ARGS__);                        \
         stdx::ct_check<B>.template emit<S>();                                  \
         return B;                                                              \


### PR DESCRIPTION
Problem:
- Sometimes, `STATIC_ASSERT` may need to capture variables.

Solution:
- Use `[&]` as the capture spec in the `STATIC_ASSERT` lambda expressions.