### PR TITLE
:bug: Fix `ct_capacity`, conversion warnings in freestanding `fmt`

### DIFF
--- a/include/stdx/detail/fmt.hpp
+++ b/include/stdx/detail/fmt.hpp
@@ -77,7 +77,7 @@ CONSTEVAL auto formatted_size(fmt_spec s, I i) -> std::size_t {
 
         while (i != 0) {
             ++sz;
-            i /= s.base;
+            i /= static_cast<I>(s.base);
         }
         return sz;
     }
@@ -131,8 +131,8 @@ CONSTEVAL auto format_to(fmt_spec s, It dest, I i) -> It {
 
         auto b = dest;
         while (i != 0) {
-            auto digit = to_digit(abs(i % s.base));
-            i /= s.base;
+            auto digit = to_digit(abs(i % static_cast<I>(s.base)));
+            i /= static_cast<I>(s.base);
             *dest++ = digit;
         }
 

--- a/include/stdx/iterator.hpp
+++ b/include/stdx/iterator.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stdx/compiler.hpp>
 #include <stdx/type_traits.hpp>
 
 #include <array>
@@ -25,7 +26,8 @@ constexpr auto ct_capacity_v<std::array<T, N>> = N;
 
 template <typename T> constexpr auto ct_capacity_v<T const> = ct_capacity_v<T>;
 
-template <typename T> constexpr auto ct_capacity(T &&) -> std::size_t {
+template <typename T>
+CONSTEVAL auto ct_capacity([[maybe_unused]] T &&) -> std::size_t {
     return ct_capacity_v<remove_cvref_t<T>>;
 }
 

--- a/test/ct_format.cpp
+++ b/test/ct_format.cpp
@@ -333,7 +333,7 @@ TEST_CASE("FORMAT a constexpr string_view argument", "[ct_format]") {
 }
 
 TEST_CASE("FORMAT an integral_constant argument", "[ct_format]") {
-    auto I = std::integral_constant<int, 17>{};
+    auto I = std::integral_constant<unsigned int, 17u>{};
     STATIC_REQUIRE(STDX_CT_FORMAT("Hello {}", I) == "Hello 17"_fmt_res);
 }
 


### PR DESCRIPTION
Problem:
- `ct_capacity` can occur at runtime even though it is always decidable at compile-time.
- There are some conversion warnings in the freestanding `fmt` code.

Solution:
- Mark `ct_capacity` `consteval`.
- Silence the conversion warnings.