### PR TITLE
:bug: Fix formatting an enum without an identifier

### DIFF
--- a/test/ct_conversions.cpp
+++ b/test/ct_conversions.cpp
@@ -34,6 +34,13 @@ enum struct B { Y };
 
 TEST_CASE("enum as string", "[ct_conversion]") {
     using namespace std::string_view_literals;
-    STATIC_REQUIRE(stdx::enum_as_string<X>() == "X"sv);
-    STATIC_REQUIRE(stdx::enum_as_string<B::Y>() == "Y"sv);
+    STATIC_CHECK(stdx::enum_as_string<X>() == "X"sv);
+    STATIC_CHECK(stdx::enum_as_string<B::Y>() == "Y"sv);
+}
+
+enum struct C {};
+
+TEST_CASE("enum as string (no identifier)", "[ct_conversion]") {
+    using namespace std::string_view_literals;
+    STATIC_CHECK(stdx::enum_as_string<C{17}>() == "(C)17"sv);
 }


### PR DESCRIPTION
Problem:
- Formatting an enumeration value does not work when the enumeration value has no identifier. e.g.

```cpp
enum struct E{};
constexpr auto s = stdx::enum_as_string<E{17}>(); // should be something like "(E)17"
```

Solution:
- Allow `enum_as_string` to take account of "cast-style" compiler representation when enumeration values don't have identifiers.