### PR TITLE
:memo: Small fixes for documentation

### DIFF
--- a/docs/design/tuple.md
+++ b/docs/design/tuple.md
@@ -25,7 +25,7 @@ For example, it can't use formatted `static_assert`s (because they make use of
 `tuplelike` is modelled by `stdx::tuple` and `stdx::indexed_tuple` only.
 
 `has_tuple_protocol` means that a type models the `get` protocol. This applies
-to much more: `stdx::tuple` but also `std::tuple`, `std::pair`, std::array`,
+to much more: `stdx::tuple` but also `std::tuple`, `std::pair`, `std::array`,
 etc.
 
 ## `one_of`

--- a/docs/header_graph.mmd
+++ b/docs/header_graph.mmd
@@ -61,8 +61,8 @@ flowchart BT
   bitset --> ct_string
   panic(<a href="https://github.com/intel/cpp-std-extensions/tree/main/include/stdx/panic.hpp">panic.hpp</a>)
   panic --> ct_string
-  A(<a href="https://github.com/intel/cpp-std-extensions/tree/main/include/stdx/env.hpp">env.hpp</a><br><a href="https://github.com/intel/cpp-std-extensions/tree/main/include/stdx/static_assert.hpp">static_assert.hpp</a>)
-  A --> ct_string
+  env(<a href="https://github.com/intel/cpp-std-extensions/tree/main/include/stdx/env.hpp">env.hpp</a>)
+  env --> ct_string
   tuple_algorithms(<a href="https://github.com/intel/cpp-std-extensions/tree/main/include/stdx/tuple_algorithms.hpp">tuple_algorithms.hpp</a>)
   tuple_algorithms --> tuple
   functional(<a href="https://github.com/intel/cpp-std-extensions/tree/main/include/stdx/functional.hpp">functional.hpp</a>)
@@ -83,15 +83,15 @@ flowchart BT
   atomic_bitset ---> bitset
   B(<a href="https://github.com/intel/cpp-std-extensions/tree/main/include/stdx/intrusive_forward_list.hpp">intrusive_forward_list.hpp<br><a href="https://github.com/intel/cpp-std-extensions/tree/main/include/stdx/intrusive_list.hpp">intrusive_list.hpp</a>)
   B --> panic
-  ct_format(<a href="https://github.com/intel/cpp-std-extensions/tree/main/include/stdx/ct_format.hpp">ct_format.hpp</a>)
   pp_map(<a href="https://github.com/intel/cpp-std-extensions/tree/main/include/stdx/pp_map.hpp">pp_map.hpp</a>)
   ranges(<a href="https://github.com/intel/cpp-std-extensions/tree/main/include/stdx/ranges.hpp">ranges.hpp</a>)
-  ct_format ----> ct_string
-  ct_format ---> tuple_algorithms
-  ct_format --> pp_map
-  ct_format --> ranges
   call_by_need(<a href="https://github.com/intel/cpp-std-extensions/tree/main/include/stdx/call_by_need.hpp">call_by_need.hpp</a>)
   call_by_need --> tuple_algorithms
+  ct_format(<a href="https://github.com/intel/cpp-std-extensions/tree/main/include/stdx/ct_format.hpp">ct_format.hpp</a>)
+  ct_format ---> ct_string
+  ct_format --> tuple_algorithms
+  ct_format --> pp_map
+  ct_format --> ranges
   latched(<a href="https://github.com/intel/cpp-std-extensions/tree/main/include/stdx/latched.hpp">latched.hpp</a>)
   latched --> functional
   optional(<a href="https://github.com/intel/cpp-std-extensions/tree/main/include/stdx/optional.hpp">optional.hpp</a>)
@@ -100,3 +100,5 @@ flowchart BT
   %% level 8
   cached(<a href="https://github.com/intel/cpp-std-extensions/tree/main/include/stdx/cached.hpp">cached.hpp</a>)
   cached --> latched
+  static_assert(<a href="https://github.com/intel/cpp-std-extensions/tree/main/include/stdx/static_assert.hpp">static_assert.hpp</a>)
+  static_assert --> ct_format


### PR DESCRIPTION
Problem:
- `static_assert.hpp` is in the wrong place in the header graph. It actually includes `ct_format.hpp`.

Solution:
- Adjust the header graph.