### PR TITLE
:art: Adjust tuple concepts

### DIFF
--- a/include/stdx/concepts.hpp
+++ b/include/stdx/concepts.hpp
@@ -2,6 +2,8 @@
 
 #include <stdx/type_traits.hpp>
 
+#include <type_traits>
+
 #if __has_include(<concepts>)
 #include <concepts>
 #endif
@@ -9,16 +11,15 @@
 #if __cpp_lib_concepts < 202002L
 
 #include <functional>
-#include <type_traits>
 #include <utility>
 
 namespace stdx {
 inline namespace v1 {
 template <typename T>
-concept integral = std::is_integral_v<T>;
+concept floating_point = std::is_floating_point_v<T>;
 
 template <typename T>
-concept floating_point = std::is_floating_point_v<T>;
+concept integral = std::is_integral_v<T>;
 
 template <typename T>
 concept signed_integral = integral<T> and std::is_signed_v<T>;
@@ -42,16 +43,6 @@ concept same_as_helper = std::is_same_v<T, U>;
 
 template <typename T, typename U>
 concept same_as = detail::same_as_helper<T, U> and detail::same_as_helper<U, T>;
-
-template <typename T, typename... Us>
-constexpr auto same_any = (... or same_as<T, Us>);
-
-template <typename T, typename... Us>
-constexpr auto same_none = not same_any<T, Us...>;
-
-template <typename T, typename U>
-concept same_as_unqualified =
-    same_as<std::remove_cvref_t<T>, std::remove_cvref_t<U>>;
 
 template <typename T>
 concept equality_comparable = requires(T const &t) {
@@ -91,21 +82,6 @@ concept boolean_testable = boolean_testable_impl<B> and requires(B &&b) {
 template <typename F, typename... Args>
 concept predicate = invocable<F, Args...> and
                     detail::boolean_testable<std::invoke_result_t<F, Args...>>;
-
-template <typename T>
-concept callable = is_callable_v<T>;
-
-template <typename T, template <typename> typename TypeTrait>
-concept has_trait = TypeTrait<T>::value;
-
-template <typename T>
-concept structural = is_structural_v<T>;
-
-template <typename T>
-concept complete = is_complete_v<T>;
-
-template <typename T, typename U>
-concept same_template_as = is_same_template_v<T, U>;
 } // namespace v1
 } // namespace stdx
 
@@ -130,16 +106,29 @@ using std::totally_ordered;
 
 using std::invocable;
 using std::predicate;
+} // namespace v1
+} // namespace stdx
+
+#endif
+
+namespace stdx {
+inline namespace v1 {
+
+template <typename T, typename U>
+concept same_as_unqualified =
+    same_as<std::remove_cvref_t<T>, std::remove_cvref_t<U>>;
+
+template <typename T, typename... Us>
+constexpr auto same_any = (... or same_as<T, Us>);
+
+template <typename T, typename... Us>
+constexpr auto same_none = not same_any<T, Us...>;
 
 template <typename T>
 concept callable = is_callable_v<T>;
 
 template <typename T, template <typename> typename TypeTrait>
 concept has_trait = TypeTrait<T>::value;
-
-template <typename T, typename U>
-concept same_as_unqualified =
-    same_as<std::remove_cvref_t<T>, std::remove_cvref_t<U>>;
 
 template <typename T>
 concept structural = is_structural_v<T>;
@@ -150,12 +139,44 @@ concept complete = is_complete_v<T>;
 template <typename T, typename U>
 concept same_template_as = is_same_template_v<T, U>;
 
-template <typename T, typename... Us>
-constexpr auto same_any = (... or same_as<T, Us>);
+template <typename T>
+concept tuple_comparable = requires { typename T::common_tuple_comparable; };
 
-template <typename T, typename... Us>
-constexpr auto same_none = not same_any<T, Us...>;
+template <typename T>
+concept tuplelike = requires { typename std::remove_cvref_t<T>::is_tuple; };
+
+namespace detail {
+template <typename T>
+concept has_vacuous_tuple_protocol = requires {
+    {
+        tuple_size_v<std::remove_cvref_t<T>>
+    } -> std::same_as<std::size_t const &>;
+};
+template <typename T>
+concept is_vacuous_tuple = tuple_size_v<std::remove_cvref_t<T>> == 0;
+
+constexpr inline auto concept_try_get = [](auto &x) -> decltype(auto) {
+    using std::get;
+    return get<0>(x);
+};
+
+template <typename T>
+concept has_get_protocol = requires(T &t) {
+    {
+        concept_try_get(t)
+    } -> same_as_unqualified<tuple_element_t<0, std::remove_cvref_t<T>>>;
+};
+} // namespace detail
+
+template <typename T>
+concept has_tuple_protocol = detail::has_vacuous_tuple_protocol<T> and
+                             (detail::is_vacuous_tuple<T> or
+                              detail::has_get_protocol<std::remove_cvref_t<T>>);
+
+template <typename T>
+concept has_array_protocol = has_tuple_protocol<T> and requires {
+    typename std::remove_cvref_t<T>::value_type;
+};
+
 } // namespace v1
 } // namespace stdx
