### PR TITLE
:sparkles: Add reverse lookup to compile-time type maps

### DIFF
--- a/docs/utility.adoc
+++ b/docs/utility.adoc
@@ -242,6 +242,27 @@ type arguments which are defaults returned when lookup fails. In the case of
 mapping to values, the `*_lookup_v` aliases have optional third NTTP arguments
 in the same role.
 
+Any of these type maps can also use reverse lookup, if values are unique:
+
+[source,cpp]
+----
+// a type-type map that uses reverse_type_lookup_t
+using M1 = stdx::type_map<stdx::tt_pair<A, X>, stdx::tt_pair<B, Y>>;
+using T1 = stdx::reverse_type_lookup_t<M1, X>; // A
+
+// a type-value map that uses reverse_value_lookup_t
+using M2 = stdx::type_map<stdx::tv_pair<A, 0>, stdx::tv_pair<B, 1>>;
+using T2 = stdx::reverse_value_lookup_t<M2, 0>; // A
+
+// a value-type map that uses reverse_type_lookup_v
+using M3 = stdx::type_map<stdx::vt_pair<0, X>, stdx::vt_pair<1, Y>>;
+constexpr auto v3 = stdx::reverse_type_lookup_v<M3, X>; // 0
+
+// a value-value map that uses reverse_value_lookup_v
+using M4 = stdx::type_map<stdx::vv_pair<0, 42>, stdx::vv_pair<1, 17>>;
+constexpr auto v4 = stdx::reverse_value_lookup_v<M4, 42>; // 0
+----
+
 === `unreachable`
 
 `unreachable` is an implementation of

--- a/include/stdx/utility.hpp
+++ b/include/stdx/utility.hpp
@@ -50,14 +50,28 @@ template <typename K, typename Default>
 constexpr static auto lookup(...) -> Default;
 template <typename K, typename Default, typename V>
 constexpr static auto lookup(type_pair<K, V>) -> V;
+
+template <typename V, typename Default>
+constexpr static auto reverse_lookup(...) -> Default;
+template <typename V, typename Default, typename K>
+constexpr static auto reverse_lookup(type_pair<K, V>) -> K;
 } // namespace detail
 
 template <typename M, typename K, typename Default = void>
 using type_lookup_t = decltype(detail::lookup<K, Default>(std::declval<M>()));
 
+template <typename M, typename V, typename Default = void>
+using reverse_type_lookup_t =
+    decltype(detail::reverse_lookup<V, Default>(std::declval<M>()));
+
 template <typename M, auto K, typename Default = void>
 using value_lookup_t =
     decltype(detail::lookup<detail::value_t<K>, Default>(std::declval<M>()));
