### PR TITLE
:art: Expose `for_each` and `transform_reduce` as `bitset` memfns

### DIFF
--- a/docs/bitset.adoc
+++ b/docs/bitset.adoc
@@ -125,6 +125,9 @@ auto result = transform_reduce([](auto i) { return i * 2 },
 // result is 1*2 + 3*2 + 5*2 + 7*2
 ----
 
+NOTE: Both `for_each` and `transform_reduce` are also member functions on
+`bitset`, as well as free functions.
+
 === `type_bitset`
 
 A `type_bitset` is much the same as a `bitset`, except that it is indexed by types.

--- a/include/stdx/bitset.hpp
+++ b/include/stdx/bitset.hpp
@@ -145,36 +145,8 @@ class bitset {
         return not std::is_enum_v<T> or std::is_same_v<T, decltype(Size)>;
     }
 
-    template <detail::bit_spec Spec, typename F>
-    constexpr auto for_each(F &&f) const -> F {
-        std::size_t idx = 0;
-        for (auto i = std::size_t{}; i < storage_size - 1; ++i) {
-            Spec::template fn<bit, iter_arg_t,
-                              std::numeric_limits<elem_t>::max()>(storage[i],
-                                                                  idx, f);
-            idx += std::numeric_limits<elem_t>::digits;
-        }
-        Spec::template fn<bit, iter_arg_t, lastmask>(highbits(), idx, f);
-        return std::forward<F>(f);
-    }
-
     template <detail::bit_spec Spec, typename F, auto M, typename... S>
     friend constexpr auto for_each(F &&f, bitset<M, S> const &...bs) -> F;
-
-    template <typename T, typename F, typename R>
-    constexpr auto transform_reduce(F &&f, R &&r, T init) const -> T {
-        std::size_t i = 0;
-        for (auto e : storage) {
-            while (e != 0) {
-                auto const offset = static_cast<std::size_t>(countr_zero(e));
-                e &= static_cast<elem_t>(~(bit << offset));
-                init =
-                    r(std::move(init), f(static_cast<iter_arg_t>(i + offset)));
-            }
-            i += std::numeric_limits<elem_t>::digits;
-        }
-        return init;
-    }
 
     template <typename T, typename F, typename R, auto M, typename... S>
     friend constexpr auto transform_reduce(F &&f, R &&r, T init,
@@ -493,6 +465,34 @@ class bitset {
             }
         }
         return *this;
+    }
+
+    template <detail::bit_spec Spec = set_bit, typename F>
+    constexpr auto for_each(F &&f) const -> F {
+        std::size_t idx = 0;
+        for (auto i = std::size_t{}; i < storage_size - 1; ++i) {
+            Spec::template fn<bit, iter_arg_t,
+                              std::numeric_limits<elem_t>::max()>(storage[i],
+                                                                  idx, f);
+            idx += std::numeric_limits<elem_t>::digits;
+        }
+        Spec::template fn<bit, iter_arg_t, lastmask>(highbits(), idx, f);
+        return std::forward<F>(f);
+    }
+
+    template <typename T, typename F, typename R>
+    constexpr auto transform_reduce(F &&f, R &&r, T init) const -> T {
+        std::size_t i = 0;
+        for (auto e : storage) {
+            while (e != 0) {
+                auto const offset = static_cast<std::size_t>(countr_zero(e));
+                e &= static_cast<elem_t>(~(bit << offset));
+                init =
+                    r(std::move(init), f(static_cast<iter_arg_t>(i + offset)));
+            }
+            i += std::numeric_limits<elem_t>::digits;
+        }
+        return init;
     }
 };
 

--- a/test/bitset.cpp
+++ b/test/bitset.cpp
@@ -350,6 +350,14 @@ TEMPLATE_TEST_CASE("for_each", "[bitset]", std::uint8_t, std::uint16_t,
     CHECK(result == bs);
 }
 
+TEMPLATE_TEST_CASE("member for_each", "[bitset]", std::uint8_t, std::uint16_t,
+                   std::uint32_t, std::uint64_t) {
+    constexpr auto bs = stdx::bitset<64, TestType>{0x01020304'05060708ul};
+    auto result = decltype(bs){};
+    bs.for_each([&](auto i) { result.set(i); });
+    CHECK(result == bs);
+}
+
 TEMPLATE_TEST_CASE("for_each (unset bits)", "[bitset]", std::uint8_t,
                    std::uint16_t, std::uint32_t, std::uint64_t) {
     constexpr auto bs = stdx::bitset<64, TestType>{0x01020304'05060708ul};
@@ -392,6 +400,20 @@ TEMPLATE_TEST_CASE("transform_reduce", "[bitset]", std::uint8_t, std::uint16_t,
             return i == 3 and calls == 2;
         },
         std::logical_or{}, false, bs);
+    CHECK(result);
+    CHECK(calls == bs.count());
+}
+
+TEMPLATE_TEST_CASE("member transform_reduce", "[bitset]", std::uint8_t,
+                   std::uint16_t, std::uint32_t, std::uint64_t) {
+    constexpr auto bs = stdx::bitset<8, TestType>{0b10101010ul};
+    int calls{};
+    auto const result = bs.transform_reduce(
+        [&](auto i) {
+            ++calls;
+            return i == 3 and calls == 2;
+        },
+        std::logical_or{}, false);
     CHECK(result);
     CHECK(calls == bs.count());
 }


### PR DESCRIPTION
Problem:
- Having `for_each` in particular as a free function on `bitset` increases the work the compiler has to do in overload resolution, concept checking etc.

Solution:
- Provide `for_each` and `transform_reduce` as member functions on `bitset`.

Note:
- `for_each` is already a member function on `type_bitset`.