-
-#endif

--- a/include/stdx/span.hpp
+++ b/include/stdx/span.hpp
@@ -281,5 +281,11 @@ constexpr auto ct_capacity_v<span<T, N>> = N;
 template <typename T>
 constexpr auto ct_capacity_v<span<T, dynamic_extent>> =
     detail::ct_capacity_fail<span<T, dynamic_extent>>{};
+
+template <std::size_t I, typename T, std::size_t N>
+struct tuple_element<I, span<T, N>> {
+    static_assert(N != dynamic_extent and I < N);
+    using type = T;
+};
 } // namespace v1
 } // namespace stdx

--- a/include/stdx/tuple.hpp
+++ b/include/stdx/tuple.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
+#include <stdx/concepts.hpp>
 #include <stdx/type_traits.hpp>
 #include <stdx/udls.hpp>
 #include <stdx/utility.hpp>
 
-#include <array>
 #include <concepts>
 #include <cstddef>
 #include <type_traits>
@@ -420,58 +420,9 @@ tuple_impl(Ts...)
     -> tuple_impl<std::index_sequence_for<Ts...>, index_function_list<>, Ts...>;
 } // namespace detail
 
-template <typename T> constexpr auto tuple_size_v = T::size();
-template <typename T, std::size_t N>
-constexpr auto tuple_size_v<std::array<T, N>> = N;
-template <typename T, typename U>
-constexpr auto tuple_size_v<std::pair<T, U>> = std::size_t{2};
-template <typename T, T N>
-constexpr auto tuple_size_v<make_integer_sequence<T, N>> = std::size_t{N};
-
-template <typename T>
-concept tuple_comparable = requires { typename T::common_tuple_comparable; };
-
-template <typename T>
-concept tuplelike = requires { typename std::remove_cvref_t<T>::is_tuple; };
-
-template <std::size_t I, typename T> struct tuple_element;
-
 template <std::size_t I, tuplelike T> struct tuple_element<I, T> {
     using type = typename T::template element_t<I>;
 };
-
-template <std::size_t I, typename T, std::size_t N>
-struct tuple_element<I, std::array<T, N>> {
-    using type = T;
-};
-
-template <std::size_t I, typename T, typename U>
-struct tuple_element<I, std::pair<T, U>> {
-    using type = nth_t<I, T, U>;
-};
-
-template <std::size_t I, typename T>
-using tuple_element_t = typename tuple_element<I, T>::type;
-
-namespace detail {
-template <typename T>
-concept has_vacuous_tuple_protocol = requires {
-    {
-        tuple_size_v<std::remove_cvref_t<T>>
-    } -> std::same_as<std::size_t const &>;
-};
-template <typename T>
-concept is_vacuous_tuple = tuple_size_v<std::remove_cvref_t<T>> == 0;
-} // namespace detail
-
-template <typename T>
-concept has_tuple_protocol =
-    detail::has_vacuous_tuple_protocol<T> and
-    (detail::is_vacuous_tuple<T> or requires(T &t) {
-        {
-            get<0>(t)
-        } -> std::same_as<tuple_element_t<0, std::remove_cvref_t<T>> &>;
-    });
 
 template <typename... Ts>
 class tuple : public detail::tuple_impl<std::index_sequence_for<Ts...>,

