### PR TITLE
:art: `CX_WRAP` should leave empty types alone

### DIFF
--- a/include/stdx/utility.hpp
+++ b/include/stdx/utility.hpp
@@ -297,7 +297,8 @@ constexpr auto cx_detect1(auto) { return 0; }
         STDX_PRAGMA(diagnostic push)                                           \
         STDX_PRAGMA(diagnostic ignored "-Wold-style-cast")                     \
         if constexpr (::stdx::is_cx_value_v<                                   \
-                          std::invoke_result_t<decltype(f)>>) {                \
+                          std::invoke_result_t<decltype(f)>> or                \
+                      std::is_empty_v<std::invoke_result_t<decltype(f)>>) {    \
             return f();                                                        \
         } else if constexpr (CX_DETECT(X)) {                                   \
             if constexpr (decltype(::stdx::cxv_detail::is_type<                \

--- a/test/ct_format.cpp
+++ b/test/ct_format.cpp
@@ -298,6 +298,6 @@ TEST_CASE("FORMAT a constexpr string_view argument", "[ct_format]") {
 }
 
 TEST_CASE("FORMAT an integral_constant argument", "[ct_format]") {
-    constexpr static auto I = std::integral_constant<int, 17>{};
+    auto I = std::integral_constant<int, 17>{};
     STATIC_REQUIRE(STDX_CT_FORMAT("Hello {}", I) == "Hello 17"_fmt_res);
 }

--- a/test/utility.cpp
+++ b/test/utility.cpp
@@ -364,4 +364,9 @@ TEST_CASE("CX_WRAP type argument", "[utility]") {
         std::is_same_v<decltype(CX_WRAP(int)()), stdx::type_identity<int>>);
 }
 
+TEST_CASE("CX_WRAP integral_constant arg", "[utility]") {
+    auto x = std::integral_constant<int, 17>{};
+    STATIC_REQUIRE(std::is_same_v<decltype(CX_WRAP(x)), decltype(x)>);
+    CHECK(CX_WRAP(x)() == 17);
+}
 #endif


### PR DESCRIPTION
Problem:
- `CX_WRAP` sometimes (on GCC) wraps empty types. In fact empty types (like `std::integral_constant` specializations) can be used as `constexpr` values just fine even when the "value" is not marked `constexpr`.

Solution:
- Detect empty types in `CX_WRAP` and leave them alone.