### PR TITLE
:sparkles: Make more algorithms work for `std::tuple`

### DIFF
--- a/include/stdx/concepts.hpp
+++ b/include/stdx/concepts.hpp
@@ -156,7 +156,6 @@ template <typename T>
 concept is_vacuous_tuple = tuple_size_v<std::remove_cvref_t<T>> == 0;
 
 constexpr inline auto concept_try_get = [](auto &x) -> decltype(auto) {
-    using std::get;
     return get<0>(x);
 };
 

--- a/include/stdx/tuple.hpp
+++ b/include/stdx/tuple.hpp
@@ -418,6 +418,18 @@ struct tuple_impl<std::index_sequence<Is...>, index_function_list<Fs...>, Ts...>
 template <typename... Ts>
 tuple_impl(Ts...)
     -> tuple_impl<std::index_sequence_for<Ts...>, index_function_list<>, Ts...>;
+
+template <std::size_t I, tuplelike Tuple>
+[[nodiscard]] constexpr auto get(Tuple &&t LIFETIMEBOUND)
+    -> decltype(std::forward<Tuple>(t)[index<I>]) {
+    return std::forward<Tuple>(t)[index<I>];
+}
+
+template <typename T, tuplelike Tuple>
+[[nodiscard]] constexpr auto get(Tuple &&t LIFETIMEBOUND)
+    -> decltype(std::forward<Tuple>(t).get(tag<T>)) {
+    return std::forward<Tuple>(t).get(tag<T>);
+}
 } // namespace detail
 
 template <std::size_t I, tuplelike T> struct tuple_element<I, T> {
@@ -456,17 +468,7 @@ class indexed_tuple : public detail::tuple_impl<std::index_sequence_for<Ts...>,
 template <typename... Ts>
 indexed_tuple(Ts...) -> indexed_tuple<detail::index_function_list<>, Ts...>;
 
-template <std::size_t I, tuplelike Tuple>
-[[nodiscard]] constexpr auto get(Tuple &&t LIFETIMEBOUND)
-    -> decltype(std::forward<Tuple>(t)[index<I>]) {
-    return std::forward<Tuple>(t)[index<I>];
-}
-
-template <typename T, tuplelike Tuple>
-[[nodiscard]] constexpr auto get(Tuple &&t LIFETIMEBOUND)
-    -> decltype(std::forward<Tuple>(t).get(tag<T>)) {
-    return std::forward<Tuple>(t).get(tag<T>);
-}
+using detail::get;
 
 template <typename... Ts> [[nodiscard]] constexpr auto make_tuple(Ts &&...ts) {
     return tuple<std::decay_t<Ts>...>{std::forward<Ts>(ts)...};

--- a/include/stdx/tuple_algorithms.hpp
+++ b/include/stdx/tuple_algorithms.hpp
@@ -178,19 +178,25 @@ constexpr std::size_t zip_length_for =
         : std::min({stdx::tuple_size_v<std::remove_cvref_t<Ts>>...});
 } // namespace detail
 
-template <template <typename> typename... Fs, typename Op, tuplelike... Ts>
-constexpr auto transform(Op &&op, Ts &&...ts) {
+template <template <typename> typename... Fs, typename Op, has_tuple_protocol T,
+          has_tuple_protocol... Ts>
+constexpr auto transform(Op &&op, T &&t, Ts &&...ts) {
     return [&]<std::size_t... Is>(std::index_sequence<Is...>) {
         if constexpr (sizeof...(Fs) == 0) {
-            return stdx::tuple<decltype(detail::invoke_at<Is>(
-                std::forward<Op>(op), std::forward<Ts>(ts)...))...>{
-                detail::invoke_at<Is>(std::forward<Op>(op),
-                                      std::forward<Ts>(ts)...)...};
+            using R = boost::mp11::mp_assign<
+                std::remove_cvref_t<T>,
+                type_list<decltype(detail::invoke_at<Is>(
+                    std::forward<Op>(op), std::forward<T>(t),
+                    std::forward<Ts>(ts)...))...>>;
+            return R{detail::invoke_at<Is>(std::forward<Op>(op),
+                                           std::forward<T>(t),
+                                           std::forward<Ts>(ts)...)...};
         } else {
-            return stdx::make_indexed_tuple<Fs...>(detail::invoke_at<Is>(
-                std::forward<Op>(op), std::forward<Ts>(ts)...)...);
+            return stdx::make_indexed_tuple<Fs...>(
+                detail::invoke_at<Is>(std::forward<Op>(op), std::forward<T>(t),
+                                      std::forward<Ts>(ts)...)...);
         }
-    }(std::make_index_sequence<detail::zip_length_for<Ts...>>{});
+    }(std::make_index_sequence<detail::zip_length_for<T, Ts...>>{});
 }
 
 namespace detail {

--- a/include/stdx/tuple_algorithms.hpp
+++ b/include/stdx/tuple_algorithms.hpp
@@ -121,19 +121,19 @@ template <has_tuple_protocol Tup, typename T>
     }(std::make_index_sequence<stdx::tuple_size_v<tuple_t>>{});
 }
 
