### PR TITLE
:books: Small documentation fixes.

### DIFF
--- a/.github/workflows/asciidoctor-ghpages.yml
+++ b/.github/workflows/asciidoctor-ghpages.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: *runner
     steps:
       - name: Checkout source
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/docs/concepts.adoc
+++ b/docs/concepts.adoc
@@ -58,6 +58,9 @@ static_assert(not stdx::complete<incomplete>);
 static_assert(stdx::complete<int>);
 ----
 
+CAUTION: Using class completeness to make decisions about definitions is a good
+way to get an ODR violation.
+
 === `has_trait`
 
 `has_trait` is used to turn a type trait (standard or otherwise) into a concept.
@@ -78,7 +81,7 @@ parameter that has a `constexpr static bool value` member.
 
 === `same_as_unqualified`
 
-`same_as_unqualified` is true when two types are the same are removing top-level
+`same_as_unqualified` is true when two types are the same after removing top-level
 cv-qualifications and references, if any. It's useful for constraining hidden
 friends -- particularly when member functions would need to be replicated with
 different reference qualifiers before C++23.

--- a/docs/ct_format.adoc
+++ b/docs/ct_format.adoc
@@ -61,7 +61,8 @@ auto s = stdx::ct_format<"Hello {} {}">(CX_VALUE(int), CX_VALUE(E::value));
 ----
 
 NOTE: Compile-time formatting is done with https://github.com/fmtlib/fmt[fmtlib]
-and supports the same formatting DSL. Positional arguments are not supported.
+and supports the same formatting DSL. Named arguments are supported, but only as
+a way to "tag", not for position-independence.
 
 When formatting a compile-time `stdx::format_result`, the strings and argument
 tuples are collapsed to a single `stdx::format_result`:

--- a/docs/function_traits.adoc
+++ b/docs/function_traits.adoc
@@ -21,7 +21,7 @@ using l_return = stdx::return_t<decltype(l)>;         // int
 using l_args = stdx::args_t<decltype(l), std::tuple>; // std::tuple<int>
 ----
 
-`stdx::args_t` returns a list of the function arguments. `std::decayed_args_t`
+`stdx::args_t` returns a list of the function arguments. `stdx::decayed_args_t`
 returns the same list, but with `std::decay_t` applied to each element. This is
 useful for example when you need to copy and store a tuple of the arguments.
 [source,cpp]

--- a/docs/functional.adoc
+++ b/docs/functional.adoc
@@ -51,7 +51,6 @@ except it calls (unary) `operator+` instead of `operator-`.
 
 It also has a specialization for `void` which is _transparent_ like that of
 https://en.cppreference.com/w/cpp/utility/functional/negate_void.html[`std::negate`].
->>>>>>> 7a78082 (:sparkles: Add `dereference`)
 
 === `with_result_of`
 

--- a/docs/optional.adoc
+++ b/docs/optional.adoc
@@ -52,7 +52,7 @@ static_assert(sizeof(stdx::optional<S> == 1);
 
 To use `stdx::optional`, specialize `stdx::tombstone_traits` for the required
 type, giving it a call operator that returns the sentinel value. After that,
-`stdx::optional`'s interface mirrors that of
+`stdx::optional`​'s interface mirrors that of
 https://en.cppreference.com/w/cpp/utility/optional[`std::optional`]. The C\+​+23
 monadic operations on `std::optional` are available on `stdx::optional` with
 C++17.
@@ -63,7 +63,7 @@ even non-movable) types.
 NOTE: Like `std::optional`, `stdx::optional` can be constructed with
 https://en.cppreference.com/w/cpp/utility/optional/nullopt_t[`std::nullopt`] or
 with https://en.cppreference.com/w/cpp/utility/in_place[`std::in_place`].
-(`stdx` does not redefine these types.)
+(`stdx` does not define its own versions of these.)
 
 NOTE: `stdx::optional` does not use exceptions. There is no
 `stdx::bad_optional_access`. If you access a disengaged `stdx::optional`, you

--- a/docs/type_traits.adoc
+++ b/docs/type_traits.adoc
@@ -81,6 +81,9 @@ static_assert(not stdx::is_complete_v<incomplete>);
 static_assert(stdx::is_complete_v<int>);
 ----
 
+CAUTION: Using class completeness to make decisions about definitions is a good
+way to get an ODR violation.
+
 === `is_function_object_v`
 
 `is_function_object_v` is a variable template that detects whether a type is a


### PR DESCRIPTION
Problem:
- Documentation has typos, small errors and a few places that could be better.

Solution:
- Fix them.