### PR TITLE
:sparkles: Add `same_template_as`

### DIFF
--- a/docs/concepts.adoc
+++ b/docs/concepts.adoc
@@ -107,3 +107,14 @@ private:
   }
 };
 ----
+
+=== `same_template_as`
+
+`same_template_as` is true when two types are specializations of the same base
+template.
+
+[source,cpp]
+----
+stdx::same_template_as<std::vector<int>, std::vector<float>>; // true
+stdx::same_template_as<std::vector<int>, std::list<int>>;     // false
+----

--- a/docs/type_traits.adoc
+++ b/docs/type_traits.adoc
@@ -97,10 +97,21 @@ stdx::is_function_object_v<decltype(lam)>;       // true
 stdx::is_function_object_v<decltype(gen_lam)>;   // true
 ----
 
+=== `is_same_template_v`
+
+`is_same_template_v` is a variable template that detects whether two types
+are specializations of the same base template.
+
+[source,cpp]
+----
+stdx::is_same_template_v<std::vector<int>, std::vector<float>>; // true
+stdx::is_same_template_v<std::vector<int>, std::list<int>>;     // false
+----
+
 === `is_same_unqualified_v`
 
-`is_same_unqualified_v` is a variable template that detects whether a two types
-are the same are removing top-level cv-qualifications and references, if any.
+`is_same_unqualified_v` is a variable template that detects whether two types
+are the same after removing top-level cv-qualifications and references, if any.
 
 [source,cpp]
 ----

--- a/include/stdx/concepts.hpp
+++ b/include/stdx/concepts.hpp
@@ -110,6 +110,9 @@ template <typename T> constexpr auto structural = is_structural_v<T>;
 
 template <typename T> constexpr auto complete = is_complete_v<T>;
 
+template <typename T, typename U>
+constexpr auto same_template_as = is_same_template_v<T, U>;
+
 #else
 
 // After C++20, we can define concepts that are lacking in the library
@@ -199,6 +202,9 @@ concept structural = is_structural_v<T>;
 template <typename T>
 concept complete = is_complete_v<T>;
 
+template <typename T, typename U>
+concept same_template_as = is_same_template_v<T, U>;
+
 #endif
 
 } // namespace v1
@@ -241,6 +247,9 @@ concept structural = is_structural_v<T>;
 
 template <typename T>
 concept complete = is_complete_v<T>;
+
+template <typename T, typename U>
+concept same_template_as = is_same_template_v<T, U>;
 
 template <typename T, typename... Us>
 constexpr auto same_any = (... or same_as<T, Us>);

--- a/include/stdx/ct_conversions.hpp
+++ b/include/stdx/ct_conversions.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
 #include <stdx/compiler.hpp>
-#include <stdx/type_traits.hpp>
 
-#include <cstddef>
 #include <string_view>
 
 namespace stdx {
 inline namespace v1 {
+template <typename...> constexpr bool always_false_v = false;
+
 template <typename Tag>
 CONSTEVAL static auto type_as_string() -> std::string_view {
 #ifdef __clang__
@@ -23,6 +23,13 @@ CONSTEVAL static auto type_as_string() -> std::string_view {
 
     constexpr auto lhs = function_name.rfind('=', rhs) + 2;
     return function_name.substr(lhs, rhs - lhs + 1);
+}
+
+template <typename T>
+CONSTEVAL static auto template_base() -> std::string_view {
+    constexpr auto t = stdx::type_as_string<T>();
+    constexpr auto rhs = t.find('<');
+    return t.substr(0, rhs);
 }
 
 template <auto Value>

--- a/include/stdx/type_traits.hpp
+++ b/include/stdx/type_traits.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdx/compiler.hpp>
+#include <stdx/ct_conversions.hpp>
 
 #include <boost/mp11/algorithm.hpp>
 
@@ -41,8 +42,6 @@ using conditional_t = typename detail::conditional<B>::template choice_t<T, U>;
 
 template <template <typename...> typename P, typename X, typename Y = void>
 using type_or_t = conditional_t<P<X>::value, X, Y>;
-
-template <typename...> constexpr bool always_false_v = false;
 
 template <typename T>
 constexpr bool is_function_v =
@@ -274,5 +273,8 @@ STDX_PRAGMA(diagnostic pop)
 template <typename T, typename = void> constexpr auto is_complete_v = false;
 template <typename T>
 constexpr auto is_complete_v<T, detail::void_v<sizeof(T)>> = true;
+
+template <typename T, typename U>
+constexpr auto is_same_template_v = template_base<T>() == template_base<U>();
 } // namespace v1
 } // namespace stdx

--- a/test/concepts.cpp
+++ b/test/concepts.cpp
@@ -172,13 +172,23 @@ struct non_structural {
 };
 } // namespace
 
-TEST_CASE("structural", "[type_traits]") {
+TEST_CASE("structural", "[concepts]") {
     STATIC_REQUIRE(stdx::structural<int>);
     STATIC_REQUIRE(not stdx::structural<non_structural>);
 }
 
-TEST_CASE("complete", "[type_traits]") {
+TEST_CASE("complete", "[concepts]") {
     struct incomplete;
     STATIC_REQUIRE(stdx::complete<int>);
     STATIC_REQUIRE(not stdx::complete<incomplete>);
+}
+
+namespace {
+template <typename> struct unary_t {};
+template <typename...> struct variadic_t {};
+} // namespace
+
+TEST_CASE("same_template_as", "[concepts]") {
+    STATIC_REQUIRE(stdx::same_template_as<unary_t<int>, unary_t<void>>);
+    STATIC_REQUIRE(not stdx::same_template_as<unary_t<int>, variadic_t<void>>);
 }

--- a/test/ct_conversions.cpp
+++ b/test/ct_conversions.cpp
@@ -14,6 +14,19 @@ TEST_CASE("type as string", "[ct_conversion]") {
     STATIC_REQUIRE(stdx::type_as_string<incomplete>() == "incomplete"sv);
 }
 
+template <typename T> struct type_template;
+
+template <auto T> struct value_template;
+
+TEST_CASE("template base", "[ct_conversion]") {
+    using namespace std::string_view_literals;
+    STATIC_REQUIRE(stdx::template_base<type_template<int>>() ==
+                   "type_template"sv);
+    STATIC_REQUIRE(stdx::template_base<value_template<42>>() ==
+                   "value_template"sv);
+    STATIC_REQUIRE(stdx::template_base<int>() == "int"sv);
+}
+
 namespace {
 enum A { X };
 enum struct B { Y };

--- a/test/type_traits.cpp
+++ b/test/type_traits.cpp
@@ -275,3 +275,9 @@ TEST_CASE("is_complete_v", "[type_traits]") {
     STATIC_REQUIRE(stdx::is_complete_v<int>);
     STATIC_REQUIRE(not stdx::is_complete_v<incomplete>);
 }
+
+TEST_CASE("is_same_template_v", "[type_traits]") {
+    STATIC_REQUIRE(stdx::is_same_template_v<unary_t<int>, unary_t<void>>);
+    STATIC_REQUIRE(
+        not stdx::is_same_template_v<unary_t<int>, variadic_t<void>>);
+}


### PR DESCRIPTION
Problem:
- It's sometimes useful to know if two types specialize the same base template.

Solution:
- Add concept: `same_template_as<T, U>` and type trait: `is_same_template_v<T, U>`.