+
+template <typename M, auto V, typename Default = void>
+using reverse_value_lookup_t =
+    decltype(detail::reverse_lookup<detail::value_t<V>, Default>(
+        std::declval<M>()));
 
 namespace detail {
 template <typename T>
@@ -70,10 +84,23 @@ constexpr static auto type_lookup_v =
               decltype(detail::lookup<K, void>(std::declval<M>())),
               detail::value_t<Default>>::value;
 
+template <typename M, typename V, auto Default = 0>
+constexpr static auto reverse_type_lookup_v =
+    type_or_t<detail::is_not_void,
+              decltype(detail::reverse_lookup<V, void>(std::declval<M>())),
+              detail::value_t<Default>>::value;
+
 template <typename M, auto K, auto Default = 0>
 constexpr static auto value_lookup_v =
     type_or_t<detail::is_not_void,
               decltype(detail::lookup<detail::value_t<K>, void>(
+                  std::declval<M>())),
+              detail::value_t<Default>>::value;
+
+template <typename M, auto V, auto Default = 0>
+constexpr static auto reverse_value_lookup_v =
+    type_or_t<detail::is_not_void,
+              decltype(detail::reverse_lookup<detail::value_t<V>, void>(
                   std::declval<M>())),
               detail::value_t<Default>>::value;
 

--- a/test/type_map.cpp
+++ b/test/type_map.cpp
@@ -57,3 +57,52 @@ TEST_CASE("look up value not in map (by value)", "[type map]") {
     STATIC_REQUIRE(stdx::value_lookup_v<M, 2> == 0);
     STATIC_REQUIRE(stdx::value_lookup_v<M, 2, 3> == 3);
 }
+
+TEST_CASE("reverse look up type in map", "[type map]") {
+    using M = stdx::type_map<stdx::type_pair<A, X>, stdx::type_pair<B, Y>>;
+    STATIC_REQUIRE(std::is_same_v<stdx::reverse_type_lookup_t<M, X>, A>);
+    STATIC_REQUIRE(std::is_same_v<stdx::reverse_type_lookup_t<M, Y>, B>);
+}
+
+TEST_CASE("reverse look up type not in map", "[type map]") {
+    using M = stdx::type_map<stdx::type_pair<A, X>, stdx::type_pair<B, Y>>;
+    STATIC_REQUIRE(std::is_same_v<stdx::reverse_type_lookup_t<M, Z>, void>);
+    STATIC_REQUIRE(std::is_same_v<stdx::reverse_type_lookup_t<M, Z, int>, int>);
+}
+
+TEST_CASE("reverse look up type in map (by value)", "[type map]") {
+    using M = stdx::type_map<stdx::tv_pair<X, 0>, stdx::tv_pair<Y, 1>>;
+    STATIC_REQUIRE(std::is_same_v<stdx::reverse_value_lookup_t<M, 0>, X>);
+    STATIC_REQUIRE(std::is_same_v<stdx::reverse_value_lookup_t<M, 1>, Y>);
+}
+
+TEST_CASE("reverse look up type not in map (by value)", "[type map]") {
+    using M = stdx::type_map<stdx::tv_pair<X, 0>, stdx::tv_pair<Y, 1>>;
+    STATIC_REQUIRE(std::is_same_v<stdx::reverse_value_lookup_t<M, 2>, void>);
+    STATIC_REQUIRE(
+        std::is_same_v<stdx::reverse_value_lookup_t<M, 2, int>, int>);
+}
+
+TEST_CASE("reverse look up value in map (by type)", "[type map]") {
+    using M = stdx::type_map<stdx::vt_pair<0, A>, stdx::vt_pair<1, B>>;
+    STATIC_REQUIRE(stdx::reverse_type_lookup_v<M, A> == 0);
+    STATIC_REQUIRE(stdx::reverse_type_lookup_v<M, B> == 1);
+}
+
+TEST_CASE("reverse look up value not in map (by type)", "[type map]") {
+    using M = stdx::type_map<stdx::vt_pair<0, A>, stdx::vt_pair<1, B>>;
+    STATIC_REQUIRE(stdx::reverse_type_lookup_v<M, Z> == 0);
+    STATIC_REQUIRE(stdx::reverse_type_lookup_v<M, Z, 2> == 2);
+}
+
+TEST_CASE("reverse look up value in map (by value)", "[type map]") {
+    using M = stdx::type_map<stdx::vv_pair<0, 10>, stdx::vv_pair<1, 11>>;
+    STATIC_REQUIRE(stdx::reverse_value_lookup_v<M, 10> == 0);
+    STATIC_REQUIRE(stdx::reverse_value_lookup_v<M, 11> == 1);
+}
+
+TEST_CASE("reverse look up value not in map (by value)", "[type map]") {
+    using M = stdx::type_map<stdx::vv_pair<0, 10>, stdx::vv_pair<1, 11>>;
+    STATIC_REQUIRE(stdx::reverse_value_lookup_v<M, 2> == 0);
+    STATIC_REQUIRE(stdx::reverse_value_lookup_v<M, 2, 3> == 3);
+}


### PR DESCRIPTION
Problem:
- `type_map` lookup is useful, but it's also sometimes useful to have reverse lookup. This normally means something like generating two maps.

Solution:
- Add reverse lookup.
- Because lookup works by function overload resolution, assuming the values are unique, reverse lookup is just as easy as normal forward lookup.