### PR TITLE
:arrow_up: :construction_worker: Update sanitizer workflow for clang-21

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -335,8 +335,8 @@ jobs:
           - compiler: clang
             cc: "clang"
             cxx: "clang++"
-            install: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 20
-            toolchain_root: "/usr/lib/llvm-20"
+            install: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 21
+            toolchain_root: "/usr/lib/llvm-21"
           - compiler: gcc
             cc: "gcc-14"
             cxx: "g++-14"


### PR DESCRIPTION
Problem:
- Sanitizer workflows are still running on clang-20.

Solution:
- Update to clang-21.