### PR TITLE
:rotating_light: Implement `modernize-use-constraints`

### DIFF
--- a/include/stdx/bit.hpp
+++ b/include/stdx/bit.hpp
@@ -16,8 +16,6 @@
 #include <bit>
 #endif
 
-// NOLINTBEGIN(modernize-use-constraints)
-
 namespace stdx {
 inline namespace v1 {
 
@@ -241,9 +239,8 @@ using std::bit_width;
 using std::has_single_bit;
 #endif
 
-template <typename T>
-[[nodiscard]] constexpr auto to_le(T x) noexcept
-    -> std::enable_if_t<std::is_unsigned_v<T>, T> {
+template <unsigned_integral T>
+[[nodiscard]] constexpr auto to_le(T x) noexcept -> T {
     if constexpr (stdx::endian::native == stdx::endian::big) {
         return byteswap(x);
     } else {
@@ -251,9 +248,8 @@ template <typename T>
     }
 }
 
-template <typename T>
-[[nodiscard]] constexpr auto to_be(T x) noexcept
-    -> std::enable_if_t<std::is_unsigned_v<T>, T> {
+template <unsigned_integral T>
+[[nodiscard]] constexpr auto to_be(T x) noexcept -> T {
     if constexpr (stdx::endian::native == stdx::endian::little) {
         return byteswap(x);
     } else {
@@ -261,9 +257,8 @@ template <typename T>
     }
 }
 
-template <typename T>
-[[nodiscard]] constexpr auto from_le(T x) noexcept
-    -> std::enable_if_t<std::is_unsigned_v<T>, T> {
+template <unsigned_integral T>
+[[nodiscard]] constexpr auto from_le(T x) noexcept -> T {
     if constexpr (stdx::endian::native == stdx::endian::big) {
         return byteswap(x);
     } else {
@@ -271,9 +266,8 @@ template <typename T>
     }
 }
 
-template <typename T>
-[[nodiscard]] constexpr auto from_be(T x) noexcept
-    -> std::enable_if_t<std::is_unsigned_v<T>, T> {
+template <unsigned_integral T>
+[[nodiscard]] constexpr auto from_be(T x) noexcept -> T {
     if constexpr (stdx::endian::native == stdx::endian::little) {
         return byteswap(x);
     } else {
@@ -463,14 +457,10 @@ constexpr auto bit_destructure_impl(T t, std::index_sequence<Is...>) {
 }
 } // namespace bit_detail
 
-template <std::size_t... Offsets, typename T>
-constexpr auto bit_destructure(T t)
-    -> std::enable_if_t<unsigned_integral<T>,
-                        std::array<T, sizeof...(Offsets) + 1>> {
+template <std::size_t... Offsets, unsigned_integral T>
+constexpr auto bit_destructure(T t) -> std::array<T, sizeof...(Offsets) + 1> {
     return bit_detail::bit_destructure_impl<Offsets..., bit_size<T>()>(
         t, std::make_index_sequence<sizeof...(Offsets) + 1>{});
 }
 } // namespace v1
 } // namespace stdx
-
-// NOLINTEND(modernize-use-constraints)

--- a/include/stdx/byterator.hpp
+++ b/include/stdx/byterator.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdx/bit.hpp>
+#include <stdx/concepts.hpp>
 #include <stdx/memory.hpp>
 #include <stdx/type_traits.hpp>
 #include <stdx/utility.hpp>
@@ -11,14 +12,12 @@
 #include <iterator>
 #include <type_traits>
 
-// NOLINTBEGIN(modernize-use-constraints)
-
 namespace stdx {
 inline namespace v1 {
 
 namespace detail {
 template <typename It>
-constexpr auto is_byteratorish_v =
+concept byteratorish =
     std::is_base_of_v<std::random_access_iterator_tag,
                       typename std::iterator_traits<It>::iterator_category> and
     std::is_trivially_copyable_v<typename std::iterator_traits<It>::value_type>;
@@ -41,9 +40,8 @@ template <typename T> class byterator {
                                                    byterator const &y) -> bool {
         return x.ptr == y.ptr;
     }
-    template <typename It,
-              std::enable_if_t<std::is_same_v<detail::iterator_value_t<It>, T>,
-                               int> = 0>
+    template <typename It>
+        requires std::is_same_v<detail::iterator_value_t<It>, T>
     [[nodiscard]] friend constexpr auto operator==(byterator const &x, It y)
         -> bool {
         return static_cast<void const *>(x.ptr) ==
@@ -54,9 +52,8 @@ template <typename T> class byterator {
                                                     byterator const &y) {
         return x.ptr <=> y.ptr;
     }
-    template <typename It,
-              std::enable_if_t<std::is_same_v<detail::iterator_value_t<It>, T>,
-                               int> = 0>
+    template <typename It>
+        requires std::is_same_v<detail::iterator_value_t<It>, T>
     [[nodiscard]] friend constexpr auto operator<=>(byterator const &x, It y) {
         return static_cast<void const *>(x.ptr) <=>
                static_cast<void const *>(stdx::to_address(y));
@@ -69,8 +66,7 @@ template <typename T> class byterator {
     using reference = value_type &;
     using iterator_category = std::random_access_iterator_tag;
 
-    template <typename It,
-              std::enable_if_t<detail::is_byteratorish_v<It>, int> = 0>
+    template <detail::byteratorish It>
     explicit byterator(It it) : ptr(bit_cast<byte_t *>(stdx::to_address(it))) {}
 
     [[nodiscard]] constexpr auto operator->() const -> byte_t * { return ptr; }
@@ -138,8 +134,8 @@ template <typename T> class byterator {
         return ptr[n];
     }
 
-    template <typename V = std::uint8_t, typename R = V,
-              std::enable_if_t<std::is_trivially_copyable_v<V>, int> = 0>
+    template <typename V = std::uint8_t, typename R = V>
+        requires std::is_trivially_copyable_v<V>
     [[nodiscard]] auto peek() -> R {
         V v;
         std::memcpy(std::addressof(v), ptr, sizeof(V));
@@ -159,17 +155,16 @@ template <typename T> class byterator {
         return advance(n * static_cast<difference_type>(sizeof(V)));
     }
 
-    template <typename V = std::uint8_t, typename R = V,
-              std::enable_if_t<std::is_trivially_copyable_v<V>, int> = 0>
+    template <typename V = std::uint8_t, typename R = V>
+        requires std::is_trivially_copyable_v<V>
     [[nodiscard]] auto read() -> R {
         R ret = peek<V, R>();
         advance<V>();
         return ret;
     }
 
-    template <typename V,
-              std::enable_if_t<std::is_trivially_copyable_v<remove_cvref_t<V>>,
-                               int> = 0>
+    template <typename V>
+        requires std::is_trivially_copyable_v<remove_cvref_t<V>>
     auto write(V &&v) -> void {
         using R = remove_cvref_t<V>;
         std::memcpy(ptr, std::addressof(v), sizeof(R));
@@ -229,10 +224,8 @@ template <typename T> class byterator {
     }
 };
 
-template <typename It, std::enable_if_t<detail::is_byteratorish_v<It>, int> = 0>
+template <detail::byteratorish It>
 byterator(It) -> byterator<detail::iterator_value_t<It>>;
 
 } // namespace v1
 } // namespace stdx
-
-// NOLINTEND(modernize-use-constraints)

--- a/include/stdx/cx_map.hpp
+++ b/include/stdx/cx_map.hpp
@@ -37,10 +37,8 @@ template <typename Key, typename Value, std::size_t N> class cx_map {
 
   public:
     constexpr cx_map() = default;
-    // NOLINTNEXTLINE(modernize-use-constraints)
-    template <typename... Vs, std::enable_if_t<((sizeof...(Vs) <= N) and ... and
-                                                stdx::same_as<value_type, Vs>),
-                                               int> = 0>
+    template <same_as<value_type>... Vs>
+        requires(sizeof...(Vs) <= N)
     constexpr explicit cx_map(Vs const &...vs)
         : storage{vs...}, current_size{sizeof...(Vs)} {}
 

--- a/include/stdx/cx_set.hpp
+++ b/include/stdx/cx_set.hpp
@@ -23,14 +23,10 @@ template <typename Key, std::size_t N> class cx_set {
     using const_iterator = value_type const *;
 
     constexpr cx_set() = default;
-    template <typename... Ts,
-              // NOLINTNEXTLINE(modernize-use-constraints)
-              std::enable_if_t<((sizeof...(Ts) <= N) and ... and
-                                stdx::convertible_to<key_type, Ts>),
-                               int> = 0>
+    template <convertible_to<key_type>... Ts>
+        requires(sizeof...(Ts) <= N)
     constexpr explicit cx_set(Ts const &...ts)
-        : storage{static_cast<value_type>(ts)...}, current_size{sizeof...(Ts)} {
-    }
+        : storage{static_cast<key_type>(ts)...}, current_size{sizeof...(Ts)} {}
 
     [[nodiscard]] constexpr auto begin() LIFETIMEBOUND -> iterator {
         return std::data(storage);

--- a/include/stdx/cx_vector.hpp
+++ b/include/stdx/cx_vector.hpp
@@ -30,11 +30,8 @@ template <typename T, std::size_t N> class cx_vector {
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
     constexpr cx_vector() = default;
-    template <typename... Ts,
-              // NOLINTNEXTLINE(modernize-use-constraints)
-              std::enable_if_t<((sizeof...(Ts) <= N) and ... and
-                                stdx::convertible_to<value_type, Ts>),
-                               int> = 0>
+    template <convertible_to<value_type>... Ts>
+        requires(sizeof...(Ts) <= N)
     constexpr explicit cx_vector(Ts const &...ts)
         : storage{static_cast<value_type>(ts)...}, current_size{sizeof...(Ts)} {
     }

--- a/include/stdx/env.hpp
+++ b/include/stdx/env.hpp
@@ -49,7 +49,7 @@ template <typename T> struct autowrap {
     T value;
 };
 
-// NOLINTNEXTLINE(modernize-avoid-c-arrays)
+// NOLINTNEXTLINE(*-avoid-c-arrays)
 template <std::size_t N> using str_lit_t = char const (&)[N];
 
 template <std::size_t N> struct autowrap<str_lit_t<N>> {

--- a/include/stdx/functional.hpp
+++ b/include/stdx/functional.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stdx/concepts.hpp>
 #include <stdx/tuple.hpp>
 #include <stdx/type_traits.hpp>
 
@@ -143,15 +144,12 @@ template <auto F, typename... Args> constexpr auto bind_back(Args &&...args) {
         {std::forward<Args>(args)...}};
 }
 
-// NOLINTBEGIN(modernize-use-constraints)
 template <typename T = void> struct unary_plus {
-    template <typename U,
-              typename = std::enable_if_t<is_same_unqualified_v<U, T>>>
+    template <same_as_unqualified<T> U>
     constexpr auto operator()(U &&u) const -> decltype(+std::forward<U>(u)) {
         return +std::forward<U>(u);
     }
 };
-// NOLINTEND(modernize-use-constraints)
 
 template <> struct unary_plus<void> {
     using is_transparent = int;
@@ -172,15 +170,12 @@ constexpr inline struct safe_identity_t {
     }
 } safe_identity;
 
-// NOLINTBEGIN(modernize-use-constraints)
 template <typename T = void> struct dereference {
-    template <typename U,
-              typename = std::enable_if_t<is_same_unqualified_v<U, T>>>
+    template <same_as_unqualified<T> U>
     constexpr auto operator()(U &&u) const -> decltype(*std::forward<U>(u)) {
         return *std::forward<U>(u);
     }
 };
-// NOLINTEND(modernize-use-constraints)
 
 template <> struct dereference<void> {
     using is_transparent = int;

--- a/include/stdx/iterator.hpp
+++ b/include/stdx/iterator.hpp
@@ -24,7 +24,7 @@ constexpr auto ct_capacity_v = detail::ct_capacity_fail<T>{};
 template <typename T, std::size_t N>
 constexpr auto ct_capacity_v<std::array<T, N>> = N;
 
-// NOLINTNEXTLINE(modernize-avoid-c-arrays)
+// NOLINTNEXTLINE(*-avoid-c-arrays)
 template <typename T, std::size_t N> constexpr auto ct_capacity_v<T[N]> = N;
 
 template <typename T> constexpr auto ct_capacity_v<T const> = ct_capacity_v<T>;

--- a/include/stdx/optional.hpp
+++ b/include/stdx/optional.hpp
@@ -10,8 +10,6 @@
 #include <type_traits>
 #include <utility>
 
-// NOLINTBEGIN(modernize-use-constraints)
-
 namespace stdx {
 inline namespace v1 {
 template <typename T, typename = void> struct tombstone_traits {
@@ -110,12 +108,11 @@ template <typename T, typename TS = tombstone_traits<T>> class optional {
     constexpr explicit optional(std::in_place_t, Args &&...args)
         : val{std::forward<Args>(args)...} {}
 
-    template <
-        typename U = T,
-        typename = std::enable_if_t<
+    template <typename U = T>
+        requires(
             std::is_constructible_v<T, U &&> and
             not std::is_same_v<stdx::remove_cvref_t<U>, std::in_place_t> and
-            not std::is_same_v<stdx::remove_cvref_t<U>, optional>>>
+            not std::is_same_v<stdx::remove_cvref_t<U>, optional>)
     constexpr explicit optional(U &&u) : val{std::forward<U>(u)} {}
 
     constexpr auto operator=(std::nullopt_t) -> optional & {
@@ -123,12 +120,12 @@ template <typename T, typename TS = tombstone_traits<T>> class optional {
         return *this;
     }
 
-    template <
-        typename U = T,
-        typename = std::enable_if_t<
-            std::is_constructible_v<T, U> and std::is_assignable_v<T &, U> and
-            not std::is_same_v<stdx::remove_cvref_t<U>, optional> and
-            (std::is_scalar_v<T> or not std::is_same_v<std::decay_t<U>, T>)>>
+    template <typename U = T>
+        requires(std::is_constructible_v<T, U> and
+                 std::is_assignable_v<T &, U> and
+                 not std::is_same_v<stdx::remove_cvref_t<U>, optional> and
+                 (std::is_scalar_v<T> or
+                  not std::is_same_v<std::decay_t<U>, T>))
     constexpr auto operator=(U &&u) -> optional & {
         val = std::forward<U>(u);
         return *this;
@@ -312,7 +309,7 @@ template <typename T> optional(T) -> optional<T>;
 
 namespace detail {
 template <typename T>
-constexpr bool optional_like =
+concept optional_like =
     stdx::is_specialization_of_v<stdx::remove_cvref_t<T>, optional> or
     stdx::is_specialization_of_v<stdx::remove_cvref_t<T>, std::optional>;
 
@@ -328,8 +325,7 @@ template <typename R, typename... Ts,
 auto convert_optional(Ts const &...) -> std::optional<R>;
 } // namespace detail
 
-template <typename F, typename... Ts,
-          typename = std::enable_if_t<(... and detail::optional_like<Ts>)>>
+template <typename F, detail::optional_like... Ts>
 constexpr auto transform(F &&f, Ts &&...ts) {
     using func_t = stdx::remove_cvref_t<F>;
     using R = std::invoke_result_t<
@@ -345,5 +341,3 @@ constexpr auto transform(F &&f, Ts &&...ts) {
 }
 } // namespace v1
 } // namespace stdx
-
-// NOLINTEND(modernize-use-constraints)

--- a/include/stdx/rollover.hpp
+++ b/include/stdx/rollover.hpp
@@ -13,15 +13,11 @@ template <typename T> struct rollover_t {
     using underlying_t = T;
 
     constexpr rollover_t() = default;
-    // NOLINTBEGIN(modernize-use-constraints)
-    template <typename U,
-              typename = std::enable_if_t<std::is_convertible_v<U, T>>>
+    template <convertible_to<underlying_t> U>
     constexpr explicit rollover_t(U u) : value{static_cast<underlying_t>(u)} {}
-    template <typename U,
-              typename = std::enable_if_t<std::is_convertible_v<U, T>>>
+    template <convertible_to<underlying_t> U>
     constexpr explicit rollover_t(rollover_t<U> u)
         : rollover_t{static_cast<U>(u)} {}
-    // NOLINTEND(modernize-use-constraints)
 
     [[nodiscard]] constexpr auto as_underlying() const -> underlying_t {
         return value;

--- a/include/stdx/span.hpp
+++ b/include/stdx/span.hpp
@@ -2,6 +2,7 @@
 
 #include <stdx/bit.hpp>
 #include <stdx/compiler.hpp>
+#include <stdx/concepts.hpp>
 #include <stdx/iterator.hpp>
 #include <stdx/memory.hpp>
 #include <stdx/type_traits.hpp>
@@ -12,8 +13,6 @@
 #include <iterator>
 #include <limits>
 #include <type_traits>
-
-// NOLINTBEGIN(modernize-use-constraints)
 
 namespace stdx {
 inline namespace v1 {
@@ -38,15 +37,13 @@ template <typename T> class span_base<T, dynamic_extent> {
   public:
     constexpr span_base() = default;
 
-    template <typename It, typename SizeOrEnd,
-              std::enable_if_t<std::is_integral_v<SizeOrEnd>, int> = 0>
-    constexpr span_base(It, SizeOrEnd count)
-        : sz{static_cast<std::size_t>(count)} {}
-
-    template <typename It, typename SizeOrEnd,
-              std::enable_if_t<not std::is_integral_v<SizeOrEnd>, int> = 0>
+    template <typename It, typename SizeOrEnd>
     constexpr span_base(It first, SizeOrEnd last)
         : sz{static_cast<std::size_t>(std::distance(first, last))} {}
+
+    template <typename It, integral SizeOrEnd>
+    constexpr span_base(It, SizeOrEnd count)
+        : sz{static_cast<std::size_t>(count)} {}
 
     [[nodiscard]] constexpr auto size() const noexcept -> std::size_t {
         return sz;
@@ -85,13 +82,13 @@ class span : public detail::span_base<T, Extent> {
 
     constexpr span() = default;
 
-    template <typename It, typename SizeOrEnd,
-              std::enable_if_t<dependent_extent<It> != dynamic_extent, int> = 0>
+    template <typename It, typename SizeOrEnd>
+        requires(dependent_extent<It> != dynamic_extent)
     explicit constexpr span(It first, SizeOrEnd)
         : ptr{stdx::to_address(first)} {}
 
-    template <typename It, typename SizeOrEnd,
-              std::enable_if_t<dependent_extent<It> == dynamic_extent, int> = 0>
+    template <typename It, typename SizeOrEnd>
+        requires(dependent_extent<It> == dynamic_extent)
     constexpr span(It first, SizeOrEnd sore)
         : base_t{first, sore}, ptr{stdx::to_address(first)} {}
 
@@ -122,27 +119,23 @@ class span : public detail::span_base<T, Extent> {
                       "Span extends beyond available storage");
     }
 
-    template <typename R,
-              std::enable_if_t<dependent_extent<R> != dynamic_extent, int> = 0>
+    template <typename R>
+        requires(dependent_extent<R> != dynamic_extent)
     explicit constexpr span(R &&r)
         : ptr{stdx::to_address(std::begin(std::forward<R>(r)))} {}
 
-    template <typename R,
-              std::enable_if_t<dependent_extent<R> == dynamic_extent, int> = 0>
+    template <typename R>
+        requires(dependent_extent<R> == dynamic_extent)
     explicit constexpr span(R &&r)
         : base_t{std::begin(std::forward<R>(r)), std::end(std::forward<R>(r))},
           ptr{stdx::to_address(std::begin(std::forward<R>(r)))} {}
 
-    template <class U, std::size_t N,
-              std::enable_if_t<dependent_extent<U> != dynamic_extent and
-                                   N == dynamic_extent,
-                               int> = 0>
+    template <class U, std::size_t N>
+        requires(dependent_extent<U> != dynamic_extent and N == dynamic_extent)
     explicit constexpr span(span<U, N> const &s) noexcept : ptr{s.data()} {}
 
-    template <class U, std::size_t N,
-              std::enable_if_t<dependent_extent<U> == dynamic_extent or
-                                   N != dynamic_extent,
-                               int> = 0>
+    template <class U, std::size_t N>
+        requires(dependent_extent<U> == dynamic_extent or N != dynamic_extent)
     // NOLINTNEXTLINE(google-explicit-constructor)
     constexpr span(span<U, N> const &s) noexcept
         : base_t{s.data(), s.size()}, ptr{s.data()} {}
@@ -254,8 +247,8 @@ template <class T, std::size_t N> auto as_bytes(span<T, N> s) noexcept {
     }
 }
 
-template <class T, std::size_t N,
-          std::enable_if_t<not std::is_const_v<T>, int> = 0>
+template <class T, std::size_t N>
+    requires(not std::is_const_v<T>)
 auto as_writable_bytes(span<T, N> s) noexcept {
     if constexpr (N == dynamic_extent) {
         return span{reinterpret_cast<std::byte *>(s.data()), s.size_bytes()};
@@ -293,5 +286,3 @@ constexpr auto ct_capacity_v<span<T, dynamic_extent>> =
     detail::ct_capacity_fail<span<T, dynamic_extent>>{};
 } // namespace v1
 } // namespace stdx
-
-// NOLINTEND(modernize-use-constraints)

--- a/include/stdx/type_traits.hpp
+++ b/include/stdx/type_traits.hpp
@@ -205,8 +205,8 @@ template <typename T, typename... Ts> constexpr auto try_construct() -> T {
 }
 
 template <typename T> struct any_t {
-    // NOLINTNEXTLINE(modernize-use-constraints)
-    template <typename U, std::enable_if_t<not std::is_same_v<T, U>, int> = 0>
+    template <typename U>
+        requires(not std::is_same_v<T, U>)
     // NOLINTNEXTLINE(google-explicit-constructor)
     constexpr operator U() {
         return try_construct<U>();

--- a/include/stdx/utility.hpp
+++ b/include/stdx/utility.hpp
@@ -10,8 +10,6 @@
 #include <type_traits>
 #include <utility>
 
-// NOLINTBEGIN(modernize-use-constraints)
-
 namespace stdx {
 inline namespace v1 {
 
@@ -126,15 +124,13 @@ template <typename T, typename U>
 template <typename T, typename U>
 using forward_like_t = decltype(stdx::forward_like<T>(std::declval<U>()));
 
-template <typename T, std::enable_if_t<std::is_integral_v<T>, int> = 0>
-[[nodiscard]] constexpr auto as_unsigned(T t) {
+template <integral T> [[nodiscard]] constexpr auto as_unsigned(T t) {
     static_assert(not std::is_same_v<T, bool>,
                   "as_unsigned is not applicable to bool");
     return static_cast<std::make_unsigned_t<T>>(t);
 }
 
-template <typename T, std::enable_if_t<std::is_integral_v<T>, int> = 0>
-[[nodiscard]] constexpr auto as_signed(T t) {
+template <integral T> [[nodiscard]] constexpr auto as_signed(T t) {
     static_assert(not std::is_same_v<T, bool>,
                   "as_signed is not applicable to bool");
     return static_cast<std::make_signed_t<T>>(t);
@@ -205,15 +201,13 @@ struct from_any {
 struct value_marker {};
 
 struct type_val {
-    template <typename T, typename U,
-              typename = std::enable_if_t<same_as_unqualified<type_val, U>>>
+    template <typename T, same_as<type_val> U>
     friend constexpr auto operator+(T t, U const &) -> T {
         return t;
     }
     friend constexpr auto operator+(type_val const &f) -> type_val { return f; }
 
-    template <typename T, typename U,
-              typename = std::enable_if_t<same_as_unqualified<type_val, U>>>
+    template <typename T, same_as<type_val> U>
     friend constexpr auto operator-(T, U const &) -> value_marker {
         return {};
     }
@@ -402,4 +396,3 @@ auto cx_detect(auto f) {
 #endif
 
 // NOLINTEND(cppcoreguidelines-macro-usage)
-// NOLINTEND(modernize-use-constraints)


### PR DESCRIPTION
Problem:
- Some code uses `enable_if` when `requires` would be clearer; this was for historical reasons (C++17 support).

Solution:
- Use `requires` instead of `enable_if` and remove the NOLINT directives.