### PR TITLE
:sparkles: Add terse udls for size conversion

### DIFF
--- a/docs/utility.adoc
+++ b/docs/utility.adoc
@@ -172,6 +172,19 @@ const auto sz = stdx::sized<T>{K}.template in<U>();
 The `sized` conversion works either from larger type to smaller type, or the
 other way around. Or even where the source and destination types are the same.
 
+==== Super-terse size conversion
+
+Size conversion is conceptually a simple thing, and preferably clear but terse.
+To achieve this, with a size known at compile-time we can use a UDL:
+
+[source,cpp]
+----
+using namespace std::literals;
+const auto sz = 42_z8->z32; // 42 bytes in std::uint32_t = 11
+----
+
+With any combination of `z8`, `z16`, `z32`, `z64`.
+
 === `type_map`
 
 `type_map` is a structure designed to allow compile-time lookups of types or

--- a/include/stdx/utility.hpp
+++ b/include/stdx/utility.hpp
@@ -3,6 +3,7 @@
 #include <stdx/compiler.hpp>
 #include <stdx/concepts.hpp>
 #include <stdx/type_traits.hpp>
+#include <stdx/udls.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -136,6 +137,33 @@ using sized8 = sized<std::uint8_t>;
 using sized16 = sized<std::uint16_t>;
 using sized32 = sized<std::uint32_t>;
 using sized64 = sized<std::uint64_t>;
+
+template <typename T, std::size_t N> struct udl_sized {
+    template <typename U = std::uint8_t>
+    constexpr static auto in = detail::size_conversion<T, U>(N);
+
+    constexpr static auto z8 = in<std::uint8_t>;
+    constexpr static auto z16 = in<std::uint16_t>;
+    constexpr static auto z32 = in<std::uint32_t>;
+    constexpr static auto z64 = in<std::uint64_t>;
+
+    constexpr auto operator->() const -> udl_sized const * { return this; }
+};
+
+inline namespace literals {
+template <char... Chars> CONSTEVAL_UDL auto operator""_z8() {
+    return udl_sized<std::uint8_t, parse_literal<std::size_t, Chars...>()>{};
+}
+template <char... Chars> CONSTEVAL_UDL auto operator""_z16() {
+    return udl_sized<std::uint16_t, parse_literal<std::size_t, Chars...>()>{};
+}
+template <char... Chars> CONSTEVAL_UDL auto operator""_z32() {
+    return udl_sized<std::uint32_t, parse_literal<std::size_t, Chars...>()>{};
+}
+template <char... Chars> CONSTEVAL_UDL auto operator""_z64() {
+    return udl_sized<std::uint64_t, parse_literal<std::size_t, Chars...>()>{};
+}
+} // namespace literals
 
 namespace cxv_detail {
 struct from_any {

--- a/test/utility.cpp
+++ b/test/utility.cpp
@@ -159,6 +159,21 @@ TEST_CASE("sized<T> in (upsize, mod > 1)", "[utility]") {
     STATIC_REQUIRE(stdx::sized<U>{2}.in<T>() == 2);
 }
 
+TEST_CASE("terse size conversion with UDLs", "[utility]") {
+    using namespace stdx::literals;
+    STATIC_REQUIRE(1_z8->z8 == 1);
+    STATIC_REQUIRE(2_z8->z16 == 1);
+    STATIC_REQUIRE(4_z8->z32 == 1);
+    STATIC_REQUIRE(8_z8->z64 == 1);
+
+    STATIC_REQUIRE(1_z16->z8 == 2);
+    STATIC_REQUIRE(1_z32->z8 == 4);
+    STATIC_REQUIRE(1_z64->z8 == 8);
+
+    STATIC_REQUIRE(1_z64->in<std::uint16_t> == 4);
+    STATIC_REQUIRE(1_z64->in<std::uint32_t> == 2);
+}
+
 TEST_CASE("CX_VALUE structural value", "[utility]") {
     auto x = CX_VALUE(42);
     STATIC_REQUIRE(x() == 42);


### PR DESCRIPTION
Problem:
- It's wordy to type `stdx::sized<std::uint8_t>{42}.in<std::uint32_t>();`.

Solution:
- Instead, allow `42_z8->z32;`