### PR TITLE
:construction_worker: Use dependabot on cpp20 branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
-  - package-ecosystem: "gitsubmodule"
+    target-branch: "main"
+
+  - package-ecosystem: "github-actions"
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    target-branch: "cpp20"


### PR DESCRIPTION
Problem:
- CI updates from dependabot only target the default branch. The `cpp20` branch does not receive updates.

Solution:
- Add dependabot configuration for the `cpp20` branch as well.