### PR TITLE
:bug: Fix lists with incomplete types

### DIFF
--- a/include/stdx/detail/list_common.hpp
+++ b/include/stdx/detail/list_common.hpp
@@ -23,13 +23,13 @@ concept base_double_linkable = base_single_linkable<T> and requires(T node) {
 } // namespace detail
 
 template <typename T>
-concept single_linkable = not complete<T> or requires(T *node) {
+concept single_linkable = requires(T *node) {
     requires detail::base_single_linkable<
         std::remove_cvref_t<decltype(node->next)>>;
 };
 
 template <typename T>
-concept double_linkable = not complete<T> or requires(T *node) {
+concept double_linkable = requires(T *node) {
     requires detail::base_double_linkable<
         std::remove_cvref_t<decltype(node->next)>>;
     requires detail::base_double_linkable<
@@ -46,6 +46,7 @@ constexpr auto
 namespace node_policy {
 template <typename Node> class checked {
     constexpr static auto valid_for_push(Node *node) -> bool {
+        static_assert(single_linkable<Node>);
         if constexpr (detail::detect::has_prev_pointer<Node>) {
             return node->prev == nullptr and node->next == nullptr;
         } else {
@@ -79,6 +80,7 @@ template <typename Node> class checked {
     }
 
     constexpr static auto on_pop(Node *node) {
+        static_assert(single_linkable<Node>);
         if constexpr (detail::detect::has_prev_pointer<Node>) {
             node->prev = nullptr;
         }
@@ -86,6 +88,7 @@ template <typename Node> class checked {
     }
 
     constexpr static auto on_clear(Node *head) {
+        static_assert(single_linkable<Node>);
         while (head != nullptr) {
             if constexpr (detail::detect::has_prev_pointer<Node>) {
                 head->prev = nullptr;

--- a/include/stdx/intrusive_forward_list.hpp
+++ b/include/stdx/intrusive_forward_list.hpp
@@ -6,7 +6,7 @@
 
 namespace stdx {
 inline namespace v1 {
-template <single_linkable NodeType,
+template <typename NodeType,
           template <typename> typename P = node_policy::checked>
 class intrusive_forward_list {
     friend P<NodeType>;
@@ -58,6 +58,7 @@ class intrusive_forward_list {
     pointer tail{};
 
     constexpr auto unchecked_push_front(pointer n) -> void {
+        static_assert(single_linkable<value_type>);
         n->next = head;
         head = n;
         if (tail == nullptr) {
@@ -66,6 +67,7 @@ class intrusive_forward_list {
     }
 
     constexpr auto unchecked_push_back(pointer n) -> void {
+        static_assert(single_linkable<value_type>);
         if (tail != nullptr) {
             tail->next = n;
         }
@@ -99,6 +101,7 @@ class intrusive_forward_list {
     }
 
     constexpr auto pop_front() -> pointer {
+        static_assert(single_linkable<value_type>);
         pointer poppedNode = head;
         head = head->next;
 

--- a/include/stdx/intrusive_list.hpp
+++ b/include/stdx/intrusive_list.hpp
@@ -6,7 +6,7 @@
 
 namespace stdx {
 inline namespace v1 {
-template <double_linkable NodeType,
+template <typename NodeType,
           template <typename> typename P = node_policy::checked>
 class intrusive_list {
     friend P<NodeType>;
@@ -58,6 +58,7 @@ class intrusive_list {
     pointer tail{};
 
     constexpr auto unchecked_push_front(pointer n) -> void {
+        static_assert(double_linkable<value_type>);
         if (head != nullptr) {
             head->prev = n;
         }
@@ -70,6 +71,7 @@ class intrusive_list {
     }
 
     constexpr auto unchecked_push_back(pointer n) -> void {
+        static_assert(double_linkable<value_type>);
         if (tail != nullptr) {
             tail->next = n;
         }
@@ -82,6 +84,7 @@ class intrusive_list {
     }
 
     constexpr auto unchecked_insert(iterator it, pointer n) -> void {
+        static_assert(double_linkable<value_type>);
         if (it != end()) {
             auto p = it.operator->();
             n->next = p;
@@ -128,6 +131,7 @@ class intrusive_list {
     }
 
     constexpr auto pop_front() -> pointer {
+        static_assert(double_linkable<value_type>);
         pointer poppedNode = head;
         head = head->next;
 
@@ -142,6 +146,7 @@ class intrusive_list {
     }
 
     constexpr auto pop_back() -> pointer {
+        static_assert(double_linkable<value_type>);
         pointer poppedNode = tail;
         tail = tail->prev;
 
@@ -166,6 +171,7 @@ class intrusive_list {
     }
 
     constexpr auto remove(pointer n) -> void {
+        static_assert(double_linkable<value_type>);
         pointer nextNode = n->next;
         pointer prevNode = n->prev;
 


### PR DESCRIPTION
Problem:
- `intrusive_list` and `intrusive_forward_list` are constrained so that they can take incomplete types. This means using an incomplete type in a SFINAE context, which causes an error with GCC 16 (probably because it can lead to an ODR violation).

Solution:
- Use mandates, not requires; i.e. instead of concept-constraining, `static_assert` completeness in functions that need it.