### PR TITLE
:white_check_mark: Add GCC to usage tests

### DIFF
--- a/.github/workflows/usage_test.yml
+++ b/.github/workflows/usage_test.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   DEBIAN_FRONTEND: noninteractive
-  USER_LLVM_VERSION: 14
+  CMAKE_GENERATOR: Ninja
   USER_CMAKE_VERSION: 3.25
 
 jobs:
@@ -21,12 +21,26 @@ jobs:
       fail-fast: false
       matrix:
         cpp_implementation: [FREESTANDING, HOSTED]
+        compiler: [clang, gcc]
+        include:
+          - compiler: clang
+            cc: "clang"
+            cxx: "clang++"
+            install: sudo apt update && sudo apt install -y clang-14
+            toolchain_root: "/usr/lib/llvm-14"
+          - compiler: gcc
+            cc: "gcc-12"
+            cxx: "g++-12"
+            install: sudo apt update && sudo apt install -y gcc-12 g++-12
+            toolchain_root: "/usr"
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Install compiler
-        run: sudo apt update && sudo apt-get install -y clang-${{env.USER_LLVM_VERSION}}
+        run: |
+          ${{ matrix.install }}
+          sudo apt install -y ninja-build
 
       - name: Install cmake
         run: |
@@ -34,10 +48,10 @@ jobs:
           pip3 install --force cmake==${{env.USER_CMAKE_VERSION}}
 
       - name: Configure CMake
-        working-directory: ${{github.workspace}}/usage_test
         env:
-          CC: "/usr/lib/llvm-${{env.USER_LLVM_VERSION}}/bin/clang"
-          CXX: "/usr/lib/llvm-${{env.USER_LLVM_VERSION}}/bin/clang++"
+          CC: ${{matrix.toolchain_root}}/bin/${{matrix.cc}}
+          CXX: ${{matrix.toolchain_root}}/bin/${{matrix.cxx}}
+        working-directory: ${{github.workspace}}/usage_test
         run: ~/.local/bin/cmake -B build -DCPP_IMPLEMENTATION=${{matrix.cpp_implementation}}
 
       - name: Build


### PR DESCRIPTION
Problem:
- Usage tests only use clang.

Solution:
- Add GCC to usage tests.