### PR TITLE
:construction_worker: Update CI for cpp20 branch

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -5,9 +5,9 @@ on:
   workflow_dispatch:
   merge_group:
   push:
-    branches: [ main ]
+    branches: [ cpp20 ]
   pull_request:
-    branches: [ main ]
+    branches: [ cpp20 ]
 
 env:
   DEBIAN_FRONTEND: noninteractive

--- a/.github/workflows/usage_test.yml
+++ b/.github/workflows/usage_test.yml
@@ -5,9 +5,9 @@ on:
   workflow_dispatch:
   merge_group:
   push:
-    branches: [ main ]
+    branches: [ cpp20 ]
   pull_request:
-    branches: [ main ]
+    branches: [ cpp20 ]
 
 env:
   DEBIAN_FRONTEND: noninteractive


### PR DESCRIPTION
Problem:
- CI directives refer to the `main` branch.

Solution:
- Update CI to run on the `cpp20` branch.