### PR TITLE
:sparkles: Add `unary_plus`

### DIFF
--- a/docs/functional.adoc
+++ b/docs/functional.adoc
@@ -34,3 +34,12 @@ v.emplace(0, stdx::with_result_of{make_S}); // this constructs S in-place thanks
 
 `with_result_of` can help to achieve in-place construction, effectively by deferring
 evaluation of function arguments.
+
+=== `unary_plus`
+
+`unary_plus` is a function object like
+https://en.cppreference.com/w/cpp/utility/functional/negate.html[`std::negate`],
+except it calls (unary) `operator+` instead of `operator-`.
+
+It also has a specialization for `void` which is _transparent_ like that of
+https://en.cppreference.com/w/cpp/utility/functional/negate_void.html[`std::negate`].

--- a/include/stdx/functional.hpp
+++ b/include/stdx/functional.hpp
@@ -170,5 +170,22 @@ template <auto F, typename... Args> constexpr auto bind_back(Args &&...args) {
 }
 
 #endif
+
+template <typename T = void> struct unary_plus {
+    constexpr auto operator()(T const &arg) const -> decltype(+arg) {
+        return +arg;
+    }
+};
+
+template <> struct unary_plus<void> {
+    using is_transparent = int;
+
+    template <typename T>
+    constexpr auto operator()(T &&arg) const
+        -> decltype(+std::forward<T>(arg)) {
+        return +std::forward<T>(arg);
+    }
+};
+
 } // namespace v1
 } // namespace stdx

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -43,6 +43,7 @@ add_tests(
     default_panic
     for_each_n_args
     function_traits
+    functional
     intrusive_forward_list
     intrusive_list
     intrusive_list_properties

--- a/test/functional.cpp
+++ b/test/functional.cpp
@@ -1,0 +1,30 @@
+#include <stdx/functional.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <type_traits>
+
+namespace {
+template <typename T, typename = void>
+constexpr auto detect_is_transparent = false;
+template <typename T>
+constexpr auto
+    detect_is_transparent<T, std::void_t<typename T::is_transparent>> = true;
+
+struct S {};
+constexpr auto operator+(S) { return 17; }
+} // namespace
+
+TEST_CASE("unary_plus", "[functional]") {
+    STATIC_REQUIRE(stdx::unary_plus<int>{}(17) == 17);
+    STATIC_REQUIRE(stdx::unary_plus<>{}(17) == 17);
+}
+
+TEST_CASE("unary_plus transparency", "[functional]") {
+    STATIC_REQUIRE(not detect_is_transparent<stdx::unary_plus<int>>);
+    STATIC_REQUIRE(detect_is_transparent<stdx::unary_plus<>>);
+}
+
+TEST_CASE("unary_plus calls operator+", "[functional]") {
+    STATIC_REQUIRE(stdx::unary_plus<>{}(S{}) == 17);
+}


### PR DESCRIPTION
Problem:
- The standard does not provide a function object that calls unary `operator+`. This can be useful for conventional conversions, for example an overloaded `operator+` that converts an scoped enumeration to its underlying type.

Solution:
- Add `unary_plus` for this purpose.
- `unary_plus<void>` deduces its argument and provides `is_transparent` in accordance with standard practice.