### PR TITLE
:bug: Fix `CX_WRAP` for empty types

### DIFF
--- a/test/utility.cpp
+++ b/test/utility.cpp
@@ -364,6 +364,13 @@ TEST_CASE("CX_WRAP type argument", "[utility]") {
         std::is_same_v<decltype(CX_WRAP(int)()), stdx::type_identity<int>>);
 }
 
+TEST_CASE("CX_WRAP empty type argument", "[utility]") {
+    using X = std::integral_constant<int, 17>;
+    STATIC_REQUIRE(stdx::is_cx_value_v<decltype(CX_WRAP(X))>);
+    STATIC_REQUIRE(
+        std::is_same_v<decltype(CX_WRAP(X)()), stdx::type_identity<X>>);
+}
+
 TEST_CASE("CX_WRAP integral_constant arg", "[utility]") {
     auto x = std::integral_constant<int, 17>{};
     STATIC_REQUIRE(std::is_same_v<decltype(CX_WRAP(x)), decltype(x)>);


### PR DESCRIPTION
Problem:
- When `CX_WRAP` wraps empty types, it doesn't turn them into `type_identity<T>`.

Solution:
- Move the emptiness check after the type check.