--- a/include/stdx/tuple_algorithms.hpp
+++ b/include/stdx/tuple_algorithms.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <stdx/concepts.hpp>
 #include <stdx/ct_conversions.hpp>
 #include <stdx/tuple.hpp>
+#include <stdx/tuple_destructure.hpp>
 #include <stdx/type_traits.hpp>
 
 #include <boost/mp11/algorithm.hpp>
@@ -95,23 +97,27 @@ template <tuplelike... Ts> [[nodiscard]] constexpr auto tuple_cat(Ts &&...ts) {
     }
 }
 
-template <typename T, tuplelike Tup>
+template <typename T, has_tuple_protocol Tup>
 [[nodiscard]] constexpr auto tuple_cons(T &&t, Tup &&tup) {
     using tuple_t = std::remove_cvref_t<Tup>;
     return [&]<std::size_t... Is>(std::index_sequence<Is...>) {
-        return stdx::tuple<std::remove_cvref_t<T>,
-                           stdx::tuple_element_t<Is, tuple_t>...>{
-            std::forward<T>(t), std::forward<Tup>(tup)[index<Is>]...};
+        using std::get;
+        using new_tuple_t =
+            boost::mp11::mp_push_front<tuple_t, std::remove_cvref_t<T>>;
+        return new_tuple_t{std::forward<T>(t),
+                           get<Is>(std::forward<Tup>(tup))...};
     }(std::make_index_sequence<stdx::tuple_size_v<tuple_t>>{});
 }
 
-template <tuplelike Tup, typename T>
+template <has_tuple_protocol Tup, typename T>
 [[nodiscard]] constexpr auto tuple_snoc(Tup &&tup, T &&t) {
     using tuple_t = std::remove_cvref_t<Tup>;
     return [&]<std::size_t... Is>(std::index_sequence<Is...>) {
-        return stdx::tuple<stdx::tuple_element_t<Is, tuple_t>...,
-                           std::remove_cvref_t<T>>{
-            std::forward<Tup>(tup)[index<Is>]..., std::forward<T>(t)};
+        using std::get;
+        using new_tuple_t =
+            boost::mp11::mp_push_back<tuple_t, std::remove_cvref_t<T>>;
+        return new_tuple_t{get<Is>(std::forward<Tup>(tup))...,
+                           std::forward<T>(t)};
     }(std::make_index_sequence<stdx::tuple_size_v<tuple_t>>{});
 }
 
@@ -186,6 +192,7 @@ constexpr auto transform(Op &&op, Ts &&...ts) {
     }(std::make_index_sequence<detail::zip_length_for<Ts...>>{});
 }
 
+namespace detail {
 template <typename Op, typename... Ts>
 constexpr auto unrolled_for_each(Op &&op, Ts &&...ts) -> Op {
     [&]<std::size_t... Is>(std::index_sequence<Is...>) {
@@ -193,10 +200,21 @@ constexpr auto unrolled_for_each(Op &&op, Ts &&...ts) -> Op {
     }(std::make_index_sequence<detail::zip_length_for<Ts...>>{});
     return op;
 }
+} // namespace detail
 
-template <typename Op, tuplelike... Ts>
+template <typename Op, has_tuple_protocol... Ts>
 constexpr auto for_each(Op &&op, Ts &&...ts) -> Op {
-    return unrolled_for_each(std::forward<Op>(op), std::forward<Ts>(ts)...);
+    static_assert((... or not has_array_protocol<Ts>),
+                  "Calling for_each on array-like type: use unrolled_for_each "
+                  "if you really want this.");
+    return detail::unrolled_for_each(std::forward<Op>(op),
+                                     std::forward<Ts>(ts)...);
+}
+
+template <typename Op, has_tuple_protocol... Ts>
+constexpr auto unrolled_for_each(Op &&op, Ts &&...ts) -> Op {
+    return detail::unrolled_for_each(std::forward<Op>(op),
+                                     std::forward<Ts>(ts)...);
 }
 
 namespace detail {
@@ -204,7 +222,6 @@ template <std::size_t I, typename... Ts>
 constexpr auto invoke_with_idx_at(auto &&op, Ts &&...ts) -> decltype(auto) {
     return op.template operator()<I>(get<I>(std::forward<Ts>(ts))...);
 }
-} // namespace detail
 
 template <typename Op, typename... Ts>
 constexpr auto unrolled_enumerate(Op &&op, Ts &&...ts) -> Op {
@@ -213,28 +230,81 @@ constexpr auto unrolled_enumerate(Op &&op, Ts &&...ts) -> Op {
     }(std::make_index_sequence<detail::zip_length_for<Ts...>>{});
     return op;
 }
+} // namespace detail
 
