### PR TITLE
:arrow_up: Update ghpages workflow

### DIFF
--- a/.github/workflows/asciidoctor-ghpages.yml
+++ b/.github/workflows/asciidoctor-ghpages.yml
@@ -49,25 +49,16 @@ jobs:
       - name: Restore CPM cache
         env:
           cache-name: cpm-cache-0
-        id: cpm-cache-restore
-        uses: actions/cache/restore@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/cpm-cache
           key: ${{runner.os}}-${{env.cache-name}}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
           restore-keys: |
+            ${{runner.os}}-${{env.cache-name}}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
             ${{runner.os}}-${{env.cache-name}}-
 
       - name: Configure CMake
         run: cmake -Bbuild -DCPM_SOURCE_CACHE=~/cpm-cache
-
-      - name: Save CPM cache
-        env:
-          cache-name: cpm-cache-0
-        if: steps.cpm-cache-restore.outputs.cache-hit != 'true'
-        uses: actions/cache/save@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
-        with:
-          path: ~/cpm-cache
-          key: ${{runner.os}}-${{env.cache-name}}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
 
       - name: Build documentation
         run: |


### PR DESCRIPTION
Problem:
- GH pages workflow changed upstream to remove the cache restore/save split.

Solution:
- Update to upstream version.