### PR TITLE
:rotating_light: Relax `google-explicit-constructor` lint directives

### DIFF
--- a/include/stdx/ct_string.hpp
+++ b/include/stdx/ct_string.hpp
@@ -27,7 +27,7 @@ concept format_convertible = requires(T t) {
 template <std::size_t N> struct ct_string {
     consteval ct_string() = default;
 
-    // NOLINTNEXTLINE(*-avoid-c-arrays, google-explicit-constructor)
+    // NOLINTNEXTLINE(*-avoid-c-arrays)
     consteval explicit(false) ct_string(char const (&str)[N]) {
         for (auto i = std::size_t{}; i < N; ++i) {
             // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-*)
@@ -36,7 +36,6 @@ template <std::size_t N> struct ct_string {
     }
 
     template <detail::format_convertible T>
-    // NOLINTNEXTLINE(google-explicit-constructor)
     consteval explicit(false) ct_string(T t) : ct_string(+t) {}
 
     consteval explicit(true) ct_string(char const *str, std::size_t sz) {

--- a/include/stdx/env.hpp
+++ b/include/stdx/env.hpp
@@ -44,8 +44,7 @@ concept envlike = is_specialization_of_v<T, env>;
 
 namespace _env {
 template <typename T> struct autowrap {
-    // NOLINTNEXTLINE(google-explicit-constructor)
-    consteval autowrap(T t) : value(t) {}
+    consteval explicit(false) autowrap(T t) : value(t) {}
     T value;
 };
 
@@ -53,8 +52,7 @@ template <typename T> struct autowrap {
 template <std::size_t N> using str_lit_t = char const (&)[N];
 
 template <std::size_t N> struct autowrap<str_lit_t<N>> {
-    // NOLINTNEXTLINE(google-explicit-constructor)
-    consteval autowrap(str_lit_t<N> str) : value(str) {}
+    consteval explicit(false) autowrap(str_lit_t<N> str) : value(str) {}
     stdx::ct_string<N> value;
 };
 

--- a/include/stdx/span.hpp
+++ b/include/stdx/span.hpp
@@ -93,16 +93,15 @@ class span : public detail::span_base<T, Extent> {
         : base_t{first, sore}, ptr{stdx::to_address(first)} {}
 
     template <typename U, std::size_t N>
-    // NOLINTNEXTLINE(google-explicit-constructor)
-    constexpr span(std::array<U, N> &arr LIFETIMEBOUND) noexcept
+    constexpr explicit(false) span(std::array<U, N> &arr LIFETIMEBOUND) noexcept
         : base_t{std::data(arr), N}, ptr{std::data(arr)} {
         static_assert(Extent == dynamic_extent or Extent <= N,
                       "Span extends beyond available storage");
     }
 
     template <typename U, std::size_t N>
-    // NOLINTNEXTLINE(google-explicit-constructor)
-    constexpr span(std::array<U, N> const &arr LIFETIMEBOUND) noexcept
+    constexpr explicit(false)
+        span(std::array<U, N> const &arr LIFETIMEBOUND) noexcept
         : base_t{std::data(arr), N}, ptr{std::data(arr)} {
         static_assert(Extent == dynamic_extent or Extent <= N,
                       "Span extends beyond available storage");
@@ -112,8 +111,7 @@ class span : public detail::span_base<T, Extent> {
     template <std::size_t N> using arr_t = type_identity_t<element_type> (&)[N];
 
     template <std::size_t N>
-    // NOLINTNEXTLINE(google-explicit-constructor)
-    constexpr span(arr_t<N> arr LIFETIMEBOUND) noexcept
+    constexpr explicit(false) span(arr_t<N> arr LIFETIMEBOUND) noexcept
         : base_t{std::data(arr), N}, ptr{std::data(arr)} {
         static_assert(Extent == dynamic_extent or Extent <= N,
                       "Span extends beyond available storage");
@@ -136,8 +134,7 @@ class span : public detail::span_base<T, Extent> {
 
     template <class U, std::size_t N>
         requires(dependent_extent<U> == dynamic_extent or N != dynamic_extent)
-    // NOLINTNEXTLINE(google-explicit-constructor)
-    constexpr span(span<U, N> const &s) noexcept
+    constexpr explicit(false) span(span<U, N> const &s) noexcept
         : base_t{s.data(), s.size()}, ptr{s.data()} {}
 
     [[nodiscard]] constexpr auto data() const noexcept -> pointer {

--- a/include/stdx/utility.hpp
+++ b/include/stdx/utility.hpp
@@ -192,10 +192,8 @@ template <char... Chars> consteval auto operator""_z64() {
 
 namespace cxv_detail {
 struct from_any {
-    // NOLINTNEXTLINE(google-explicit-constructor)
-    template <typename... Ts> constexpr from_any(Ts const &...) {}
-    // NOLINTNEXTLINE(google-explicit-constructor)
-    constexpr operator int() const { return 0; }
+    template <typename... Ts>
+    constexpr explicit(false) from_any(Ts const &...) {}
 };
 
 struct value_marker {};
@@ -252,8 +250,7 @@ constexpr auto is_aligned_with = [](auto v) -> bool {
 
 namespace detail {
 template <typename T> struct ct_helper {
-    // NOLINTNEXTLINE(google-explicit-constructor)
-    consteval ct_helper(auto t) : value(t) {}
+    consteval explicit(false) ct_helper(auto t) : value(t) {}
     T value;
 };
 


### PR DESCRIPTION
Problem:
- The clang-tidy `google-explicit-constructor` can now (clang-22, but perhaps earlier also) deal with `explicit(false)` directives, so we don't need to mark such constructors with a lint-workaround comment.

Solution:
- Remove the `NOLINT` directives from constructors that can be marked `explicit(false)`.

Note:
- Implicit conversion operators must still be marked. (https://godbolt.org/z/nfj6sahvo)
- In clang-23 it looks like `misc-explicit-constructor` is now the "base" clang-tidy, which `google-explicit-constructor` aliases.