-template <typename Op, tuplelike... Ts>
+template <typename Op, has_tuple_protocol... Ts>
 constexpr auto enumerate(Op &&op, Ts &&...ts) -> Op {
-    return unrolled_enumerate(std::forward<Op>(op), std::forward<Ts>(ts)...);
+    static_assert(
+        (... or not has_array_protocol<Ts>),
+        "Calling enumerate on array-like type: use unrolled_enumerate "
+        "if you really want this.");
+    return detail::unrolled_enumerate(std::forward<Op>(op),
+                                      std::forward<Ts>(ts)...);
 }
 
-template <typename F, tuplelike... Ts>
-constexpr auto all_of(F &&f, Ts &&...ts) -> bool {
+template <typename Op, has_tuple_protocol... Ts>
+constexpr auto unrolled_enumerate(Op &&op, Ts &&...ts) -> Op {
+    return detail::unrolled_enumerate(std::forward<Op>(op),
+                                      std::forward<Ts>(ts)...);
+}
+
+namespace detail {
+template <typename F, typename... Ts>
+constexpr auto unrolled_all_of(F &&f, Ts &&...ts) -> bool {
     return [&]<std::size_t... Is>(std::index_sequence<Is...>) {
         return (... and detail::invoke_at<Is>(f, std::forward<Ts>(ts)...));
     }(std::make_index_sequence<detail::zip_length_for<Ts...>>{});
 }
+} // namespace detail
 
-template <typename F, tuplelike... Ts>
-constexpr auto any_of(F &&f, Ts &&...ts) -> bool {
+template <typename F, has_tuple_protocol... Ts>
+constexpr auto all_of(F &&f, Ts &&...ts) -> bool {
+    static_assert((... or not has_array_protocol<Ts>),
+                  "Calling all_of on array-like type: use unrolled_all_of "
+                  "if you really want this.");
+    return detail::unrolled_all_of(std::forward<F>(f), std::forward<Ts>(ts)...);
+}
+
+template <typename F, has_tuple_protocol... Ts>
+constexpr auto unrolled_all_of(F &&f, Ts &&...ts) -> bool {
+    return detail::unrolled_all_of(std::forward<F>(f), std::forward<Ts>(ts)...);
+}
+
+namespace detail {
+template <typename F, typename... Ts>
+constexpr auto unrolled_any_of(F &&f, Ts &&...ts) -> bool {
     return [&]<std::size_t... Is>(std::index_sequence<Is...>) {
         return (... or detail::invoke_at<Is>(f, std::forward<Ts>(ts)...));
     }(std::make_index_sequence<detail::zip_length_for<Ts...>>{});
 }
+} // namespace detail
 
-template <typename... Ts> constexpr auto none_of(Ts &&...ts) -> bool {
-    return not any_of(std::forward<Ts>(ts)...);
+template <typename F, has_tuple_protocol... Ts>
+constexpr auto any_of(F &&f, Ts &&...ts) -> bool {
+    static_assert((... or not has_array_protocol<Ts>),
+                  "Calling any_of on array-like type: use unrolled_any_of "
+                  "if you really want this.");
+    return detail::unrolled_any_of(std::forward<F>(f), std::forward<Ts>(ts)...);
+}
+
+template <typename F, has_tuple_protocol... Ts>
+constexpr auto unrolled_any_of(F &&f, Ts &&...ts) -> bool {
+    return detail::unrolled_any_of(std::forward<F>(f), std::forward<Ts>(ts)...);
+}
+
+template <typename F, has_tuple_protocol... Ts>
+constexpr auto none_of(F &&f, Ts &&...ts) -> bool {
+    static_assert((... or not has_array_protocol<Ts>),
+                  "Calling none_of on array-like type: use unrolled_none_of "
+                  "if you really want this.");
+    return not detail::unrolled_any_of(std::forward<F>(f),
+                                       std::forward<Ts>(ts)...);
+}
+
+template <typename F, has_tuple_protocol... Ts>
+constexpr auto unrolled_none_of(F &&f, Ts &&...ts) -> bool {
+    return not detail::unrolled_any_of(std::forward<F>(f),
+                                       std::forward<Ts>(ts)...);
 }
 
 namespace detail {
@@ -280,7 +350,6 @@ template <template <typename> typename Proj = std::type_identity_t,
 }
 
 namespace detail {
-
 template <tuplelike T, template <typename> typename Proj> struct test_pair_t {
     template <std::size_t I, std::size_t J>
     constexpr static auto value =

--- a/include/stdx/tuple_destructure.hpp
+++ b/include/stdx/tuple_destructure.hpp
@@ -27,3 +27,12 @@ struct std::tuple_element<I, stdx::indexed_tuple<IL, Ts...>>
                                            IL, Ts...>>()[stdx::index<I>])>> {};
 
 // NOLINTEND(bugprone-std-namespace-modification)
+
+namespace stdx {
+template <typename... Ts>
+constexpr auto tuple_size_v<std::tuple<Ts...>> = sizeof...(Ts);
+template <std::size_t I, typename... Ts>
+struct tuple_element<I, std::tuple<Ts...>> {
+    using type = nth_t<I, Ts...>;
+};
+} // namespace stdx

--- a/include/stdx/type_traits.hpp
+++ b/include/stdx/type_traits.hpp
@@ -5,6 +5,8 @@
 
 #include <boost/mp11/algorithm.hpp>
 
+#include <array>
+#include <cstddef>
 #include <type_traits>
 #include <utility>
 
@@ -330,5 +332,31 @@ constexpr auto is_complete_v<T, detail::void_v<sizeof(T)>> = true;
 
 template <typename T, typename U>
 constexpr auto is_same_template_v = template_base<T>() == template_base<U>();
+
+template <typename T> constexpr auto tuple_size_v = 0u;
+template <typename T>
+    requires requires { T::size(); }
+constexpr auto tuple_size_v<T> = T::size();
+
+template <typename T, std::size_t N>
+constexpr auto tuple_size_v<std::array<T, N>> = N;
+template <typename T, typename U>
+constexpr auto tuple_size_v<std::pair<T, U>> = std::size_t{2};
+
+template <std::size_t I, typename T> struct tuple_element;
+
+template <std::size_t I, typename T>
+using tuple_element_t = typename tuple_element<I, T>::type;
+
+template <std::size_t I, typename T, std::size_t N>
+struct tuple_element<I, std::array<T, N>> {
+    using type = T;
+};
+
+template <std::size_t I, typename T, typename U>
+struct tuple_element<I, std::pair<T, U>> {
+    static_assert(I < 2);
+    using type = stdx::conditional_t<I == 0, T, U>;
+};
 } // namespace v1
 } // namespace stdx

--- a/include/stdx/utility.hpp
+++ b/include/stdx/utility.hpp
@@ -285,6 +285,14 @@ constexpr auto get(make_integer_sequence<T, N>) {
     return std::integral_constant<T, I>{};
 }
 
+template <typename T, T N>
+constexpr auto tuple_size_v<make_integer_sequence<T, N>> = std::size_t{N};
+
+template <std::size_t I, typename T, T N>
+struct tuple_element<I, make_integer_sequence<T, N>> {
+    static_assert(I < N);
+    using type = std::integral_constant<T, I>;
+};
 } // namespace v1
 } // namespace stdx
 

