### PR TITLE
:bug: Fix `tuple_size_v` for types which shouldn't have it

### DIFF
--- a/include/stdx/type_traits.hpp
+++ b/include/stdx/type_traits.hpp
@@ -323,7 +323,12 @@ constexpr auto is_complete_v<T, detail::void_v<sizeof(T)>> = true;
 template <typename T, typename U>
 constexpr auto is_same_template_v = template_base<T>() == template_base<U>();
 
-template <typename T> constexpr auto tuple_size_v = 0u;
+namespace detail {
+struct invalid_tuple_size_t {};
+} // namespace detail
+template <typename T>
+constexpr auto tuple_size_v = detail::invalid_tuple_size_t{};
+
 template <typename T>
     requires requires { T::size(); }
 constexpr auto tuple_size_v<T> = T::size();


### PR DESCRIPTION
Problem:
- The concept `has_tuple_protocol` incorrectly succeeds on some platforms for types like `std::optional<T>` because the primary template definition for `stdx::tuple_size_v` is:

```cpp
template <typename T> constexpr auto tuple_size_v = 0u;
```

  And on some platforms, `std::size_t` is `unsigned int`, which means literally any type satisfies `has_vacuous_tuple_protocol` concept!

Solution:
- Make the primary template definition of `tuple_size_v` an invalid type.