-template <typename T, tuplelike Tup>
+template <typename T, has_tuple_protocol Tup>
 [[nodiscard]] constexpr auto tuple_push_front(T &&t, Tup &&tup)
     -> decltype(auto) {
     return tuple_cons(std::forward<T>(t), std::forward<Tup>(tup));
 }
 
-template <tuplelike Tup, typename T>
+template <has_tuple_protocol Tup, typename T>
 [[nodiscard]] constexpr auto tuple_push_back(Tup &&tup, T &&t)
     -> decltype(auto) {
     return tuple_snoc(std::forward<Tup>(tup), std::forward<T>(t));
 }
 
-template <template <typename T> typename Pred, tuplelike T>
+template <template <typename T> typename Pred, has_tuple_protocol T>
 [[nodiscard]] constexpr auto filter(T &&t) {
     using tuple_t = std::remove_cvref_t<T>;
     return [&]<std::size_t... Is>(std::index_sequence<Is...>) {
@@ -157,9 +157,10 @@ template <template <typename T> typename Pred, tuplelike T>
         }();
 
         return [&]<std::size_t... Js>(std::index_sequence<Js...>) {
-            using R =
-                stdx::tuple<stdx::tuple_element_t<indices[Js], tuple_t>...>;
-            return R{std::forward<T>(t)[index<indices[Js]>]...};
+            using R = boost::mp11::mp_assign<
+                tuple_t,
+                type_list<stdx::tuple_element_t<indices[Js], tuple_t>...>>;
+            return R{get<indices[Js]>(std::forward<T>(t))...};
         }(std::make_index_sequence<num_matches>{});
     }(std::make_index_sequence<stdx::tuple_size_v<tuple_t>>{});
 }

--- a/test/tuple_algorithms.cpp
+++ b/test/tuple_algorithms.cpp
@@ -68,6 +68,15 @@ TEST_CASE("n-ary transform", "[tuple_algorithms]") {
     STATIC_REQUIRE(u == stdx::tuple{2, 4, 6});
 }
 
+TEST_CASE("n-ary transform on std::tuple", "[tuple_algorithms]") {
+    STATIC_REQUIRE(stdx::transform([](auto, auto) { return 1; }, std::tuple{},
+                                   std::tuple{}) == std::tuple{});
+    constexpr auto t = std::tuple{1, 2, 3};
+    constexpr auto u =
+        stdx::transform([](auto x, auto y) { return x + y; }, t, t);
+    STATIC_REQUIRE(u == std::tuple{2, 4, 6});
+}
+
 TEST_CASE("rvalue transform", "[tuple_algorithms]") {
     auto t = stdx::tuple{1, 2, 3};
     auto const u = stdx::transform([](int &&x) { return x + 1; }, std::move(t));

--- a/test/tuple_algorithms.cpp
+++ b/test/tuple_algorithms.cpp
@@ -533,6 +533,15 @@ TEST_CASE("filter", "[tuple_algorithms]") {
                                     std::integral_constant<int, 4>{}});
 }
 
+TEST_CASE("filter on std::tuple", "[tuple_algorithms]") {
+    constexpr auto t = std::tuple{
+        std::integral_constant<int, 1>{}, std::integral_constant<int, 2>{},
+        std::integral_constant<int, 3>{}, std::integral_constant<int, 4>{}};
+    constexpr auto u = stdx::filter<is_even>(t);
+    STATIC_REQUIRE(u == std::tuple{std::integral_constant<int, 2>{},
+                                   std::integral_constant<int, 4>{}});
+}
+
 TEST_CASE("copy/move behavior for tuple_cat", "[tuple_algorithms]") {
     auto t1 = stdx::tuple{counter{}};
     auto t2 = stdx::tuple{counter{}};


### PR DESCRIPTION
Problem:
- `filter` works on `stdx::tuple` only. It doesn't work on `std::tuple`.
- `transform` works on `stdx::tuple` only. It doesn't work on `std::tuple`.

Solution:
- Make both algorithms work for `std::tuple` as well.