--- a/test/fail/CMakeLists.txt
+++ b/test/fail/CMakeLists.txt
@@ -18,6 +18,7 @@ add_fail_tests(
     dynamic_std_span_no_ct_capacity
     dynamic_stdx_span_no_ct_capacity
     for_each_n_args_bad_size
+    non_unrolled_for_each
     optional_without_tombstone
     optional_integral_with_tombstone_traits
     rollover_less_than

--- a/test/fail/non_unrolled_for_each.cpp
+++ b/test/fail/non_unrolled_for_each.cpp
@@ -1,0 +1,10 @@
+#include <stdx/tuple_algorithms.hpp>
+
+#include <array>
+
+// EXPECT: Calling for_each on array-like type
+
+auto main() -> int {
+    auto a = std::array{1, 2, 3};
+    stdx::for_each([](auto) {}, a);
+}

--- a/test/indexed_tuple.cpp
+++ b/test/indexed_tuple.cpp
@@ -22,11 +22,6 @@ TEST_CASE("indexed_tuple is tuplelike", "[tuple]") {
     STATIC_CHECK(stdx::tuplelike<decltype(t)>);
 }
 
-TEST_CASE("indexed_tuple has tuple protocol", "[tuple]") {
-    auto t = stdx::indexed_tuple{1, 2, 3};
-    STATIC_CHECK(stdx::has_tuple_protocol<decltype(t)>);
-}
-
 TEST_CASE("make_indexed_tuple", "[indexed_tuple]") {
     STATIC_REQUIRE(stdx::make_indexed_tuple<>() == stdx::indexed_tuple{});
     STATIC_REQUIRE(stdx::make_indexed_tuple<>(1, 2, 3) ==

--- a/test/tuple.cpp
+++ b/test/tuple.cpp
@@ -51,23 +51,6 @@ TEST_CASE("tuple is tuplelike", "[tuple]") {
     STATIC_CHECK(stdx::tuplelike<stdx::tuple<>>);
 }
 
-TEST_CASE("tuple has tuple protocol", "[tuple]") {
-    auto t = stdx::tuple{1, 2, 3};
-    STATIC_CHECK(stdx::has_tuple_protocol<decltype(t)>);
-    STATIC_CHECK(stdx::has_tuple_protocol<stdx::tuple<>>);
-}
-
-TEST_CASE("std::array has tuple protocol", "[tuple_algorithms]") {
-    auto t = std::array{1, 2, 3};
-    STATIC_CHECK(stdx::has_tuple_protocol<decltype(t)>);
-    STATIC_CHECK(stdx::has_tuple_protocol<std::array<int, 0>>);
-}
-
-TEST_CASE("std::pair has tuple protocol", "[tuple_algorithms]") {
-    auto t = std::pair{1, 2};
-    STATIC_CHECK(stdx::has_tuple_protocol<decltype(t)>);
-}
-
 namespace {
 template <auto N> struct empty {};
 } // namespace

--- a/test/tuple_algorithms.cpp
+++ b/test/tuple_algorithms.cpp
@@ -10,8 +10,37 @@
 #include <algorithm>
 #include <array>
 #include <functional>
+#include <tuple>
 #include <type_traits>
 #include <utility>
+
+TEST_CASE("tuple has tuple protocol", "[tuple_algorithms]") {
+    auto t = stdx::tuple{1, 2, 3};
+    STATIC_CHECK(stdx::has_tuple_protocol<decltype(t)>);
+    STATIC_CHECK(stdx::has_tuple_protocol<stdx::tuple<>>);
+}
+
+TEST_CASE("span has tuple protocol", "[tuple_algorithms]") {
+    auto a = std::array{1, 2, 3};
+    auto s = stdx::span<int, 3>{a};
+    STATIC_CHECK(stdx::has_tuple_protocol<decltype(s)>);
+}
+
+TEST_CASE("std::pair has tuple protocol", "[tuple_algorithms]") {
+    auto t = std::pair{1, 2};
+    STATIC_CHECK(stdx::has_tuple_protocol<decltype(t)>);
+}
+
+TEST_CASE("std::tuple has tuple protocol", "[tuple_algorithms]") {
+    auto t = std::tuple{1, 2};
+    STATIC_CHECK(stdx::has_tuple_protocol<decltype(t)>);
+}
+
+TEST_CASE("std::array has tuple protocol", "[tuple_algorithms]") {
+    auto t = std::array{1, 2, 3};
+    STATIC_CHECK(stdx::has_tuple_protocol<decltype(t)>);
+    STATIC_CHECK(stdx::has_tuple_protocol<std::array<int, 0>>);
+}
 
 TEST_CASE("unary transform", "[tuple_algorithms]") {
     STATIC_REQUIRE(stdx::transform([](auto) { return 1; }, stdx::tuple{}) ==
@@ -247,6 +276,38 @@ TEST_CASE("for_each", "[tuple_algorithms]") {
     }
 }
 
+TEST_CASE("for_each on std::tuple", "[tuple_algorithms]") {
+    {
+        auto const t = std::tuple{};
+        auto sum = 0;
+        stdx::for_each([&](auto x, auto y) { sum += x + y; }, t, t);
+        CHECK(sum == 0);
+    }
+    {
+        auto const t = std::tuple{1, 2, 3};
+        auto sum = 0;
+        stdx::for_each([&](auto x, auto y) { sum += x + y; }, t, t);
+        CHECK(sum == 12);
+    }
+    {
+        auto const t = std::tuple{1};
+        auto sum = 0;
+        stdx::for_each([&](auto x, auto &&y) { sum += x + y.value; }, t,
+                       stdx::tuple{move_only{2}});
+        CHECK(sum == 3);
+    }
+    {
+        auto const t = std::tuple{1, 2, 3};
+        auto f = stdx::for_each(
+            [calls = 0](auto) mutable {
+                ++calls;
+                return calls;
+            },
+            t);
+        CHECK(f(0) == 4);
+    }
+}
+
 TEST_CASE("for_each stops at smallest tuple length", "[tuple_algorithms]") {
     auto sum = 0;
     stdx::for_each([&](auto x, auto y) { sum += x + y; }, stdx::tuple{1, 2, 3},
@@ -291,6 +352,20 @@ TEST_CASE("unrolled_for_each on index_sequence", "[tuple_algorithms]") {
         a, stdx::make_index_sequence<stdx::ct_capacity(a)>{});
     CHECK(sum == 9u);
     CHECK(a == std::array{0u, 1u, 2u});
+}
+
+TEST_CASE("heterogeneous for_each", "[tuple_algorithms]") {
+    auto a = std::array{1, 2, 3};
+    auto t = std::tuple{1, 2, 3};
+    auto sum = 0;
+    stdx::for_each(
+        [&](auto &x, auto y) {
+            sum += x + y;
+            x--;
+        },
+        a, t);
+    CHECK(sum == 12);
+    CHECK(a == std::array{0, 1, 2});
 }
 
 TEST_CASE("tuple_cat", "[tuple_algorithms]") {
@@ -497,6 +572,13 @@ TEST_CASE("all_of", "[tuple_algorithms]") {
                                 stdx::tuple{1, 3, 5}, stdx::tuple{1, 3}));
 }
 
+TEST_CASE("unrolled all_of on arrays", "[tuple_algorithms]") {
+    auto const a = std::array{1, 2, 3};
+    CHECK(stdx::unrolled_all_of([](auto n) { return n > 0; }, a));
+    CHECK(stdx::unrolled_all_of([](auto x, auto y) { return (x + y) % 2 == 0; },
+                                a, a));
+}
+
 TEST_CASE("any_of", "[tuple_algorithms]") {
     constexpr auto t = stdx::tuple{1, 2, 3};
     STATIC_REQUIRE(stdx::any_of([](auto n) { return n % 2 == 0; }, t));
@@ -505,6 +587,13 @@ TEST_CASE("any_of", "[tuple_algorithms]") {
 
     STATIC_REQUIRE(stdx::any_of([](auto x, auto y) { return (x + y) % 2 == 0; },
                                 stdx::tuple{1, 3, 5}, stdx::tuple{1, 3}));
+}
+
+TEST_CASE("unrolled any_of on arrays", "[tuple_algorithms]") {
+    auto const a = std::array{1, 2, 3};
+    CHECK(stdx::unrolled_any_of([](auto n) { return n % 2 == 0; }, a));
+    CHECK(stdx::unrolled_any_of([](auto x, auto y) { return (x + y) % 2 == 0; },
+                                a, a));
 }
 
 TEST_CASE("none_of", "[tuple_algorithms]") {
@@ -516,6 +605,13 @@ TEST_CASE("none_of", "[tuple_algorithms]") {
     STATIC_REQUIRE(
         stdx::none_of([](auto x, auto y) { return (x + y) % 2 != 0; },
                       stdx::tuple{1, 3, 5}, stdx::tuple{1, 3}));
+}
+
+TEST_CASE("unrolled none_of on arrays", "[tuple_algorithms]") {
+    auto const a = std::array{1, 3, 5};
+    CHECK(stdx::unrolled_none_of([](auto n) { return n % 2 == 0; }, a));
+    CHECK(stdx::unrolled_none_of(
+        [](auto x, auto y) { return (x + y) % 2 != 0; }, a, a));
 }
 
 TEST_CASE("contains_type", "[tuple_algorithms]") {
@@ -898,6 +994,12 @@ TEST_CASE("tuple_cons", "[tuple_algorithms]") {
     STATIC_REQUIRE(std::is_same_v<decltype(t), stdx::tuple<int>>);
 }
 
+TEST_CASE("tuple_cons on std::tuple", "[tuple_algorithms]") {
+    STATIC_REQUIRE(stdx::tuple_cons(1, std::tuple{}) == std::tuple{1});
+    auto t = stdx::tuple_cons(1, std::tuple{});
+    STATIC_REQUIRE(std::is_same_v<decltype(t), std::tuple<int>>);
+}
+
 TEST_CASE("tuple_cons (move only)", "[tuple_algorithms]") {
     auto t = stdx::tuple_cons(move_only{5}, stdx::tuple{move_only{10}});
     STATIC_REQUIRE(
@@ -917,6 +1019,12 @@ TEST_CASE("tuple_snoc", "[tuple_algorithms]") {
     STATIC_REQUIRE(stdx::tuple_snoc(stdx::tuple{}, 1) == stdx::tuple{1});
     auto t = stdx::tuple_snoc(stdx::tuple{}, 1);
     STATIC_REQUIRE(std::is_same_v<decltype(t), stdx::tuple<int>>);
+}
+
+TEST_CASE("tuple_snoc on std::tuple", "[tuple_algorithms]") {
+    STATIC_REQUIRE(stdx::tuple_snoc(std::tuple{}, 1) == std::tuple{1});
+    auto t = stdx::tuple_snoc(std::tuple{}, 1);
+    STATIC_REQUIRE(std::is_same_v<decltype(t), std::tuple<int>>);
 }
 
 TEST_CASE("tuple_snoc (move only)", "[tuple_algorithms]") {


### PR DESCRIPTION
Problem:
- Algorithms like `all_of` don't work with `std::tuple` or `std::array`.

Solution:
- Adjust concepts to separate `has_tuple_protocol` and `has_array_protocol` (note: `has_array_protocol` subsumes `has_tuple_protocol`.
- Allow tuple algorithms to work with `std::tuple` by constraining on `has_tuple_protocol` instead of `tuplelike` (which means just `stdx::tuple`).
- Add more `unrolled_*` algorithms to deal with those use cases for arrays and spans.