### PR TITLE
:bug: Fix `STATIC_ASSERT` in non-local context

### DIFF
--- a/include/stdx/static_assert.hpp
+++ b/include/stdx/static_assert.hpp
@@ -31,7 +31,7 @@ template <bool B> constexpr auto ct_check = ct_check_t<B>{};
 
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define STATIC_ASSERT(cond, ...)                                               \
-    [&]<bool B>() -> bool {                                                    \
+    []<bool B>() -> bool {                                                     \
         STDX_PRAGMA(diagnostic push)                                           \
         STDX_PRAGMA(diagnostic ignored "-Wunknown-warning-option")             \
         STDX_PRAGMA(diagnostic ignored "-Wc++26-extensions")                   \
@@ -45,7 +45,7 @@ template <bool B> constexpr auto ct_check = ct_check_t<B>{};
 
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define STATIC_ASSERT(cond, ...)                                               \
-    [&]<bool B>() -> bool {                                                    \
+    []<bool B>() -> bool {                                                     \
         constexpr auto S = STDX_CT_FORMAT(__VA_ARGS__);                        \
         stdx::detail::ct_check<B>.template emit<S>();                          \
         return B;                                                              \

--- a/test/fail/static_assert.cpp
+++ b/test/fail/static_assert.cpp
@@ -5,6 +5,8 @@
 constexpr auto msg =
     stdx::ct_string{"01234567890123456789012345678901234567890123456789"};
 
+static_assert(STATIC_ASSERT(true, "not emitted"));
+
 auto main() -> int {
     static_assert(STATIC_ASSERT(true, "not emitted"));
     STATIC_ASSERT(false, msg);

--- a/test/fail/static_assert_format.cpp
+++ b/test/fail/static_assert_format.cpp
@@ -3,6 +3,8 @@
 
 // EXPECT: hello world int 123
 
+static_assert(STATIC_ASSERT(true, "hello {} {} {}", "world", int, 42));
+
 template <typename T> constexpr auto f() {
     STATIC_ASSERT(false, "hello {} {} {}", "world", T, 123);
 }


### PR DESCRIPTION
Problem:
- The lambda used in `STATIC_ASSERT` has a default capture spec, which is not allowed in non-local contexts.

Solution:
- Remove the capture spec. It's not needed.