### PR TITLE
:art: Add `bitset::operator=` from `std::uint64_t`

### DIFF
--- a/docs/bitset.adoc
+++ b/docs/bitset.adoc
@@ -22,6 +22,8 @@ platform.
 * `size` does the same as `count()`: `capacity()` is the static size
 * `empty` (size == 0) is provided
 * `clear` does the same as `reset`
+* The single-argument constructor (from `std::uint64_t`) is `explicit`. There is
+  also an assignment operator from `std::uint64_t`.
 
 A bitset has two template parameters: the size of the bitset and the storage
 element type to use. The storage element type must be unsigned.

--- a/include/stdx/bitset.hpp
+++ b/include/stdx/bitset.hpp
@@ -170,6 +170,11 @@ class bitset {
         }
     }
 
+    constexpr auto operator=(std::uint64_t value) -> bitset & {
+        *this = bitset{value};
+        return *this;
+    }
+
     template <typename... Bs>
     constexpr explicit bitset(place_bits_t, Bs... bs) {
         static_assert(((std::is_integral_v<Bs> or std::is_enum_v<Bs>) and ...),

--- a/test/bitset.cpp
+++ b/test/bitset.cpp
@@ -575,3 +575,9 @@ TEST_CASE("fix type of bitset argument to std::size_t", "[bitset]") {
     STATIC_CHECK(std::same_as<A, B>);
     STATIC_CHECK(std::same_as<A, stdx::bitset<std::size_t{16}>>);
 }
+
+TEST_CASE("bitset assign", "[bitset]") {
+    auto bs = stdx::bitset<16>{};
+    bs = 0xa5a5;
+    CHECK(bs.to_natural() == 0xa5a5);
+}


### PR DESCRIPTION
Problem:
- It's annoying to have to write:

```cpp
bs = decltype(bs){0b1010u};
```

when you wanted to write:

```cpp
bs = 0b1010u;
```

but can't because `bitset`'s single-argument constructor is explicit.

Solution:
- Add an assignment operator from `std::uint64_t` to match the constructor.