### PR TITLE
:arrow_up: Update `.gitignore` for mermaid config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ __pycache__
 .hypothesis
 requirements.txt
 docs/puppeteer_config.json
+docs/mermaid.conf


### PR DESCRIPTION
Problem:
- We receive docs/mermaid.conf from the CICD repo upstream, but it's not in the `.gitignore` file.

Solution:
- Add it to the `.gitignore` file.