### PR TITLE
Bump cicd-repo-infrastructure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ include(cmake/get_cpm.cmake)
 if(PROJECT_IS_TOP_LEVEL)
     cpmaddpackage("gh:intel/cicd-repo-infrastructure#dev")
 else()
-    cpmaddpackage("gh:intel/cicd-repo-infrastructure#3e2bef0")
+    cpmaddpackage("gh:intel/cicd-repo-infrastructure#6021593")
 endif()
 
 add_versioned_package(URI "gh:boostorg/mp11#boost-1.83.0" TARGET boost_mp11)


### PR DESCRIPTION
cicd-repo-infrastructure bump to latest commit to fix build error when project is not top level.

Output in current branch:
```bash
CMake Error at build/cmake/CPM_0.40.2.cmake:675 (message):
  CPM: 'NAME' was not provided and couldn't be automatically inferred for
  package added with arguments:
  'URI;gh:boostorg/mp11#boost-1.83.0;TARGET;boost_mp11'
Call Stack (most recent call first):
  build/_deps/cicd-repo-infrastructure-src/cmake/dependencies.cmake:167 (cpmaddpackage)
  build/_deps/stdx-src/CMakeLists.txt:17 (add_versioned_package)
```

Reproduce this error with CMakeLists.txt:
```cmake
cmake_minimum_required(VERSION 3.29)
project(Test)
include(FetchContent)
FetchContent_Declare(
    stdx
    GIT_REPOSITORY https://github.com/intel/cpp-std-extensions.git
    GIT_TAG main
)
FetchContent_MakeAvailable(stdx)
```
```bash
cmake -Bbuild -H.
```
