### PR TITLE
:sparkles: Expose types in `type_pair`

### DIFF
--- a/include/stdx/utility.hpp
+++ b/include/stdx/utility.hpp
@@ -31,7 +31,12 @@ template <auto V> struct value_t {
 };
 } // namespace detail
 
-template <typename K, typename V> struct type_pair {};
+template <typename K, typename V> struct type_pair {
+    using first_type = K;
+    using second_type = V;
+    using key_type = K;
+    using value_type = V;
+};
 template <typename K, typename V> using tt_pair = type_pair<K, V>;
 template <auto K, typename V> using vt_pair = tt_pair<detail::value_t<K>, V>;
 template <typename K, auto V> using tv_pair = tt_pair<K, detail::value_t<V>>;


### PR DESCRIPTION
Problem:
- Iterating a `type_map` is fine using `template_for_each` but it's difficult to extract the first and second (or key and value) types.

Solution:
- Add `first_type` and `second_type` to `type_pair`.
- Add `key_type` and `value_type` to `type_pair`.