### PR TITLE
type_traits: fix empty pack indexing

### DIFF
--- a/include/stdx/type_traits.hpp
+++ b/include/stdx/type_traits.hpp
@@ -300,10 +300,10 @@ STDX_PRAGMA(diagnostic ignored "-Wc++26-extensions")
 #endif
 template <unsigned int N, typename... Ts>
 using nth_t =
-#if __cpp_pack_indexing >= 202311L
-    Ts...[N];
-#elif __has_builtin(__type_pack_element)
+#if __has_builtin(__type_pack_element)
     __type_pack_element<N, Ts...>;
+#elif __cpp_pack_indexing >= 202311L
+    Ts...[N];
 #else
     boost::mp11::mp_at_c<type_list<Ts...>, N>;
 #endif


### PR DESCRIPTION
Compiling with C++26 fails on empty packs with this message:
include/stdx/type_traits.hpp:302:7: error: cannot index an empty pack
  302 | using nth_t =
      |       ^~~~~
The fix is to prioritize __type_pack_element over C++26 pack indexing in
type_traits.hpp, since the builtin evaluates lazily (only when a member is
accessed) while pack indexing is checked eagerly when the class is
instantiated with an empty pack.