### PR TITLE
:bug: Fix `CX_WRAP` for expressions

### DIFF
--- a/test/ct_format.cpp
+++ b/test/ct_format.cpp
@@ -301,3 +301,18 @@ TEST_CASE("FORMAT an integral_constant argument", "[ct_format]") {
     auto I = std::integral_constant<int, 17>{};
     STATIC_REQUIRE(STDX_CT_FORMAT("Hello {}", I) == "Hello 17"_fmt_res);
 }
+
+#ifdef __clang__
+namespace {
+struct expression_test {
+    int f(int x) { return x; }
+};
+} // namespace
+
+TEST_CASE("FORMAT non-constexpr expression", "[utility]") {
+    auto x = 17;
+    constexpr auto expected =
+        stdx::format_result{"Hello {}"_ctst, stdx::make_tuple(17)};
+    CHECK(STDX_CT_FORMAT("Hello {}", expression_test{}.f(x)) == expected);
+}
+#endif

--- a/test/utility.cpp
+++ b/test/utility.cpp
@@ -376,4 +376,20 @@ TEST_CASE("CX_WRAP integral_constant arg", "[utility]") {
     STATIC_REQUIRE(std::is_same_v<decltype(CX_WRAP(x)), decltype(x)>);
     CHECK(CX_WRAP(x)() == 17);
 }
+
+#ifdef __clang__
+namespace {
+struct expression_test {
+    int f(int x) { return x; }
+};
+} // namespace
+
+TEST_CASE("CX_WRAP non-constexpr expression", "[utility]") {
+    auto x = 17;
+    STATIC_REQUIRE(
+        std::is_same_v<decltype(CX_WRAP(expression_test{}.f(x))), int>);
+    CHECK(CX_WRAP(expression_test{}.f(x)) == 17);
+}
+#endif
+
 #endif


### PR DESCRIPTION
Problem:
- When `CX_WRAP` wraps expressions, it can cause a compiler error with `is_type` and `type_of`.

Solution:
- Use `__typeof__` to get around this.